### PR TITLE
Release TCY stylesheet fix

### DIFF
--- a/.changeset/fresh-tcy-styles.md
+++ b/.changeset/fresh-tcy-styles.md
@@ -1,5 +1,0 @@
----
-"@illusions-lab/mdi-to-hast": patch
----
-
-Apply `text-combine-upright` to tate-chu-yoko output in the default MDI stylesheet.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,12 @@
 # docs
 
+## 0.0.3
+
+### Patch Changes
+
+- Updated dependencies [1375175]
+  - @illusions-lab/mdi-to-hast@2.0.4
+
 ## 0.0.2
 
 ### Patch Changes

--- a/docs/package.json
+++ b/docs/package.json
@@ -2,7 +2,7 @@
   "name": "docs",
   "private": true,
   "type": "module",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @illusions-lab/mdi-cli
 
+## 2.0.4
+
+### Patch Changes
+
+- @illusions-lab/mdi-to-epub@2.0.4
+- @illusions-lab/mdi-to-html@2.0.4
+- @illusions-lab/mdi-to-pdf@2.0.4
+
 ## 2.0.3
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@illusions-lab/mdi-cli",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Command-line interface for converting MDI (.mdi) documents",
   "license": "MIT",
   "repository": {

--- a/packages/to-epub/CHANGELOG.md
+++ b/packages/to-epub/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @illusions-lab/mdi-to-epub
 
+## 2.0.4
+
+### Patch Changes
+
+- Updated dependencies [1375175]
+  - @illusions-lab/mdi-to-hast@2.0.4
+
 ## 2.0.3
 
 ### Patch Changes

--- a/packages/to-epub/package.json
+++ b/packages/to-epub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@illusions-lab/mdi-to-epub",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Render MDI (.mdi) documents to EPUB",
   "license": "MIT",
   "repository": {

--- a/packages/to-hast/CHANGELOG.md
+++ b/packages/to-hast/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @illusions-lab/mdi-to-hast
 
+## 2.0.4
+
+### Patch Changes
+
+- 1375175: Apply `text-combine-upright` to tate-chu-yoko output in the default MDI stylesheet.
+
 ## 2.0.3
 
 ### Patch Changes

--- a/packages/to-hast/package.json
+++ b/packages/to-hast/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@illusions-lab/mdi-to-hast",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "mdast (MDI) to hast transform, shared by the HTML/PDF/EPUB converters",
   "license": "MIT",
   "repository": {

--- a/packages/to-html/CHANGELOG.md
+++ b/packages/to-html/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @illusions-lab/mdi-to-html
 
+## 2.0.4
+
+### Patch Changes
+
+- Updated dependencies [1375175]
+  - @illusions-lab/mdi-to-hast@2.0.4
+
 ## 2.0.3
 
 ### Patch Changes

--- a/packages/to-html/package.json
+++ b/packages/to-html/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@illusions-lab/mdi-to-html",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Render MDI (.mdi) documents to HTML",
   "license": "MIT",
   "repository": {

--- a/packages/to-pdf/CHANGELOG.md
+++ b/packages/to-pdf/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @illusions-lab/mdi-to-pdf
 
+## 2.0.4
+
+### Patch Changes
+
+- @illusions-lab/mdi-to-html@2.0.4
+
 ## 2.0.3
 
 ### Patch Changes

--- a/packages/to-pdf/package.json
+++ b/packages/to-pdf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@illusions-lab/mdi-to-pdf",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Render MDI (.mdi) documents to PDF",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

Version the packages affected by the tate-chu-yoko stylesheet fix.

- `@illusions-lab/mdi-to-hast` → `2.0.4`
- dependent HTML, PDF, EPUB, and CLI packages are updated by Changesets

The behavioral fix and docs deployment were merged in PR #3; this version PR makes the corrected stylesheet available on npm.