### PR TITLE
Add package provenance metadata

### DIFF
--- a/packages/export-profile/package.json
+++ b/packages/export-profile/package.json
@@ -3,6 +3,10 @@
   "version": "2.0.0",
   "description": "Shared export profile schema for MDI converters",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/illusions-lab/mdi-js"
+  },
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Adds the repository URL required by npm provenance verification for `@illusions-lab/mdi-export-profile`.

The profile package was the only unpublished package in the release run; retrying the idempotent release workflow after this merge will publish it.