### PR TITLE
Allow manual release recovery

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,9 @@ name: Release
 on:
   push:
     branches: [main]
+  # Keeps the normal main-push release path intact while allowing a logged,
+  # idempotent recovery run if GitHub ever drops a push event.
+  workflow_dispatch:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 


### PR DESCRIPTION
Adds an idempotent manual-dispatch path to the existing release workflow.

Normal behaviour is unchanged: every push to `main` releases automatically. This provides a traceable recovery option if GitHub fails to enqueue a push-triggered release run.