### PR TITLE
Suppress DOCX CLI warning

### DIFF
--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -139,4 +139,25 @@ describe("CLI command output", () => {
       await rm(directory, { recursive: true, force: true });
     }
   });
+
+  it("writes DOCX without emitting a Node web-storage warning", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "mdi-cli-docx-command-"));
+    try {
+      const input = join(directory, "book.mdi");
+      const output = join(directory, "book.docx");
+      await writeFile(input, "# Book");
+      const { stdout, stderr } = await run(process.execPath, [
+        resolve("dist/cli.js"),
+        "build",
+        input,
+        "--to",
+        "docx",
+      ]);
+      expect(stderr).toBe("");
+      expect(stdout).toBe(`Written ${output}\n`);
+      expect((await readFile(output)).subarray(0, 2).toString()).toBe("PK");
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
 });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -50,9 +50,7 @@ export async function build(
           cover: await loadCover(resolvedOptions.profile),
         })
       : format === "docx"
-      ? await (
-          await import("@illusions-lab/mdi-to-docx")
-        ).mdiToDocx(tree, resolvedOptions.profile)
+      ? await exportDocx(tree, resolvedOptions.profile)
       : mdiToText(tree, resolvedOptions.profile, format === "txt-ruby");
   const extension = format === "txt-ruby" ? "txt" : format;
   const destination =
@@ -138,6 +136,23 @@ async function loadCover(
     data: await readFile(coverPath),
     mediaType: extension === ".png" ? "image/png" : "image/jpeg",
   };
+}
+
+/**
+ * Node 25+ exposes `localStorage` behind an experimental getter. `docx` checks
+ * that global while loading an optional browser polyfill, which otherwise emits
+ * a warning for every CLI conversion. The CLI does not use web storage.
+ */
+async function exportDocx(
+  tree: Root,
+  profile?: ExportProfile
+): Promise<Buffer> {
+  Object.defineProperty(globalThis, "localStorage", {
+    value: undefined,
+    configurable: true,
+    writable: true,
+  });
+  return (await import("@illusions-lab/mdi-to-docx")).mdiToDocx(tree, profile);
 }
 
 function textBlock(


### PR DESCRIPTION
## What changed
- avoid Node 25 experimental localStorage warning when the CLI loads `docx`
- add a subprocess regression test for clean DOCX CLI output

## Validation
- `pnpm --filter @illusions-lab/mdi-cli build`
- `pnpm --filter @illusions-lab/mdi-cli test`
- `pnpm --filter @illusions-lab/mdi-cli typecheck`
- manual `node --trace-warnings ... --to docx`