### PR TITLE
Add configurable export profiles

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -28,6 +28,7 @@ const packages = [
 	'to-pdf',
 	'to-epub',
 	'to-docx',
+	'export-profile',
 	'cli',
 ];
 
@@ -88,6 +89,14 @@ export default defineConfig({
 							label: 'Architecture',
 							translations: { ja: 'アーキテクチャ', 'zh-TW': '架構' },
 							slug: 'guides/architecture',
+						},
+						{
+							label: 'Export Profiles',
+							translations: {
+								ja: 'エクスポート・プロファイル',
+								'zh-TW': '匯出設定檔',
+							},
+							slug: 'guides/export-profiles',
 						},
 					],
 				},

--- a/docs/src/content/docs/guides/export-profiles.md
+++ b/docs/src/content/docs/guides/export-profiles.md
@@ -1,0 +1,60 @@
+---
+title: Export Profiles
+description: Share exact PDF, DOCX, EPUB, and text export settings across applications.
+---
+
+`@illusions-lab/mdi-export-profile` is the common, validated contract for an MDI export. Keep it beside a manuscript or in an application's preferences; it is intentionally separate from MDI syntax and front matter.
+
+```json
+{
+  "metadata": {
+    "title": "The Last Station",
+    "author": "A Writer",
+    "publisher": "Example Press",
+    "identifier": "isbn:9780000000000"
+  },
+  "typesetting": {
+    "writingMode": "vertical",
+    "fontFamily": "Noto Serif JP",
+    "textIndentEm": 1,
+    "fullwidthSpaceIndent": false
+  },
+  "pagination": {
+    "pageSize": "A4",
+    "landscape": true,
+    "charactersPerLine": 40,
+    "linesPerPage": 30,
+    "margins": { "top": 34, "bottom": 28, "left": 28, "right": 45 },
+    "pageNumbers": {
+      "enabled": true,
+      "format": "simple",
+      "position": "bottom-center"
+    }
+  },
+  "epub": { "chapterSplitLevel": "h1", "coverPath": "cover.png" },
+  "text": { "fullwidthSpaceIndent": true, "indentCount": 1 }
+}
+```
+
+```sh
+mdi build novel.mdi --to pdf --config novel.export.json -o novel.pdf
+mdi build novel.mdi --to docx --config novel.export.json
+mdi build novel.mdi --to epub --config novel.export.json
+mdi build novel.mdi --to txt-ruby --config novel.export.json
+```
+
+The CLI resolves a relative `coverPath` against the profile file and accepts JPEG and PNG covers only. Invalid dimensions, ranges, page-number values, and chapter split levels fail clearly instead of producing a different layout.
+
+## Format support
+
+| Setting                              | PDF               | DOCX              | EPUB                                         | TXT / TXT ruby  |
+| ------------------------------------ | ----------------- | ----------------- | -------------------------------------------- | --------------- |
+| Paper size, orientation, margins     | Yes               | Yes               | Reflowable EPUB has no paper geometry        | —               |
+| Writing direction, font, em indent   | Yes               | Yes               | Yes                                          | —               |
+| Characters per line / lines per page | Yes               | Yes               | Reflowable EPUB cannot guarantee fixed pages | —               |
+| Full-width-space indent              | Yes               | Yes               | CSS `em` indent only                         | Yes, 1–4 spaces |
+| Page number format and position      | Yes               | Yes               | Reflowable EPUB has no stable page number    | —               |
+| Title, author, publisher, identifier | Document metadata | Document metadata | OPF metadata                                 | —               |
+| Cover and heading chapter split      | —                 | —                 | Yes                                          | —               |
+
+`pageSize` supports the complete Illusions page-size collection: ISO A, JIS B, ISO B, Japanese literary/book/envelope sizes, North American office sizes, and postcard/photo sizes. Use the exported `PAGE_SIZES` list when building a UI.

--- a/docs/src/content/docs/ja/guides/export-profiles.md
+++ b/docs/src/content/docs/ja/guides/export-profiles.md
@@ -1,0 +1,25 @@
+---
+title: エクスポート・プロファイル
+description: PDF、DOCX、EPUB、テキストの出力設定をアプリ間で共有します。
+---
+
+`@illusions-lab/mdi-export-profile` は MDI 出力の共通かつ検証済みの設定契約です。原稿の front matter や MDI 構文には入れず、JSON ファイルまたはアプリ設定として保存します。
+
+```sh
+mdi build novel.mdi --to pdf --config novel.export.json -o novel.pdf
+mdi build novel.mdi --to docx --config novel.export.json
+mdi build novel.mdi --to epub --config novel.export.json
+mdi build novel.mdi --to txt-ruby --config novel.export.json
+```
+
+プロファイルには、書名・著者・出版社・UUID/ISBN、組方向、フォント、字下げ、用紙サイズ、用紙方向、文字数、行数、余白、ページ番号、EPUB の表紙と見出し分割、TXT の全角スペース字下げを指定できます。`coverPath` はプロファイルファイルからの相対パスで、JPEG/PNG のみです。
+
+| 設定                         | PDF  | DOCX           | EPUB                       | TXT / TXT ruby |
+| ---------------------------- | ---- | -------------- | -------------------------- | -------------- |
+| 用紙・余白・文字数・行数     | 対応 | 対応           | リフロー形式のため非対応   | —              |
+| 組方向・フォント・字下げ     | 対応 | 対応           | 対応                       | —              |
+| 全角スペース字下げ           | 対応 | 対応           | CSS 字下げ                 | 1–4 字         |
+| ページ番号                   | 対応 | 対応           | 固定ページがないため非対応 | —              |
+| 表紙、出版社、識別子、章分割 | —    | 文書プロパティ | 対応                       | —              |
+
+不正な用紙サイズ、余白、ページ番号の値、章分割レベルは黙って補正せず、明確なエラーとして返します。UI では `PAGE_SIZES` を用紙サイズセレクタに利用できます。

--- a/docs/src/content/docs/zh-tw/guides/export-profiles.md
+++ b/docs/src/content/docs/zh-tw/guides/export-profiles.md
@@ -1,0 +1,25 @@
+---
+title: 匯出設定檔
+description: 在應用程式間共用精確的 PDF、DOCX、EPUB 與文字匯出設定。
+---
+
+`@illusions-lab/mdi-export-profile` 是 MDI 匯出的共用、已驗證設定契約。它刻意與 MDI 語法及 front matter 分離，可儲存為 JSON 檔或應用程式偏好設定。
+
+```sh
+mdi build novel.mdi --to pdf --config novel.export.json -o novel.pdf
+mdi build novel.mdi --to docx --config novel.export.json
+mdi build novel.mdi --to epub --config novel.export.json
+mdi build novel.mdi --to txt-ruby --config novel.export.json
+```
+
+設定檔可以指定書名、作者、出版社、UUID/ISBN、組方向、字體、字下げ、紙張尺寸、方向、每行字數、每頁行數、邊界、頁碼、EPUB 封面與見出し切章，以及 TXT 的全形空格字下げ。相對 `coverPath` 以設定檔所在目錄為基準，且只接受 JPEG/PNG。
+
+| 設定                           | PDF  | DOCX     | EPUB                      | TXT / TXT ruby |
+| ------------------------------ | ---- | -------- | ------------------------- | -------------- |
+| 紙張、方向、邊界、字數、行數   | 支援 | 支援     | EPUB 可重排，沒有固定紙張 | —              |
+| 組方向、字體、`em` 字下げ      | 支援 | 支援     | 支援                      | —              |
+| 全形空格字下げ                 | 支援 | 支援     | 使用 CSS 字下げ           | 1–4 個空格     |
+| 頁碼格式與位置                 | 支援 | 支援     | 沒有穩定固定頁碼          | —              |
+| 封面、出版社、識別碼、章節切分 | —    | 文件屬性 | 支援                      | —              |
+
+不合法的紙張尺寸、邊界、頁碼設定或章節切分層級會明確報錯，不會悄悄產生不同版面。UI 可使用匯出的 `PAGE_SIZES` 建立紙張尺寸選擇器。

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -25,11 +25,13 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@illusions-lab/mdi-export-profile": "workspace:*",
     "@illusions-lab/mdi-remark": "workspace:*",
     "@illusions-lab/mdi-to-html": "workspace:*",
     "@illusions-lab/mdi-to-pdf": "workspace:*",
     "@illusions-lab/mdi-to-epub": "workspace:*",
     "@illusions-lab/mdi-to-docx": "workspace:*",
+    "mdast-util-mdi": "workspace:*",
     "remark-parse": "^11.0.0",
     "unified": "^11.0.0",
     "@types/mdast": "^4.0.0"

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,13 +1,18 @@
 #!/usr/bin/env node
-import { build, parseArgs } from "./index.js";
+import { build, loadExportProfile, parseArgs } from "./index.js";
 
 const args = parseArgs(process.argv.slice(3));
 if (!args || process.argv[2] !== "build") {
-	console.error("Usage: mdi build <input.mdi> --to html|pdf|epub|docx [-o <output>]");
-	process.exitCode = 1;
+  console.error(
+    "Usage: mdi build <input.mdi> --to html|pdf|epub|docx|txt|txt-ruby [--config export.json] [-o <output>]"
+  );
+  process.exitCode = 1;
 } else {
-	build(args.input, args.format, args.output).catch((error: unknown) => {
-		console.error(error instanceof Error ? error.message : String(error));
-		process.exitCode = 1;
-	});
+  build(args.input, args.format, {
+    output: args.output,
+    profile: await loadExportProfile(args.config),
+  }).catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
 }

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -2,47 +2,111 @@ import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { build, parseArgs } from "./index.js";
+import { build, loadExportProfile, mdiToText, parseArgs } from "./index.js";
+import { unified } from "unified";
+import remarkParse from "remark-parse";
+import remarkMdi from "@illusions-lab/mdi-remark";
 
-describe("mdi CLI library", () => it("builds HTML and DOCX output", async () => {
-	const directory = await mkdtemp(join(tmpdir(), "mdi-cli-"));
-	try {
-		const input = join(directory, "book.mdi");
-		await writeFile(input, "---\ntitle: Book\n---\n{東京|とうきょう}");
-		const html = await build(input, "html");
-		expect(await readFile(html, "utf8")).toContain("<title>Book</title>");
-		const docx = await build(input, "docx");
-		expect((await readFile(docx)).subarray(0, 2).toString()).toBe("PK");
-	} finally { await rm(directory, { recursive: true, force: true }); }
-}));
+describe("mdi CLI library", () =>
+  it("builds HTML and DOCX output", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "mdi-cli-"));
+    try {
+      const input = join(directory, "book.mdi");
+      await writeFile(input, "---\ntitle: Book\n---\n{東京|とうきょう}");
+      const html = await build(input, "html");
+      expect(await readFile(html, "utf8")).toContain("<title>Book</title>");
+      const docx = await build(input, "docx");
+      expect((await readFile(docx)).subarray(0, 2).toString()).toBe("PK");
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  }));
 
 describe("parseArgs", () => {
-	it("requires an output format", () => expect(parseArgs(["book.mdi"])).toBeUndefined());
-	it("parses a supported format", () => expect(parseArgs(["book.mdi", "--to", "html"])).toEqual({ input: "book.mdi", format: "html" }));
-	it("rejects malformed and unrecognized argument forms", () => {
-		for (const args of [[], ["book.mdi", "--to", "html", "extra"], ["book.mdi", "-o", "out.html"], ["book.mdi", "--to", "html", "-o"], ["book.mdi", "--wat", "html"], ["book.mdi", "--to", "txt"]]) {
-			expect(parseArgs(args)).toBeUndefined();
-		}
-	});
-	it("parses an explicit output path", () => expect(parseArgs(["book.mdi", "--to", "epub", "-o", "out/book.epub"])).toEqual({ input: "book.mdi", format: "epub", output: "out/book.epub" }));
+  it("requires an output format", () =>
+    expect(parseArgs(["book.mdi"])).toBeUndefined());
+  it("parses a supported format", () =>
+    expect(parseArgs(["book.mdi", "--to", "html"])).toEqual({
+      input: "book.mdi",
+      format: "html",
+    }));
+  it("rejects malformed and unrecognized argument forms", () => {
+    for (const args of [
+      [],
+      ["book.mdi", "--to", "html", "extra"],
+      ["book.mdi", "-o", "out.html"],
+      ["book.mdi", "--to", "html", "-o"],
+      ["book.mdi", "--wat", "html"],
+    ]) {
+      expect(parseArgs(args)).toBeUndefined();
+    }
+  });
+  it("parses an explicit output path", () =>
+    expect(
+      parseArgs(["book.mdi", "--to", "epub", "-o", "out/book.epub"])
+    ).toEqual({ input: "book.mdi", format: "epub", output: "out/book.epub" }));
+  it("accepts TXT formats and profile configuration in either flag order", () =>
+    expect(
+      parseArgs([
+        "book.mdi",
+        "--config",
+        "book.export.json",
+        "--to",
+        "txt-ruby",
+      ])
+    ).toEqual({
+      input: "book.mdi",
+      format: "txt-ruby",
+      config: "book.export.json",
+    }));
+});
+
+describe("text export", () => {
+  it("uses full-width indentation only for paragraphs and preserves ruby on request", () => {
+    const processor = unified().use(remarkParse).use(remarkMdi);
+    const tree = processor.runSync(
+      processor.parse("# 題\n\n{東京|とうきょう}\n\n[[blank]]\n\n次")
+    ) as import("mdast").Root;
+    expect(
+      mdiToText(tree, { text: { fullwidthSpaceIndent: true, indentCount: 2 } })
+    ).toBe("題\n　　東京\n\n　　次");
+    expect(mdiToText(tree, undefined, true)).toContain("{東京|とうきょう}");
+  });
 });
 
 describe("build edge cases", () => {
-	it("rejects a missing input with the readable filesystem error", async () => {
-		const missing = join(tmpdir(), "mdi-cli-missing-input.mdi");
-		await expect(build(missing, "html")).rejects.toThrow(/ENOENT.*mdi-cli-missing-input\.mdi/);
-	});
+  it("rejects a missing input with the readable filesystem error", async () => {
+    const missing = join(tmpdir(), "mdi-cli-missing-input.mdi");
+    await expect(build(missing, "html")).rejects.toThrow(
+      /ENOENT.*mdi-cli-missing-input\.mdi/
+    );
+  });
 
 	it("writes an explicit output in a different directory", async () => {
-		const directory = await mkdtemp(join(tmpdir(), "mdi-cli-output-"));
+    const directory = await mkdtemp(join(tmpdir(), "mdi-cli-output-"));
+    try {
+      const input = join(directory, "input", "book.mdi");
+      const output = join(directory, "output", "book.html");
+      await (await import("node:fs/promises")).mkdir(join(directory, "input"));
+      await (await import("node:fs/promises")).mkdir(join(directory, "output"));
+      await writeFile(input, "# Elsewhere");
+      expect(await build(input, "html", output)).toBe(output);
+      expect(await readFile(output, "utf8")).toContain("<h1>Elsewhere</h1>");
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+	});
+
+	it("loads a profile and resolves its EPUB cover relative to the JSON file", async () => {
+		const directory = await mkdtemp(join(tmpdir(), "mdi-cli-profile-"));
 		try {
-			const input = join(directory, "input", "book.mdi");
-			const output = join(directory, "output", "book.html");
-			await (await import("node:fs/promises")).mkdir(join(directory, "input"));
-			await (await import("node:fs/promises")).mkdir(join(directory, "output"));
-			await writeFile(input, "# Elsewhere");
-			expect(await build(input, "html", output)).toBe(output);
-			expect(await readFile(output, "utf8")).toContain("<h1>Elsewhere</h1>");
-		} finally { await rm(directory, { recursive: true, force: true }); }
+			const config = join(directory, "export.json");
+			await writeFile(config, '{"epub":{"coverPath":"cover.png"},"text":{"fullwidthSpaceIndent":true,"indentCount":2}}');
+			const profile = await loadExportProfile(config);
+			expect(profile?.epub?.coverPath).toBe(join(directory, "cover.png"));
+			expect(profile?.text?.indentCount).toBe(2);
+		} finally {
+			await rm(directory, { recursive: true, force: true });
+		}
 	});
 });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,5 +1,5 @@
 import { readFile, writeFile } from "node:fs/promises";
-import { extname, resolve } from "node:path";
+import { dirname, extname, resolve } from "node:path";
 import { unified } from "unified";
 import remarkParse from "remark-parse";
 import remarkMdi from "@illusions-lab/mdi-remark";
@@ -7,26 +7,181 @@ import { mdiToHtml } from "@illusions-lab/mdi-to-html";
 import { mdiToPdf } from "@illusions-lab/mdi-to-pdf";
 import { mdiToEpub } from "@illusions-lab/mdi-to-epub";
 import { mdiToDocx } from "@illusions-lab/mdi-to-docx";
-import type { Root } from "mdast";
+import {
+  parseExportProfileJson,
+  resolveExportProfile,
+  type ExportProfile,
+} from "@illusions-lab/mdi-export-profile";
+import type { Root, RootContent, PhrasingContent } from "mdast";
+import type {} from "mdast-util-mdi";
+import type {} from "@illusions-lab/mdi-remark";
 
 export const MDI_SPEC_VERSION = "2.0";
-export type OutputFormat = "html" | "pdf" | "epub" | "docx";
-
-export async function build(input: string, format: OutputFormat, output?: string): Promise<string> {
-	const source = await readFile(input, "utf8");
-	const processor = unified().use(remarkParse).use(remarkMdi);
-	const tree = processor.runSync(processor.parse(source)) as Root;
-	const result = format === "html" ? mdiToHtml(tree) : format === "pdf" ? await mdiToPdf(tree) : format === "epub" ? await mdiToEpub(tree) : await mdiToDocx(tree);
-	const destination = output ?? input.slice(0, input.length - extname(input).length) + `.${format}`;
-	await writeFile(destination, result);
-	return resolve(destination);
+export type OutputFormat =
+  | "html"
+  | "pdf"
+  | "epub"
+  | "docx"
+  | "txt"
+  | "txt-ruby";
+export interface BuildOptions {
+  output?: string;
+  profile?: ExportProfile;
 }
 
-export function parseArgs(args: string[]): { input: string; format: OutputFormat; output?: string } | undefined {
-	const [input, flag, format, ...rest] = args;
-	if (!input || flag !== "--to" || !isFormat(format)) return undefined;
-	if (rest.length === 0) return { input, format };
-	if (rest.length === 2 && rest[0] === "-o") return { input, format, output: rest[1] };
-	return undefined;
+export async function build(
+  input: string,
+  format: OutputFormat,
+  options: BuildOptions | string = {}
+): Promise<string> {
+  const resolvedOptions =
+    typeof options === "string" ? { output: options } : options;
+  const source = await readFile(input, "utf8");
+  const processor = unified().use(remarkParse).use(remarkMdi);
+  const tree = processor.runSync(processor.parse(source)) as Root;
+  const result =
+    format === "html"
+      ? mdiToHtml(tree)
+      : format === "pdf"
+      ? await mdiToPdf(tree, resolvedOptions.profile)
+      : format === "epub"
+      ? await mdiToEpub(tree, {
+          profile: resolvedOptions.profile,
+          cover: await loadCover(resolvedOptions.profile),
+        })
+      : format === "docx"
+      ? await mdiToDocx(tree, resolvedOptions.profile)
+      : mdiToText(tree, resolvedOptions.profile, format === "txt-ruby");
+  const extension = format === "txt-ruby" ? "txt" : format;
+  const destination =
+    resolvedOptions.output ??
+    input.slice(0, input.length - extname(input).length) + `.${extension}`;
+  await writeFile(destination, result);
+  return resolve(destination);
 }
-function isFormat(value: string | undefined): value is OutputFormat { return value === "html" || value === "pdf" || value === "epub" || value === "docx"; }
+
+export interface CliArgs {
+  input: string;
+  format: OutputFormat;
+  output?: string;
+  config?: string;
+}
+export function parseArgs(args: string[]): CliArgs | undefined {
+  const [input, ...tail] = args;
+  if (!input) return undefined;
+  let format: OutputFormat | undefined;
+  let output: string | undefined;
+  let config: string | undefined;
+  for (let index = 0; index < tail.length; index += 2) {
+    const flag = tail[index];
+    const value = tail[index + 1];
+    if (!value) return undefined;
+    if (flag === "--to" && isFormat(value) && !format) format = value;
+    else if (flag === "-o" && !output) output = value;
+    else if (flag === "--config" && !config) config = value;
+    else return undefined;
+  }
+  return format
+    ? {
+        input,
+        format,
+        ...(output ? { output } : {}),
+        ...(config ? { config } : {}),
+      }
+    : undefined;
+}
+
+export async function loadExportProfile(
+  configPath?: string
+): Promise<ExportProfile | undefined> {
+  if (!configPath) return undefined;
+  const profile = parseExportProfileJson(await readFile(configPath, "utf8"));
+  if (profile.epub.coverPath)
+    profile.epub.coverPath = resolve(
+      dirname(configPath),
+      profile.epub.coverPath
+    );
+  return profile;
+}
+
+/** Plain text and ruby-preserving text exports share the profile's U+3000 indentation. */
+export function mdiToText(
+  tree: Root,
+  profile?: ExportProfile,
+  ruby = false
+): string {
+  const settings = resolveExportProfile(profile).text;
+  const prefix = settings.fullwidthSpaceIndent
+    ? "　".repeat(settings.indentCount)
+    : "";
+  return tree.children
+    .map((node) => textBlock(node, ruby, prefix))
+    .filter((value) => value !== undefined)
+    .join("\n");
+}
+
+async function loadCover(
+  profile: ExportProfile | undefined
+): Promise<
+  { data: Uint8Array; mediaType: "image/jpeg" | "image/png" } | undefined
+> {
+  const coverPath = profile
+    ? resolveExportProfile(profile).epub.coverPath
+    : undefined;
+  if (!coverPath) return undefined;
+  const extension = extname(coverPath).toLowerCase();
+  if (extension !== ".jpg" && extension !== ".jpeg" && extension !== ".png")
+    throw new Error("EPUB cover must be a JPEG or PNG file");
+  return {
+    data: await readFile(coverPath),
+    mediaType: extension === ".png" ? "image/png" : "image/jpeg",
+  };
+}
+
+function textBlock(
+  node: RootContent,
+  ruby: boolean,
+  prefix: string
+): string | undefined {
+  if (node.type === "paragraph")
+    return `${prefix}${inlineText(node.children, ruby)}`;
+  if (node.type === "heading") return inlineText(node.children, ruby);
+  if (node.type === "list")
+    return node.children
+      .map((item) =>
+        item.children
+          .filter((child) => child.type === "paragraph")
+          .map((child) => `${prefix}${inlineText(child.children, ruby)}`)
+          .join("\n")
+      )
+      .join("\n");
+  if (node.type === "mdiBlank" || node.type === "mdiPagebreak") return "";
+  return undefined;
+}
+function inlineText(nodes: PhrasingContent[], ruby: boolean): string {
+  return nodes
+    .map((node) => {
+      if (node.type === "text") return node.value;
+      if (node.type === "break" || node.type === "mdiBreak") return "\n";
+      if (node.type === "mdiRuby")
+        return ruby
+          ? `{${node.base}|${
+              Array.isArray(node.ruby) ? node.ruby.join(".") : node.ruby
+            }}`
+          : node.base;
+      if ("children" in node)
+        return inlineText(node.children as PhrasingContent[], ruby);
+      return "";
+    })
+    .join("");
+}
+function isFormat(value: string): value is OutputFormat {
+  return (
+    value === "html" ||
+    value === "pdf" ||
+    value === "epub" ||
+    value === "docx" ||
+    value === "txt" ||
+    value === "txt-ruby"
+  );
+}

--- a/packages/export-profile/README.md
+++ b/packages/export-profile/README.md
@@ -1,0 +1,3 @@
+# @illusions-lab/mdi-export-profile
+
+The validated shared export-profile schema for MDI PDF, DOCX, EPUB, and text exporters. See the [export-profile guide](https://illusions-lab.github.io/mdi-js/guides/export-profiles/) for configuration and CLI usage.

--- a/packages/export-profile/package.json
+++ b/packages/export-profile/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@illusions-lab/mdi-export-profile",
+  "version": "2.0.0",
+  "description": "Shared export profile schema for MDI converters",
+  "license": "MIT",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup src/index.ts --format esm,cjs --dts",
+    "test": "vitest run --passWithNoTests",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "tsup": "^8.3.0",
+    "typescript": "^5.6.0",
+    "vitest": "^2.1.0"
+  }
+}

--- a/packages/export-profile/src/index.test.ts
+++ b/packages/export-profile/src/index.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import {
+  PAGE_SIZES,
+  parseExportProfileJson,
+  resolveExportProfile,
+} from "./index.js";
+
+describe("export profiles", () => {
+  it("resolves every supported paper size", () => {
+    for (const pageSize of PAGE_SIZES)
+      expect(
+        resolveExportProfile({ pagination: { pageSize } }).pagination.pageSize
+      ).toBe(pageSize);
+  });
+  it("rejects invalid values instead of silently changing print layout", () => {
+    expect(() =>
+      resolveExportProfile({ pagination: { pageSize: "A11" as never } })
+    ).toThrow("Unsupported page size");
+    expect(() =>
+      resolveExportProfile({ pagination: { charactersPerLine: 9 } })
+    ).toThrow("charactersPerLine");
+    expect(() =>
+      resolveExportProfile({ typesetting: { textIndentEm: 4.1 } })
+    ).toThrow("textIndentEm");
+    expect(() => resolveExportProfile({ text: { indentCount: 0 } })).toThrow(
+      "text.indentCount"
+    );
+  });
+  it("parses nested profile settings", () => {
+    const profile = parseExportProfileJson(
+      '{"typesetting":{"writingMode":"horizontal","fullwidthSpaceIndent":true},"pagination":{"pageNumbers":{"format":"fraction","position":"top-right"}},"epub":{"chapterSplitLevel":"h3"}}'
+    );
+    expect(profile.typesetting.writingMode).toBe("horizontal");
+    expect(profile.pagination.pageNumbers).toEqual({
+      enabled: true,
+      format: "fraction",
+      position: "top-right",
+    });
+    expect(profile.epub.chapterSplitLevel).toBe("h3");
+  });
+  it("rejects malformed profiles", () => {
+    expect(() => parseExportProfileJson("[]")).toThrow("JSON object");
+    expect(() => parseExportProfileJson("{")).toThrow("valid JSON");
+  });
+  it("rejects runtime JSON values with the wrong primitive type", () => {
+    expect(() =>
+      parseExportProfileJson('{"pagination":{"landscape":"yes"}}')
+    ).toThrow("landscape must be a boolean");
+    expect(() => parseExportProfileJson('{"metadata":{"title":42}}')).toThrow(
+      "metadata.title must be a string"
+    );
+    expect(() =>
+      parseExportProfileJson('{"pagination":{"margins":[]}}')
+    ).toThrow("pagination.margins must be an object");
+  });
+});

--- a/packages/export-profile/src/index.ts
+++ b/packages/export-profile/src/index.ts
@@ -1,0 +1,390 @@
+export type WritingMode = "vertical" | "horizontal";
+export type PageNumberFormat = "simple" | "dash" | "fraction";
+export type PageNumberPosition =
+  | "top-left"
+  | "top-center"
+  | "top-right"
+  | "bottom-left"
+  | "bottom-center"
+  | "bottom-right";
+export type ChapterSplitLevel = "h1" | "h2" | "h3" | "none";
+
+export interface Margins {
+  top: number;
+  bottom: number;
+  left: number;
+  right: number;
+}
+
+export interface ExportMetadata {
+  title?: string;
+  author?: string;
+  publisher?: string;
+  identifier?: string;
+  language?: string;
+  date?: string;
+}
+
+export interface ExportProfile {
+  metadata?: ExportMetadata;
+  typesetting?: {
+    writingMode?: WritingMode;
+    fontFamily?: string;
+    textIndentEm?: number;
+    fullwidthSpaceIndent?: boolean;
+  };
+  pagination?: {
+    pageSize?: PageSize;
+    landscape?: boolean;
+    charactersPerLine?: number;
+    linesPerPage?: number;
+    margins?: Partial<Margins>;
+    pageNumbers?: {
+      enabled?: boolean;
+      format?: PageNumberFormat;
+      position?: PageNumberPosition;
+    };
+  };
+  epub?: {
+    chapterSplitLevel?: ChapterSplitLevel;
+    /** A JSON config path; the CLI loads it as JPEG or PNG. */
+    coverPath?: string;
+  };
+  text?: {
+    fullwidthSpaceIndent?: boolean;
+    indentCount?: number;
+  };
+}
+
+export interface ResolvedExportProfile {
+  metadata: ExportMetadata;
+  typesetting: Required<NonNullable<ExportProfile["typesetting"]>>;
+  pagination: {
+    pageSize: PageSize;
+    landscape: boolean;
+    charactersPerLine: number;
+    linesPerPage: number;
+    margins: Margins;
+    pageNumbers: {
+      enabled: boolean;
+      format: PageNumberFormat;
+      position: PageNumberPosition;
+    };
+  };
+  epub: { chapterSplitLevel: ChapterSplitLevel; coverPath?: string };
+  text: { fullwidthSpaceIndent: boolean; indentCount: number };
+}
+
+export const PAGE_DIMENSIONS = {
+  A0: { width: 841, height: 1189 },
+  A1: { width: 594, height: 841 },
+  A2: { width: 420, height: 594 },
+  A3: { width: 297, height: 420 },
+  A4: { width: 210, height: 297 },
+  A5: { width: 148, height: 210 },
+  A6: { width: 105, height: 148 },
+  A7: { width: 74, height: 105 },
+  A8: { width: 52, height: 74 },
+  A9: { width: 37, height: 52 },
+  A10: { width: 26, height: 37 },
+  "JIS-B0": { width: 1030, height: 1456 },
+  "JIS-B1": { width: 728, height: 1030 },
+  "JIS-B2": { width: 515, height: 728 },
+  "JIS-B3": { width: 364, height: 515 },
+  "JIS-B4": { width: 257, height: 364 },
+  "JIS-B5": { width: 182, height: 257 },
+  "JIS-B6": { width: 128, height: 182 },
+  "JIS-B7": { width: 91, height: 128 },
+  "JIS-B8": { width: 64, height: 91 },
+  "JIS-B9": { width: 45, height: 64 },
+  "JIS-B10": { width: 32, height: 45 },
+  "ISO-B0": { width: 1000, height: 1414 },
+  "ISO-B1": { width: 707, height: 1000 },
+  "ISO-B2": { width: 500, height: 707 },
+  "ISO-B3": { width: 353, height: 500 },
+  "ISO-B4": { width: 250, height: 353 },
+  "ISO-B5": { width: 176, height: 250 },
+  "ISO-B6": { width: 125, height: 176 },
+  "ISO-B7": { width: 88, height: 125 },
+  "ISO-B8": { width: 62, height: 88 },
+  "ISO-B9": { width: 44, height: 62 },
+  "ISO-B10": { width: 31, height: 44 },
+  Bunko: { width: 105, height: 148 },
+  Shinsho: { width: 103, height: 182 },
+  Shirokuban: { width: 127, height: 188 },
+  Kikuban: { width: 150, height: 220 },
+  "A5-ban": { width: 148, height: 210 },
+  "B6-ban": { width: 128, height: 182 },
+  "AB-ban": { width: 210, height: 257 },
+  "Ju-ban": { width: 182, height: 206 },
+  "Kiku-tate": { width: 152, height: 218 },
+  Tankobon: { width: 130, height: 188 },
+  Letter: { width: 216, height: 279 },
+  Legal: { width: 216, height: 356 },
+  Tabloid: { width: 279, height: 432 },
+  Executive: { width: 184, height: 267 },
+  Statement: { width: 140, height: 216 },
+  Folio: { width: 210, height: 330 },
+  Quarto: { width: 203, height: 254 },
+  "10x14": { width: 254, height: 356 },
+  "Naga-3": { width: 120, height: 235 },
+  "Naga-4": { width: 90, height: 205 },
+  "Kaku-2": { width: 240, height: 332 },
+  "Kaku-3": { width: 216, height: 277 },
+  "Kaku-6": { width: 162, height: 229 },
+  "Kaku-8": { width: 119, height: 197 },
+  "You-4": { width: 105, height: 235 },
+  "You-6": { width: 98, height: 190 },
+  Hagaki: { width: 100, height: 148 },
+  "Ofuku-Hagaki": { width: 200, height: 148 },
+  "L-ban": { width: 89, height: 127 },
+  "2L-ban": { width: 127, height: 178 },
+  KG: { width: 102, height: 152 },
+  Cabinet: { width: 130, height: 180 },
+  B5: { width: 176, height: 250 },
+  B6: { width: 125, height: 176 },
+} as const;
+
+export type PageSize = keyof typeof PAGE_DIMENSIONS;
+export const PAGE_SIZES = Object.keys(PAGE_DIMENSIONS) as PageSize[];
+
+export const DEFAULT_EXPORT_PROFILE: ResolvedExportProfile = {
+  metadata: {},
+  typesetting: {
+    writingMode: "vertical",
+    fontFamily: "serif",
+    textIndentEm: 1,
+    fullwidthSpaceIndent: false,
+  },
+  pagination: {
+    pageSize: "A4",
+    landscape: true,
+    charactersPerLine: 40,
+    linesPerPage: 30,
+    margins: { top: 34, bottom: 28, left: 28, right: 45 },
+    pageNumbers: { enabled: true, format: "simple", position: "bottom-center" },
+  },
+  epub: { chapterSplitLevel: "h1" },
+  text: { fullwidthSpaceIndent: false, indentCount: 1 },
+};
+
+/** Validates and fills an export profile without silently accepting bad layout data. */
+export function resolveExportProfile(
+  profile: ExportProfile = {}
+): ResolvedExportProfile {
+  if (!profile || typeof profile !== "object" || Array.isArray(profile))
+    throw new Error("Export profile must be an object");
+  for (const [key, value] of Object.entries(profile))
+    if (
+      value !== undefined &&
+      (typeof value !== "object" || value === null || Array.isArray(value))
+    )
+      throw new Error(`${key} must be an object`);
+  const requireObject = (value: unknown, label: string) => {
+    if (
+      value !== undefined &&
+      (typeof value !== "object" || value === null || Array.isArray(value))
+    )
+      throw new Error(`${label} must be an object`);
+  };
+  requireObject(profile.typesetting, "typesetting");
+  requireObject(profile.pagination, "pagination");
+  requireObject(profile.epub, "epub");
+  requireObject(profile.text, "text");
+  requireObject(profile.metadata, "metadata");
+  const typesetting = profile.typesetting ?? {};
+  const pagination = profile.pagination ?? {};
+  const text = profile.text ?? {};
+  requireObject(pagination.pageNumbers, "pagination.pageNumbers");
+  requireObject(pagination.margins, "pagination.margins");
+  const pageNumbers = pagination.pageNumbers ?? {};
+  const margins = pagination.margins ?? {};
+  const pageSize =
+    pagination.pageSize ?? DEFAULT_EXPORT_PROFILE.pagination.pageSize;
+  for (const [key, value] of Object.entries(profile.metadata ?? {}))
+    if (value !== undefined && typeof value !== "string")
+      throw new Error(`metadata.${key} must be a string`);
+  if (
+    typesetting.fontFamily !== undefined &&
+    typeof typesetting.fontFamily !== "string"
+  )
+    throw new Error("fontFamily must be a string");
+  if (
+    profile.epub?.coverPath !== undefined &&
+    typeof profile.epub.coverPath !== "string"
+  )
+    throw new Error("coverPath must be a string");
+  if (typeof pageSize !== "string" || !(pageSize in PAGE_DIMENSIONS))
+    throw new Error(`Unsupported page size: ${String(pageSize)}`);
+  if (
+    typesetting.writingMode !== undefined &&
+    typesetting.writingMode !== "vertical" &&
+    typesetting.writingMode !== "horizontal"
+  )
+    throw new Error("writingMode must be vertical or horizontal");
+  if (
+    profile.epub?.chapterSplitLevel !== undefined &&
+    !["h1", "h2", "h3", "none"].includes(profile.epub.chapterSplitLevel)
+  )
+    throw new Error("chapterSplitLevel must be h1, h2, h3, or none");
+  if (
+    pageNumbers.format !== undefined &&
+    !["simple", "dash", "fraction"].includes(pageNumbers.format)
+  )
+    throw new Error("Unsupported page number format");
+  if (
+    pageNumbers.position !== undefined &&
+    ![
+      "top-left",
+      "top-center",
+      "top-right",
+      "bottom-left",
+      "bottom-center",
+      "bottom-right",
+    ].includes(pageNumbers.position)
+  )
+    throw new Error("Unsupported page number position");
+  const number = (
+    value: number | undefined,
+    fallback: number,
+    min: number,
+    max: number,
+    label: string
+  ) => {
+    const resolved = value ?? fallback;
+    if (!Number.isFinite(resolved) || resolved < min || resolved > max)
+      throw new Error(`${label} must be between ${min} and ${max}`);
+    return resolved;
+  };
+  const boolean = (
+    value: boolean | undefined,
+    fallback: boolean,
+    label: string
+  ) => {
+    if (value !== undefined && typeof value !== "boolean")
+      throw new Error(`${label} must be a boolean`);
+    return value ?? fallback;
+  };
+  const resolvedMargins: Margins = {
+    top: number(
+      margins.top,
+      DEFAULT_EXPORT_PROFILE.pagination.margins.top,
+      0,
+      50,
+      "top margin"
+    ),
+    bottom: number(
+      margins.bottom,
+      DEFAULT_EXPORT_PROFILE.pagination.margins.bottom,
+      0,
+      50,
+      "bottom margin"
+    ),
+    left: number(
+      margins.left,
+      DEFAULT_EXPORT_PROFILE.pagination.margins.left,
+      0,
+      50,
+      "left margin"
+    ),
+    right: number(
+      margins.right,
+      DEFAULT_EXPORT_PROFILE.pagination.margins.right,
+      0,
+      50,
+      "right margin"
+    ),
+  };
+  return {
+    metadata: { ...profile.metadata },
+    typesetting: {
+      writingMode:
+        typesetting.writingMode ??
+        DEFAULT_EXPORT_PROFILE.typesetting.writingMode,
+      fontFamily:
+        typesetting.fontFamily?.trim() ||
+        DEFAULT_EXPORT_PROFILE.typesetting.fontFamily,
+      textIndentEm: number(
+        typesetting.textIndentEm,
+        DEFAULT_EXPORT_PROFILE.typesetting.textIndentEm,
+        0,
+        4,
+        "textIndentEm"
+      ),
+      fullwidthSpaceIndent: boolean(
+        typesetting.fullwidthSpaceIndent,
+        DEFAULT_EXPORT_PROFILE.typesetting.fullwidthSpaceIndent,
+        "fullwidthSpaceIndent"
+      ),
+    },
+    pagination: {
+      pageSize,
+      landscape: boolean(
+        pagination.landscape,
+        DEFAULT_EXPORT_PROFILE.pagination.landscape,
+        "landscape"
+      ),
+      charactersPerLine: number(
+        pagination.charactersPerLine,
+        DEFAULT_EXPORT_PROFILE.pagination.charactersPerLine,
+        10,
+        60,
+        "charactersPerLine"
+      ),
+      linesPerPage: number(
+        pagination.linesPerPage,
+        DEFAULT_EXPORT_PROFILE.pagination.linesPerPage,
+        10,
+        50,
+        "linesPerPage"
+      ),
+      margins: resolvedMargins,
+      pageNumbers: {
+        enabled: boolean(
+          pageNumbers.enabled,
+          DEFAULT_EXPORT_PROFILE.pagination.pageNumbers.enabled,
+          "pageNumbers.enabled"
+        ),
+        format:
+          pageNumbers.format ??
+          DEFAULT_EXPORT_PROFILE.pagination.pageNumbers.format,
+        position:
+          pageNumbers.position ??
+          DEFAULT_EXPORT_PROFILE.pagination.pageNumbers.position,
+      },
+    },
+    epub: {
+      chapterSplitLevel:
+        profile.epub?.chapterSplitLevel ??
+        DEFAULT_EXPORT_PROFILE.epub.chapterSplitLevel,
+      ...(profile.epub?.coverPath ? { coverPath: profile.epub.coverPath } : {}),
+    },
+    text: {
+      fullwidthSpaceIndent: boolean(
+        text.fullwidthSpaceIndent,
+        DEFAULT_EXPORT_PROFILE.text.fullwidthSpaceIndent,
+        "text.fullwidthSpaceIndent"
+      ),
+      indentCount: number(
+        text.indentCount,
+        DEFAULT_EXPORT_PROFILE.text.indentCount,
+        1,
+        4,
+        "text.indentCount"
+      ),
+    },
+  };
+}
+
+/** Parse a JSON profile for the CLI; malformed JSON never falls back silently. */
+export function parseExportProfileJson(source: string): ResolvedExportProfile {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(source);
+  } catch {
+    throw new Error("Export profile must be valid JSON");
+  }
+  if (!raw || typeof raw !== "object" || Array.isArray(raw))
+    throw new Error("Export profile must be a JSON object");
+  return resolveExportProfile(raw as ExportProfile);
+}

--- a/packages/export-profile/tsconfig.json
+++ b/packages/export-profile/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src"]
+}

--- a/packages/to-docx/package.json
+++ b/packages/to-docx/package.json
@@ -28,6 +28,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@illusions-lab/mdi-export-profile": "workspace:*",
     "mdast-util-mdi": "workspace:*",
     "docx": "^9.0.0",
     "@types/mdast": "^4.0.0"

--- a/packages/to-docx/src/index.test.ts
+++ b/packages/to-docx/src/index.test.ts
@@ -7,40 +7,88 @@ import type { Root } from "mdast";
 import { mdiToDocx } from "./index.js";
 
 function parse(source: string): Root {
-	const p = unified().use(remarkParse).use(remarkMdi);
-	return p.runSync(p.parse(source)) as Root;
+  const p = unified().use(remarkParse).use(remarkMdi);
+  return p.runSync(p.parse(source)) as Root;
 }
 
-describe("mdiToDocx", () => it("creates a DOCX containing ordinary, ruby, and tcy runs", async () => {
-	const p = unified().use(remarkParse).use(remarkMdi);
-	const zip = await JSZip.loadAsync(await mdiToDocx(p.runSync(p.parse("# Heading\n\nplain {東京|とうきょう} ^12^")) as Root));
-	const document = await zip.file("word/document.xml")!.async("string");
-	expect(document).toContain("<w:document");
-	expect(document).toContain("<w:ruby>");
-	expect(document).toContain("<w:eastAsianLayout");
-}));
+describe("mdiToDocx", () =>
+  it("creates a DOCX containing ordinary, ruby, and tcy runs", async () => {
+    const p = unified().use(remarkParse).use(remarkMdi);
+    const zip = await JSZip.loadAsync(
+      await mdiToDocx(
+        p.runSync(p.parse("# Heading\n\nplain {東京|とうきょう} ^12^")) as Root
+      )
+    );
+    const document = await zip.file("word/document.xml")!.async("string");
+    expect(document).toContain("<w:document");
+    expect(document).toContain("<w:ruby>");
+    expect(document).toContain("<w:eastAsianLayout");
+  }));
 
 describe("mdiToDocx edge cases", () => {
-	it("keeps supported GFM list and inline content while table blocks are skipped", async () => {
-		const zip = await JSZip.loadAsync(await mdiToDocx(parse("- [x] done ~~old~~ {東京|とうきょう}\n\n| A | B |\n| - | - |\n| dropped | table |")));
-		const document = await zip.file("word/document.xml")!.async("string");
-		expect(document).toContain("done");
-		expect(document).toContain("<w:strike/>");
-		expect(document).toContain("<w:ruby>");
-		expect(document).not.toContain("dropped");
-	});
+  it("keeps supported GFM list and inline content while table blocks are skipped", async () => {
+    const zip = await JSZip.loadAsync(
+      await mdiToDocx(
+        parse(
+          "- [x] done ~~old~~ {東京|とうきょう}\n\n| A | B |\n| - | - |\n| dropped | table |"
+        )
+      )
+    );
+    const document = await zip.file("word/document.xml")!.async("string");
+    expect(document).toContain("done");
+    expect(document).toContain("<w:strike/>");
+    expect(document).toContain("<w:ruby>");
+    expect(document).not.toContain("dropped");
+  });
 
-	it("serializes split ruby readings as a dot-joined Word ruby reading", async () => {
-		const zip = await JSZip.loadAsync(await mdiToDocx(parse("{東京|とう.きょう}")));
-		const document = await zip.file("word/document.xml")!.async("string");
-		expect(document).toContain("<w:rt><w:r><w:t>とう.きょう</w:t>");
-	});
+  it("serializes split ruby readings as a dot-joined Word ruby reading", async () => {
+    const zip = await JSZip.loadAsync(
+      await mdiToDocx(parse("{東京|とう.きょう}"))
+    );
+    const document = await zip.file("word/document.xml")!.async("string");
+    expect(document).toContain("<w:rt><w:r><w:t>とう.きょう</w:t>");
+  });
 
-	it("generates ordinary DOCX content without ruby or tcy XML", async () => {
-		const zip = await JSZip.loadAsync(await mdiToDocx(parse("# Heading\n\nPlain text")));
-		const document = await zip.file("word/document.xml")!.async("string");
-		expect(document).toContain("Plain text");
-		expect(document).not.toContain("<w:ruby>");
-		expect(document).not.toContain("<w:eastAsianLayout");
-	});
+  it("generates ordinary DOCX content without ruby or tcy XML", async () => {
+    const zip = await JSZip.loadAsync(
+      await mdiToDocx(parse("# Heading\n\nPlain text"))
+    );
+    const document = await zip.file("word/document.xml")!.async("string");
+    expect(document).toContain("Plain text");
+    expect(document).not.toContain("<w:ruby>");
+    expect(document).not.toContain("<w:eastAsianLayout");
+  });
+
+  it("maps paper, typography, margins, full-width indentation, and page numbers to OOXML", async () => {
+    const zip = await JSZip.loadAsync(
+      await mdiToDocx(parse("paragraph"), {
+        typesetting: {
+          writingMode: "horizontal",
+          fontFamily: "Noto Serif JP",
+          textIndentEm: 2,
+          fullwidthSpaceIndent: true,
+        },
+        pagination: {
+          pageSize: "A4",
+          landscape: false,
+          charactersPerLine: 40,
+          linesPerPage: 30,
+          margins: { top: 10, bottom: 11, left: 12, right: 13 },
+          pageNumbers: {
+            enabled: true,
+            format: "fraction",
+            position: "top-right",
+          },
+        },
+      })
+    );
+    const document = await zip.file("word/document.xml")!.async("string");
+    const header = await zip.file("word/header1.xml")!.async("string");
+    expect(document).toContain('w:w="11906"'); // A4 width in twips
+    expect(document).toContain('w:top="567"');
+    expect(document).toContain('<w:t xml:space="preserve">　　</w:t>');
+    expect(document).toContain("paragraph");
+    expect(header).toContain(">PAGE<");
+    expect(header).toContain("NUMPAGES");
+  });
 });

--- a/packages/to-docx/src/index.ts
+++ b/packages/to-docx/src/index.ts
@@ -1,44 +1,257 @@
-import { Document, HeadingLevel, ImportedXmlComponent, Packer, PageBreak, PageTextDirectionType, Paragraph, TextRun } from "docx";
+import {
+  AlignmentType,
+  Document,
+  Footer,
+  HeadingLevel,
+  Header,
+  ImportedXmlComponent,
+  Packer,
+  PageBreak,
+  PageNumber,
+  PageTextDirectionType,
+  Paragraph,
+  TextRun,
+} from "docx";
 import type { Root, RootContent, PhrasingContent } from "mdast";
 import type {} from "mdast-util-mdi";
 import type {} from "@illusions-lab/mdi-remark";
+import {
+  PAGE_DIMENSIONS,
+  resolveExportProfile,
+  type ExportProfile,
+  type ResolvedExportProfile,
+} from "@illusions-lab/mdi-export-profile";
 
 export const MDI_SPEC_VERSION = "2.0";
 
-export async function mdiToDocx(tree: Root): Promise<Buffer> {
-	const children = tree.children.flatMap(block);
-	const vertical = tree.data?.frontmatter?.writingMode === "vertical";
-	const document = new Document({ sections: [{ children, properties: vertical ? { page: { textDirection: PageTextDirectionType.TOP_TO_BOTTOM_RIGHT_TO_LEFT } } : undefined }], title: tree.data?.frontmatter?.title, creator: tree.data?.frontmatter?.author });
-	return Packer.toBuffer(document);
+/** Creates a DOCX file using the same profile fields as PDF and EPUB exports. */
+export async function mdiToDocx(
+  tree: Root,
+  profile?: ExportProfile
+): Promise<Buffer> {
+  const options = resolveExportProfile(
+    profile ?? {
+      typesetting: {
+        writingMode:
+          tree.data?.frontmatter?.writingMode === "vertical"
+            ? "vertical"
+            : "horizontal",
+      },
+    }
+  );
+  const children = tree.children.flatMap((node) => block(node, options));
+  const dimensions = PAGE_DIMENSIONS[options.pagination.pageSize];
+  const widthMm = options.pagination.landscape
+    ? dimensions.height
+    : dimensions.width;
+  const heightMm = options.pagination.landscape
+    ? dimensions.width
+    : dimensions.height;
+  const primary =
+    options.typesetting.writingMode === "vertical"
+      ? heightMm -
+        options.pagination.margins.top -
+        options.pagination.margins.bottom
+      : widthMm -
+        options.pagination.margins.left -
+        options.pagination.margins.right;
+  const cross =
+    options.typesetting.writingMode === "vertical"
+      ? widthMm -
+        options.pagination.margins.left -
+        options.pagination.margins.right
+      : heightMm -
+        options.pagination.margins.top -
+        options.pagination.margins.bottom;
+  const fontSizeMm = primary / options.pagination.charactersPerLine;
+  const fontSizeHalfPoints = Math.round((fontSizeMm / 25.4) * 72 * 2);
+  const lineTwips = Math.round(
+    (cross / options.pagination.linesPerPage / 25.4) * 1440
+  );
+  const document = new Document({
+    title: options.metadata.title ?? tree.data?.frontmatter?.title,
+    creator: options.metadata.author ?? tree.data?.frontmatter?.author,
+    styles: {
+      default: {
+        document: {
+          run: {
+            font: options.typesetting.fontFamily,
+            size: fontSizeHalfPoints,
+          },
+          paragraph: { spacing: { line: lineTwips } },
+        },
+      },
+    },
+    sections: [
+      {
+        ...pageNumberSection(options, fontSizeHalfPoints),
+        properties: {
+          page: {
+            size: { width: mmToTwips(widthMm), height: mmToTwips(heightMm) },
+            margin: Object.fromEntries(
+              Object.entries(options.pagination.margins).map(([key, value]) => [
+                key,
+                mmToTwips(value),
+              ])
+            ),
+            ...(options.pagination.pageNumbers.enabled
+              ? { pageNumbers: { start: 1 } }
+              : {}),
+            ...(options.typesetting.writingMode === "vertical"
+              ? {
+                  textDirection:
+                    PageTextDirectionType.TOP_TO_BOTTOM_RIGHT_TO_LEFT,
+                }
+              : {}),
+          },
+        },
+        children,
+      },
+    ],
+  });
+  return Packer.toBuffer(document);
 }
 
-function block(node: RootContent): Paragraph[] {
-	if (node.type === "heading") return [new Paragraph({ heading: [HeadingLevel.HEADING_1, HeadingLevel.HEADING_2, HeadingLevel.HEADING_3, HeadingLevel.HEADING_4, HeadingLevel.HEADING_5, HeadingLevel.HEADING_6][node.depth - 1], children: inline(node.children) })];
-	if (node.type === "paragraph") return [new Paragraph({ children: inline(node.children) })];
-	if (node.type === "list") return node.children.flatMap(item => item.children.filter(n => n.type === "paragraph").map(n => new Paragraph({ children: inline(n.children), bullet: { level: 0 } })));
-	if (node.type === "mdiPagebreak") return [new Paragraph({ children: [new PageBreak()] })];
-	if (node.type === "mdiBlank") return [new Paragraph("")];
-	return [];
+function pageNumberSection(
+  options: ResolvedExportProfile,
+  size: number
+): { headers?: { default: Header }; footers?: { default: Footer } } {
+  const page = options.pagination.pageNumbers;
+  if (!page.enabled) return {};
+  const alignment = page.position.endsWith("left")
+    ? AlignmentType.LEFT
+    : page.position.endsWith("right")
+    ? AlignmentType.RIGHT
+    : AlignmentType.CENTER;
+  const current = new TextRun({ children: [PageNumber.CURRENT], size });
+  const runs =
+    page.format === "dash"
+      ? [
+          new TextRun({ text: "— ", size }),
+          current,
+          new TextRun({ text: " —", size }),
+        ]
+      : page.format === "fraction"
+      ? [
+          current,
+          new TextRun({ text: " / ", size }),
+          new TextRun({ children: [PageNumber.TOTAL_PAGES], size }),
+        ]
+      : [current];
+  const paragraph = new Paragraph({ alignment, children: runs });
+  return page.position.startsWith("top-")
+    ? { headers: { default: new Header({ children: [paragraph] }) } }
+    : { footers: { default: new Footer({ children: [paragraph] }) } };
+}
+
+function block(node: RootContent, options: ResolvedExportProfile): Paragraph[] {
+  if (node.type === "heading")
+    return [
+      new Paragraph({
+        heading: [
+          HeadingLevel.HEADING_1,
+          HeadingLevel.HEADING_2,
+          HeadingLevel.HEADING_3,
+          HeadingLevel.HEADING_4,
+          HeadingLevel.HEADING_5,
+          HeadingLevel.HEADING_6,
+        ][node.depth - 1],
+        children: inline(node.children),
+      }),
+    ];
+  if (node.type === "paragraph") return [paragraph(node.children, options)];
+  if (node.type === "list")
+    return node.children.flatMap((item) =>
+      item.children
+        .filter((n) => n.type === "paragraph")
+        .map(
+          (n) =>
+            new Paragraph({
+              children: inline(n.children),
+              bullet: { level: 0 },
+            })
+        )
+    );
+  if (node.type === "mdiPagebreak")
+    return [new Paragraph({ children: [new PageBreak()] })];
+  if (node.type === "mdiBlank") return [new Paragraph("")];
+  return [];
+}
+
+function paragraph(
+  nodes: PhrasingContent[],
+  options: ResolvedExportProfile
+): Paragraph {
+  const fontSizeMm = (() => {
+    const dimensions = PAGE_DIMENSIONS[options.pagination.pageSize];
+    const primary =
+      options.typesetting.writingMode === "vertical"
+        ? (options.pagination.landscape
+            ? dimensions.width
+            : dimensions.height) -
+          options.pagination.margins.top -
+          options.pagination.margins.bottom
+        : (options.pagination.landscape
+            ? dimensions.height
+            : dimensions.width) -
+          options.pagination.margins.left -
+          options.pagination.margins.right;
+    return primary / options.pagination.charactersPerLine;
+  })();
+  const prefix = options.typesetting.fullwidthSpaceIndent
+    ? [new TextRun("　".repeat(Math.round(options.typesetting.textIndentEm)))]
+    : [];
+  return new Paragraph({
+    indent: options.typesetting.fullwidthSpaceIndent
+      ? undefined
+      : {
+          firstLine: Math.round(
+            ((options.typesetting.textIndentEm * fontSizeMm) / 25.4) * 1440
+          ),
+        },
+    children: [...prefix, ...inline(nodes)],
+  });
 }
 
 function inline(nodes: PhrasingContent[]): TextRun[] {
-	return nodes.flatMap(node => {
-		if (node.type === "text") return [new TextRun(node.value)];
-		if (node.type === "break" || node.type === "mdiBreak") return [new TextRun({ break: 1 })];
-		if (node.type === "emphasis") return [new TextRun({ italics: true, children: inline(node.children) })];
-		if (node.type === "strong") return [new TextRun({ bold: true, children: inline(node.children) })];
-		if (node.type === "delete") return [new TextRun({ strike: true, children: inline(node.children) })];
-		if (node.type === "mdiRuby") return [rawRun(rubyXml(node.base, node.ruby))];
-		if (node.type === "mdiTcy") return [rawRun(`<w:r><w:rPr><w:eastAsianLayout w:combine="1" w:combineBrackets="none"/></w:rPr><w:t>${xml(node.value)}</w:t></w:r>`)];
-		if ("children" in node) return inline(node.children as PhrasingContent[]);
-		return [];
-	});
+  return nodes.flatMap((node) => {
+    if (node.type === "text") return [new TextRun(node.value)];
+    if (node.type === "break" || node.type === "mdiBreak")
+      return [new TextRun({ break: 1 })];
+    if (node.type === "emphasis")
+      return [new TextRun({ italics: true, children: inline(node.children) })];
+    if (node.type === "strong")
+      return [new TextRun({ bold: true, children: inline(node.children) })];
+    if (node.type === "delete")
+      return [new TextRun({ strike: true, children: inline(node.children) })];
+    if (node.type === "mdiRuby") return [rawRun(rubyXml(node.base, node.ruby))];
+    if (node.type === "mdiTcy")
+      return [
+        rawRun(
+          `<w:r><w:rPr><w:eastAsianLayout w:combine="1" w:combineBrackets="none"/></w:rPr><w:t>${xml(
+            node.value
+          )}</w:t></w:r>`
+        ),
+      ];
+    if ("children" in node) return inline(node.children as PhrasingContent[]);
+    return [];
+  });
 }
 
-// ECMA-376 w:ruby stores the reading in rubyText and the base in rubyBase.
-function rubyXml(base: string, reading: string | string[]): string {
-	const text = Array.isArray(reading) ? reading.join(".") : reading;
-	return `<w:ruby><w:rubyPr><w:rubyAlign w:val="center"/><w:hps w:val="12"/><w:hpsRaise w:val="18"/><w:hpsBaseText w:val="24"/></w:rubyPr><w:rt><w:r><w:t>${xml(text)}</w:t></w:r></w:rt><w:rubyBase><w:r><w:t>${xml(base)}</w:t></w:r></w:rubyBase></w:ruby>`;
+function mmToTwips(mm: number): number {
+  return Math.round((mm / 25.4) * 1440);
 }
-function rawRun(xmlString: string): TextRun { return ImportedXmlComponent.fromXmlString(xmlString) as unknown as TextRun; }
-function xml(value: string): string { return value.replaceAll("&", "&amp;").replaceAll("<", "&lt;"); }
+function rubyXml(base: string, reading: string | string[]): string {
+  const text = Array.isArray(reading) ? reading.join(".") : reading;
+  return `<w:ruby><w:rubyPr><w:rubyAlign w:val="center"/><w:hps w:val="12"/><w:hpsRaise w:val="18"/><w:hpsBaseText w:val="24"/></w:rubyPr><w:rt><w:r><w:t>${xml(
+    text
+  )}</w:t></w:r></w:rt><w:rubyBase><w:r><w:t>${xml(
+    base
+  )}</w:t></w:r></w:rubyBase></w:ruby>`;
+}
+function rawRun(xmlString: string): TextRun {
+  return ImportedXmlComponent.fromXmlString(xmlString) as unknown as TextRun;
+}
+function xml(value: string): string {
+  return value.replaceAll("&", "&amp;").replaceAll("<", "&lt;");
+}

--- a/packages/to-epub/package.json
+++ b/packages/to-epub/package.json
@@ -28,6 +28,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@illusions-lab/mdi-export-profile": "workspace:*",
     "@illusions-lab/mdi-to-hast": "workspace:*",
     "hast-util-to-html": "^9.0.0",
     "jszip": "^3.10.0",

--- a/packages/to-epub/src/index.test.ts
+++ b/packages/to-epub/src/index.test.ts
@@ -7,45 +7,120 @@ import type { Root } from "mdast";
 import { mdiToEpub } from "./index.js";
 
 function parse(source: string): Root {
-	const p = unified().use(remarkParse).use(remarkMdi);
-	return p.runSync(p.parse(source)) as Root;
+  const p = unified().use(remarkParse).use(remarkMdi);
+  return p.runSync(p.parse(source)) as Root;
 }
 
-describe("mdiToEpub", () => it("packages pagebreak segments as EPUB spine chapters", async () => {
-	const p = unified().use(remarkParse).use(remarkMdi);
-	const zip = await JSZip.loadAsync(await mdiToEpub(p.runSync(p.parse("---\ntitle: Test\n---\none\n\n[[pagebreak]]\n\ntwo")) as Root));
-	expect(await zip.file("mimetype")!.async("string")).toBe("application/epub+zip");
-	// JSZip drops `.options.compression` on reload; compressed === uncompressed
-	// size is the reliable signal that STORE (no compression) was used.
-	const mimetypeData = (zip.file("mimetype") as unknown as { _data: { compressedSize: number; uncompressedSize: number } })._data;
-	expect(mimetypeData.compressedSize).toBe(mimetypeData.uncompressedSize);
-	expect(zip.file("META-INF/container.xml")).toBeTruthy();
-	const opf = await zip.file("OEBPS/package.opf")!.async("string");
-	expect(opf).toContain('<itemref idref="chapter-1"/>');
-	expect(opf).toContain('<itemref idref="chapter-2"/>');
-	expect(Object.keys(zip.files).filter(name => name.startsWith("OEBPS/chapter-")).length).toBe(2);
-}));
+describe("mdiToEpub", () =>
+  it("packages pagebreak segments as EPUB spine chapters", async () => {
+    const p = unified().use(remarkParse).use(remarkMdi);
+    const zip = await JSZip.loadAsync(
+      await mdiToEpub(
+        p.runSync(
+          p.parse("---\ntitle: Test\n---\none\n\n[[pagebreak]]\n\ntwo")
+        ) as Root
+      )
+    );
+    expect(await zip.file("mimetype")!.async("string")).toBe(
+      "application/epub+zip"
+    );
+    // JSZip drops `.options.compression` on reload; compressed === uncompressed
+    // size is the reliable signal that STORE (no compression) was used.
+    const mimetypeData = (
+      zip.file("mimetype") as unknown as {
+        _data: { compressedSize: number; uncompressedSize: number };
+      }
+    )._data;
+    expect(mimetypeData.compressedSize).toBe(mimetypeData.uncompressedSize);
+    expect(zip.file("META-INF/container.xml")).toBeTruthy();
+    const opf = await zip.file("OEBPS/package.opf")!.async("string");
+    expect(opf).toContain('<itemref idref="chapter-1"/>');
+    expect(opf).toContain('<itemref idref="chapter-2"/>');
+    expect(
+      Object.keys(zip.files).filter((name) => name.startsWith("OEBPS/chapter-"))
+        .length
+    ).toBe(2);
+  }));
 
 describe("mdiToEpub edge cases", () => {
-	it("creates one chapter when no pagebreak is present", async () => {
-		const zip = await JSZip.loadAsync(await mdiToEpub(parse("one chapter")));
-		expect(Object.keys(zip.files).filter((name) => name.startsWith("OEBPS/chapter-")).sort()).toEqual(["OEBPS/chapter-1.xhtml"]);
-	});
+  it("creates one chapter when no pagebreak is present", async () => {
+    const zip = await JSZip.loadAsync(await mdiToEpub(parse("one chapter")));
+    expect(
+      Object.keys(zip.files)
+        .filter((name) => name.startsWith("OEBPS/chapter-"))
+        .sort()
+    ).toEqual(["OEBPS/chapter-1.xhtml"]);
+  });
 
-	it("splits chapters for left and right pagebreak variants", async () => {
-		const zip = await JSZip.loadAsync(await mdiToEpub(parse("one\n\n[[pagebreak:right]]\n\ntwo\n\n[[pagebreak:left]]\n\nthree")));
-		const opf = await zip.file("OEBPS/package.opf")!.async("string");
-		expect(Object.keys(zip.files).filter((name) => name.startsWith("OEBPS/chapter-")).length).toBe(3);
-		expect(opf).toContain('<itemref idref="chapter-3"/>');
-	});
+  it("splits chapters for left and right pagebreak variants", async () => {
+    const zip = await JSZip.loadAsync(
+      await mdiToEpub(
+        parse(
+          "one\n\n[[pagebreak:right]]\n\ntwo\n\n[[pagebreak:left]]\n\nthree"
+        )
+      )
+    );
+    const opf = await zip.file("OEBPS/package.opf")!.async("string");
+    expect(
+      Object.keys(zip.files).filter((name) => name.startsWith("OEBPS/chapter-"))
+        .length
+    ).toBe(3);
+    expect(opf).toContain('<itemref idref="chapter-3"/>');
+  });
 
-	it("XML-escapes metadata and uses fallbacks without front matter", async () => {
-		const escaped = await JSZip.loadAsync(await mdiToEpub(parse('---\ntitle: "A < B & \\"quoted\\""\nauthor: "Me & You"\n---\ntext')));
-		const opf = await escaped.file("OEBPS/package.opf")!.async("string");
-		expect(opf).toContain("<dc:title>A &lt; B &amp; &quot;quoted&quot;</dc:title>");
-		expect(opf).toContain("<dc:creator>Me &amp; You</dc:creator>");
+  it("XML-escapes metadata and uses fallbacks without front matter", async () => {
+    const escaped = await JSZip.loadAsync(
+      await mdiToEpub(
+        parse(
+          '---\ntitle: "A < B & \\"quoted\\""\nauthor: "Me & You"\n---\ntext'
+        )
+      )
+    );
+    const opf = await escaped.file("OEBPS/package.opf")!.async("string");
+    expect(opf).toContain(
+      "<dc:title>A &lt; B &amp; &quot;quoted&quot;</dc:title>"
+    );
+    expect(opf).toContain("<dc:creator>Me &amp; You</dc:creator>");
 
-		const fallback = await JSZip.loadAsync(await mdiToEpub(parse("text")));
-		expect(await fallback.file("OEBPS/package.opf")!.async("string")).toContain("<dc:title>Untitled</dc:title>");
-	});
+    const fallback = await JSZip.loadAsync(await mdiToEpub(parse("text")));
+    expect(await fallback.file("OEBPS/package.opf")!.async("string")).toContain(
+      "<dc:title>Untitled</dc:title>"
+    );
+  });
+
+  it("writes cover, profile metadata, vertical progression, styles, and heading chapters", async () => {
+    const zip = await JSZip.loadAsync(
+      await mdiToEpub(parse("# One\n\ntext\n\n# Two\n\nmore"), {
+        profile: {
+          metadata: {
+            title: "Book",
+            author: "Writer",
+            publisher: "Press",
+            identifier: "isbn:1",
+          },
+          typesetting: {
+            writingMode: "vertical",
+            fontFamily: "Noto Serif JP",
+            textIndentEm: 2,
+          },
+          epub: { chapterSplitLevel: "h1" },
+        },
+        cover: {
+          data: new Uint8Array([137, 80, 78, 71]),
+          mediaType: "image/png",
+        },
+      })
+    );
+    const opf = await zip.file("OEBPS/package.opf")!.async("string");
+    const css = await zip.file("OEBPS/style.css")!.async("string");
+    expect(zip.file("OEBPS/cover.png")).toBeTruthy();
+    expect(opf).toContain("<dc:publisher>Press</dc:publisher>");
+    expect(opf).toContain('page-progression-direction="rtl"');
+    expect(
+      Object.keys(zip.files).filter((name) => name.startsWith("OEBPS/chapter-"))
+        .length
+    ).toBe(2);
+    expect(css).toContain("font-family:Noto Serif JP");
+    expect(css).toContain("text-indent:2em");
+  });
 });

--- a/packages/to-epub/src/index.ts
+++ b/packages/to-epub/src/index.ts
@@ -3,47 +3,209 @@ import { toHtml } from "hast-util-to-html";
 import type { Root } from "mdast";
 import type { RootContent as HastRootContent } from "hast";
 import { MDI_STYLESHEET, mdiToHast } from "@illusions-lab/mdi-to-hast";
+import {
+  resolveExportProfile,
+  type ExportProfile,
+} from "@illusions-lab/mdi-export-profile";
 
 export const MDI_SPEC_VERSION = "2.0";
 
-export async function mdiToEpub(tree: Root): Promise<Buffer> {
-	const zip = new JSZip();
-	const { hast, frontmatter } = mdiToHast(tree);
-	const chapters = splitChapters(hast.children);
-	const title = frontmatter?.title ?? "Untitled";
-	const lang = frontmatter?.lang ?? "ja";
-	const id = "urn:uuid:mdi-document";
-	zip.file("mimetype", "application/epub+zip", { compression: "STORE" });
-	zip.file("META-INF/container.xml", '<?xml version="1.0"?><container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container"><rootfiles><rootfile full-path="OEBPS/package.opf" media-type="application/oebps-package+xml"/></rootfiles></container>');
-	zip.file("OEBPS/style.css", MDI_STYLESHEET);
-	zip.file("OEBPS/nav.xhtml", xhtml("Contents", lang, `<nav epub:type="toc" id="toc"><ol>${chapters.map((_, i) => `<li><a href="chapter-${i + 1}.xhtml">Chapter ${i + 1}</a></li>`).join("")}</ol></nav>`));
-	chapters.forEach((children, index) => zip.file(`OEBPS/chapter-${index + 1}.xhtml`, xhtml(title, lang, toHtml({ type: "root", children }))));
-	const metadata = `<dc:title>${xml(title)}</dc:title>${frontmatter?.author ? `<dc:creator>${xml(frontmatter.author)}</dc:creator>` : ""}<dc:language>${xml(lang)}</dc:language>${frontmatter?.date ? `<dc:date>${xml(String(frontmatter.date))}</dc:date>` : ""}`;
-	const manifest = `<item id="nav" href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/><item id="css" href="style.css" media-type="text/css"/>${chapters.map((_, i) => `<item id="chapter-${i + 1}" href="chapter-${i + 1}.xhtml" media-type="application/xhtml+xml"/>`).join("")}`;
-	zip.file("OEBPS/package.opf", `<?xml version="1.0" encoding="UTF-8"?><package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="book-id"><metadata xmlns:dc="http://purl.org/dc/elements/1.1/"><dc:identifier id="book-id">${id}</dc:identifier>${metadata}</metadata><manifest>${manifest}</manifest><spine>${chapters.map((_, i) => `<itemref idref="chapter-${i + 1}"/>`).join("")}</spine></package>`);
-	return zip.generateAsync({ type: "nodebuffer", compression: "DEFLATE" });
+export interface EpubCover {
+  data: Uint8Array;
+  mediaType: "image/jpeg" | "image/png";
+}
+export interface EpubExportOptions {
+  profile?: ExportProfile;
+  cover?: EpubCover;
 }
 
-function splitChapters(children: HastRootContent[]): HastRootContent[][] {
-	const chapters: HastRootContent[][] = [[]];
-	for (const child of children) {
-		if (isPagebreak(child)) chapters.push([]);
-		else chapters.at(-1)!.push(child);
-	}
-	return chapters;
+/** Builds a reflowable EPUB 3 with profile-driven metadata, cover, chapters and typography. */
+export async function mdiToEpub(
+  tree: Root,
+  options: EpubExportOptions = {}
+): Promise<Buffer> {
+  const profile = resolveExportProfile(
+    options.profile ?? {
+      typesetting: {
+        writingMode:
+          tree.data?.frontmatter?.writingMode === "vertical"
+            ? "vertical"
+            : "horizontal",
+      },
+    }
+  );
+  const zip = new JSZip();
+  const { hast, frontmatter } = mdiToHast(tree);
+  const title = profile.metadata.title ?? frontmatter?.title ?? "Untitled";
+  const author = profile.metadata.author ?? frontmatter?.author;
+  const lang = profile.metadata.language ?? frontmatter?.lang ?? "ja";
+  const identifier = profile.metadata.identifier ?? crypto.randomUUID();
+  const chapters = splitChapters(hast.children, profile.epub.chapterSplitLevel);
+  const cover = options.cover;
+  zip.file("mimetype", "application/epub+zip", { compression: "STORE" });
+  zip.file(
+    "META-INF/container.xml",
+    '<?xml version="1.0"?><container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container"><rootfiles><rootfile full-path="OEBPS/package.opf" media-type="application/oebps-package+xml"/></rootfiles></container>'
+  );
+  zip.file("OEBPS/style.css", epubStyles(profile));
+  zip.file(
+    "OEBPS/nav.xhtml",
+    xhtml(
+      "Contents",
+      lang,
+      `<nav epub:type="toc" id="toc"><ol>${chapters
+        .map(
+          (chapter, i) =>
+            `<li><a href="chapter-${i + 1}.xhtml">${xml(
+              chapter.title || `Chapter ${i + 1}`
+            )}</a></li>`
+        )
+        .join("")}</ol></nav>`
+    )
+  );
+  chapters.forEach((chapter, index) =>
+    zip.file(
+      `OEBPS/chapter-${index + 1}.xhtml`,
+      xhtml(
+        chapter.title || title,
+        lang,
+        toHtml({ type: "root", children: chapter.children })
+      )
+    )
+  );
+  if (cover) {
+    zip.file(
+      `OEBPS/cover.${cover.mediaType === "image/png" ? "png" : "jpg"}`,
+      cover.data
+    );
+    zip.file(
+      "OEBPS/cover.xhtml",
+      xhtml(
+        title,
+        lang,
+        `<img src="cover.${
+          cover.mediaType === "image/png" ? "png" : "jpg"
+        }" alt="${xml(title)}"/>`
+      )
+    );
+  }
+  const metadata = `<dc:identifier id="book-id">${xml(
+    identifier
+  )}</dc:identifier><dc:title>${xml(title)}</dc:title><dc:language>${xml(
+    lang
+  )}</dc:language>${author ? `<dc:creator>${xml(author)}</dc:creator>` : ""}${
+    profile.metadata.publisher
+      ? `<dc:publisher>${xml(profile.metadata.publisher)}</dc:publisher>`
+      : ""
+  }${
+    profile.metadata.date ?? frontmatter?.date
+      ? `<dc:date>${xml(
+          String(profile.metadata.date ?? frontmatter?.date)
+        )}</dc:date>`
+      : ""
+  }`;
+  const coverManifest = cover
+    ? `<item id="cover-image" href="cover.${
+        cover.mediaType === "image/png" ? "png" : "jpg"
+      }" media-type="${
+        cover.mediaType
+      }" properties="cover-image"/><item id="cover" href="cover.xhtml" media-type="application/xhtml+xml"/>`
+    : "";
+  const manifest = `<item id="nav" href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/><item id="css" href="style.css" media-type="text/css"/>${coverManifest}${chapters
+    .map(
+      (_, i) =>
+        `<item id="chapter-${i + 1}" href="chapter-${
+          i + 1
+        }.xhtml" media-type="application/xhtml+xml"/>`
+    )
+    .join("")}`;
+  const spine = `${cover ? '<itemref idref="cover"/>' : ""}${chapters
+    .map((_, i) => `<itemref idref="chapter-${i + 1}"/>`)
+    .join("")}`;
+  zip.file(
+    "OEBPS/package.opf",
+    `<?xml version="1.0" encoding="UTF-8"?><package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="book-id"><metadata xmlns:dc="http://purl.org/dc/elements/1.1/">${metadata}</metadata><manifest>${manifest}</manifest><spine${
+      profile.typesetting.writingMode === "vertical"
+        ? ' page-progression-direction="rtl"'
+        : ""
+    }>${spine}</spine></package>`
+  );
+  return zip.generateAsync({ type: "nodebuffer", compression: "DEFLATE" });
 }
 
-// mdiToHast() has already turned mdast `mdiPagebreak` nodes into
-// `<div class="mdi-pagebreak">` hast elements by the time we see this tree.
+interface Chapter {
+  title: string;
+  children: HastRootContent[];
+}
+function splitChapters(
+  children: HastRootContent[],
+  level: "h1" | "h2" | "h3" | "none"
+): Chapter[] {
+  if (level === "none")
+    return [
+      { title: "", children: children.filter((child) => !isPagebreak(child)) },
+    ];
+  const chapters: Chapter[] = [{ title: "", children: [] }];
+  const splitTag = level;
+  for (const child of children) {
+    if (isPagebreak(child)) {
+      if (chapters.at(-1)!.children.length)
+        chapters.push({ title: "", children: [] });
+      continue;
+    }
+    if (
+      child.type === "element" &&
+      child.tagName === splitTag &&
+      chapters.at(-1)!.children.length
+    )
+      chapters.push({ title: textContent(child), children: [child] });
+    else {
+      if (child.type === "element" && child.tagName === splitTag)
+        chapters.at(-1)!.title = textContent(child);
+      chapters.at(-1)!.children.push(child);
+    }
+  }
+  return chapters.filter((chapter) => chapter.children.length > 0);
+}
 function isPagebreak(node: HastRootContent): boolean {
-	return (
-		node.type === "element" &&
-		node.tagName === "div" &&
-		Array.isArray(node.properties?.className) &&
-		node.properties.className.includes("mdi-pagebreak")
-	);
+  return (
+    node.type === "element" &&
+    node.tagName === "div" &&
+    Array.isArray(node.properties?.className) &&
+    node.properties.className.includes("mdi-pagebreak")
+  );
+}
+function textContent(node: HastRootContent): string {
+  return node.type === "text"
+    ? node.value
+    : node.type === "element"
+    ? node.children.map(textContent).join("")
+    : "";
+}
+function epubStyles(profile: ReturnType<typeof resolveExportProfile>): string {
+  const mode =
+    profile.typesetting.writingMode === "vertical"
+      ? "writing-mode:vertical-rl;-webkit-writing-mode:vertical-rl;text-orientation:mixed;"
+      : "";
+  return `body{font-family:${css(
+    profile.typesetting.fontFamily
+  )};${mode}line-height:1.8;margin:1em}p{text-indent:${
+    profile.typesetting.textIndentEm
+  }em;margin:.3em 0}${MDI_STYLESHEET}`;
 }
 function xhtml(title: string, lang: string, body: string): string {
-	return `<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="${xml(lang)}" lang="${xml(lang)}"><head><title>${xml(title)}</title><link rel="stylesheet" type="text/css" href="style.css"/></head><body>${body}</body></html>`;
+  return `<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="${xml(
+    lang
+  )}" lang="${xml(lang)}"><head><meta charset="UTF-8"/><title>${xml(
+    title
+  )}</title><link rel="stylesheet" type="text/css" href="style.css"/></head><body>${body}</body></html>`;
 }
-function xml(value: string): string { return value.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll('"', "&quot;"); }
+function xml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll('"', "&quot;");
+}
+function css(value: string): string {
+  return value.replace(/[{}<>;]/g, "") || "serif";
+}

--- a/packages/to-pdf/package.json
+++ b/packages/to-pdf/package.json
@@ -28,6 +28,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@illusions-lab/mdi-export-profile": "workspace:*",
     "@illusions-lab/mdi-to-html": "workspace:*",
     "playwright": "^1.48.0",
     "@types/mdast": "^4.0.0"

--- a/packages/to-pdf/src/index.test.ts
+++ b/packages/to-pdf/src/index.test.ts
@@ -3,25 +3,65 @@ import { unified } from "unified";
 import remarkParse from "remark-parse";
 import remarkMdi from "@illusions-lab/mdi-remark";
 import type { Root } from "mdast";
-import { mdiToPdf } from "./index.js";
+import { applyPdfProfile, mdiToPdf } from "./index.js";
 
-describe("mdiToPdf", () => it("generates a browser-rendered PDF", async () => {
-	const p = unified().use(remarkParse).use(remarkMdi);
-	const tree = p.runSync(p.parse("---\nwriting-mode: vertical\n---\n{東京|とうきょう}")) as Root;
-	const pdf = await mdiToPdf(tree);
-	expect(pdf.subarray(0, 5).toString()).toBe("%PDF-");
-	expect(pdf.length).toBeGreaterThan(500);
-}, 30_000));
+describe("mdiToPdf", () =>
+  it("generates a browser-rendered PDF", async () => {
+    const p = unified().use(remarkParse).use(remarkMdi);
+    const tree = p.runSync(
+      p.parse("---\nwriting-mode: vertical\n---\n{東京|とうきょう}")
+    ) as Root;
+    const pdf = await mdiToPdf(tree);
+    expect(pdf.subarray(0, 5).toString()).toBe("%PDF-");
+    expect(pdf.length).toBeGreaterThan(500);
+  }, 30_000));
 
 describe("mdiToPdf edge cases", () => {
-	it("renders plain Markdown and can be called repeatedly", async () => {
-		const p = unified().use(remarkParse).use(remarkMdi);
-		const tree = p.runSync(p.parse("# Plain heading\n\nA regular paragraph.")) as Root;
-		const [first, second] = await Promise.all([mdiToPdf(tree), mdiToPdf(tree)]);
+  it("renders plain Markdown and can be called repeatedly", async () => {
+    const p = unified().use(remarkParse).use(remarkMdi);
+    const tree = p.runSync(
+      p.parse("# Plain heading\n\nA regular paragraph.")
+    ) as Root;
+    const [first, second] = await Promise.all([mdiToPdf(tree), mdiToPdf(tree)]);
 
-		for (const pdf of [first, second]) {
-			expect(pdf.subarray(0, 5).toString()).toBe("%PDF-");
-			expect(pdf.length).toBeGreaterThan(500);
-		}
-	}, 30_000);
+    for (const pdf of [first, second]) {
+      expect(pdf.subarray(0, 5).toString()).toBe("%PDF-");
+      expect(pdf.length).toBeGreaterThan(500);
+    }
+  }, 30_000);
+});
+
+describe("PDF export profile", () => {
+  it("applies geometry, composition, full-width indentation, and page options", () => {
+    const html = applyPdfProfile(
+      "<html><head></head><body><p>本文</p></body></html>",
+      {
+        metadata: {},
+        typesetting: {
+          writingMode: "vertical",
+          fontFamily: "Noto Serif JP",
+          textIndentEm: 2,
+          fullwidthSpaceIndent: true,
+        },
+        pagination: {
+          pageSize: "A4",
+          landscape: false,
+          charactersPerLine: 40,
+          linesPerPage: 30,
+          margins: { top: 34, bottom: 28, left: 28, right: 45 },
+          pageNumbers: {
+            enabled: true,
+            format: "fraction",
+            position: "bottom-center",
+          },
+        },
+        epub: { chapterSplitLevel: "h1" },
+        text: { fullwidthSpaceIndent: false, indentCount: 1 },
+      }
+    );
+    expect(html).toContain("@page{size:210mm 297mm");
+    expect(html).toContain("writing-mode:vertical-rl");
+    expect(html).toContain("font-family:Noto Serif JP");
+    expect(html).toContain("<p>　　本文");
+  });
 });

--- a/packages/to-pdf/src/index.ts
+++ b/packages/to-pdf/src/index.ts
@@ -1,16 +1,122 @@
 import { chromium } from "playwright";
 import type { Root } from "mdast";
 import { mdiToHtml } from "@illusions-lab/mdi-to-html";
+import {
+  PAGE_DIMENSIONS,
+  resolveExportProfile,
+  type ExportProfile,
+  type ResolvedExportProfile,
+} from "@illusions-lab/mdi-export-profile";
 
 export const MDI_SPEC_VERSION = "2.0";
 
-export async function mdiToPdf(tree: Root): Promise<Buffer> {
-	const browser = await chromium.launch({ headless: true });
-	try {
-		const page = await browser.newPage();
-		await page.setContent(mdiToHtml(tree));
-		return Buffer.from(await page.pdf());
-	} finally {
-		await browser.close();
-	}
+/** Renders an MDI document with the complete Illusions PDF export profile. */
+export async function mdiToPdf(
+  tree: Root,
+  profile?: ExportProfile
+): Promise<Buffer> {
+  const sourceWritingMode = (
+    tree.data as { frontmatter?: { writingMode?: unknown } } | undefined
+  )?.frontmatter?.writingMode;
+  const resolved = resolveExportProfile(
+    profile ?? {
+      typesetting: {
+        writingMode:
+          sourceWritingMode === "vertical" ? "vertical" : "horizontal",
+      },
+    }
+  );
+  const browser = await chromium.launch({ headless: true });
+  try {
+    const page = await browser.newPage();
+    await page.setContent(applyPdfProfile(mdiToHtml(tree), resolved));
+    const dimensions = PAGE_DIMENSIONS[resolved.pagination.pageSize];
+    const width = resolved.pagination.landscape
+      ? dimensions.height
+      : dimensions.width;
+    const height = resolved.pagination.landscape
+      ? dimensions.width
+      : dimensions.height;
+    const pageNumber = resolved.pagination.pageNumbers;
+    return Buffer.from(
+      await page.pdf({
+        width: `${width}mm`,
+        height: `${height}mm`,
+        printBackground: true,
+        margin: { top: "0mm", right: "0mm", bottom: "0mm", left: "0mm" },
+        displayHeaderFooter: pageNumber.enabled,
+        headerTemplate:
+          pageNumber.enabled && pageNumber.position.startsWith("top-")
+            ? pageNumberTemplate(pageNumber.format, pageNumber.position)
+            : "<span></span>",
+        footerTemplate:
+          pageNumber.enabled && pageNumber.position.startsWith("bottom-")
+            ? pageNumberTemplate(pageNumber.format, pageNumber.position)
+            : "<span></span>",
+      })
+    );
+  } finally {
+    await browser.close();
+  }
+}
+
+/** Converts page geometry and Japanese composition settings into isolated print CSS. */
+export function applyPdfProfile(
+  html: string,
+  profile: ResolvedExportProfile
+): string {
+  const { pagination, typesetting } = profile;
+  const dimensions = PAGE_DIMENSIONS[pagination.pageSize];
+  const width = pagination.landscape ? dimensions.height : dimensions.width;
+  const height = pagination.landscape ? dimensions.width : dimensions.height;
+  const primary =
+    typesetting.writingMode === "vertical"
+      ? height - pagination.margins.top - pagination.margins.bottom
+      : width - pagination.margins.left - pagination.margins.right;
+  const cross =
+    typesetting.writingMode === "vertical"
+      ? width - pagination.margins.left - pagination.margins.right
+      : height - pagination.margins.top - pagination.margins.bottom;
+  const fontSize = primary / pagination.charactersPerLine;
+  const lineHeight = cross / pagination.linesPerPage / fontSize;
+  const fullwidth = typesetting.fullwidthSpaceIndent
+    ? "　".repeat(Math.round(typesetting.textIndentEm))
+    : "";
+  const css = `<style id="mdi-export-profile">@page{size:${width}mm ${height}mm;margin:0}html,body{width:${width}mm;height:${height}mm;margin:0;box-sizing:border-box}body{padding:${
+    pagination.margins.top
+  }mm ${pagination.margins.right}mm ${pagination.margins.bottom}mm ${
+    pagination.margins.left
+  }mm;font-family:${cssValue(
+    typesetting.fontFamily
+  )};font-size:${fontSize}mm;line-height:${lineHeight};writing-mode:${
+    typesetting.writingMode === "vertical" ? "vertical-rl" : "horizontal-tb"
+  };text-orientation:mixed}p{text-indent:${
+    typesetting.fullwidthSpaceIndent ? "0" : `${typesetting.textIndentEm}em`
+  }}</style>`;
+  return html
+    .replace("</head>", `${css}</head>`)
+    .replace(/(<p(?:\s[^>]*)?>)(?!\s*<\/p>)/g, `$1${fullwidth}`);
+}
+
+function pageNumberTemplate(
+  format: ResolvedExportProfile["pagination"]["pageNumbers"]["format"],
+  position: ResolvedExportProfile["pagination"]["pageNumbers"]["position"]
+): string {
+  const align = position.endsWith("left")
+    ? "left"
+    : position.endsWith("right")
+    ? "right"
+    : "center";
+  const page = '<span class="pageNumber"></span>';
+  const value =
+    format === "dash"
+      ? `— ${page} —`
+      : format === "fraction"
+      ? `${page} / <span class="totalPages"></span>`
+      : page;
+  return `<div style="width:100%;font-size:8pt;text-align:${align};padding:0 8mm">${value}</div>`;
+}
+
+function cssValue(value: string): string {
+  return value.replace(/[{}<>;]/g, "") || "serif";
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
 
   packages/cli:
     dependencies:
+      '@illusions-lab/mdi-export-profile':
+        specifier: workspace:*
+        version: link:../export-profile
       '@illusions-lab/mdi-remark':
         specifier: workspace:*
         version: link:../remark
@@ -71,6 +74,9 @@ importers:
       '@types/mdast':
         specifier: ^4.0.0
         version: 4.0.4
+      mdast-util-mdi:
+        specifier: workspace:*
+        version: link:../mdast-util-mdi
       remark-parse:
         specifier: ^11.0.0
         version: 11.0.0
@@ -90,6 +96,18 @@ importers:
       vitest:
         specifier: ^2.1.0
         version: 2.1.9(@types/node@20.19.43)(lightningcss@1.32.0)
+
+  packages/export-profile:
+    devDependencies:
+      tsup:
+        specifier: ^8.3.0
+        version: 8.5.1(postcss@8.5.19)(typescript@5.9.3)(yaml@2.9.0)
+      typescript:
+        specifier: ^5.6.0
+        version: 5.9.3
+      vitest:
+        specifier: ^2.1.0
+        version: 2.1.9(@types/node@25.9.5)(lightningcss@1.32.0)
 
   packages/mdast-util-mdi:
     dependencies:
@@ -183,6 +201,9 @@ importers:
 
   packages/to-docx:
     dependencies:
+      '@illusions-lab/mdi-export-profile':
+        specifier: workspace:*
+        version: link:../export-profile
       '@types/mdast':
         specifier: ^4.0.0
         version: 4.0.4
@@ -220,6 +241,9 @@ importers:
 
   packages/to-epub:
     dependencies:
+      '@illusions-lab/mdi-export-profile':
+        specifier: workspace:*
+        version: link:../export-profile
       '@illusions-lab/mdi-to-hast':
         specifier: workspace:*
         version: link:../to-hast
@@ -328,6 +352,9 @@ importers:
 
   packages/to-pdf:
     dependencies:
+      '@illusions-lab/mdi-export-profile':
+        specifier: workspace:*
+        version: link:../export-profile
       '@illusions-lab/mdi-to-html':
         specifier: workspace:*
         version: link:../to-html


### PR DESCRIPTION
## What changed

- Adds `@illusions-lab/mdi-export-profile`, a validated common profile for all Illusions export settings.
- Applies profiles to PDF, DOCX, EPUB, and TXT/TXT-ruby CLI output, including layout, pagination, metadata, EPUB covers, chapter splitting, and text indentation.
- Adds English, Japanese, and Traditional Chinese documentation plus API reference generation.

## Why

Illusions can now pass one portable configuration object or JSON file to MDI exports instead of reimplementing format-specific settings.

## Validation

- `pnpm test`
- `pnpm build`
- `pnpm typecheck`
- `git diff --check`