### PR TITLE
Fix EPUB XHTML footnote attributes

### DIFF
--- a/packages/to-epub/src/index.test.ts
+++ b/packages/to-epub/src/index.test.ts
@@ -95,6 +95,18 @@ describe("mdiToEpub edge cases", () => {
     );
   });
 
+  it("writes XHTML-safe values for footnote data attributes", async () => {
+    const zip = await JSZip.loadAsync(
+      await mdiToEpub(parse("A note[^1].\n\n[^1]: note text"))
+    );
+    const chapter = await zip.file("OEBPS/chapter-1.xhtml")!.async("string");
+
+    expect(chapter).toContain('data-footnote-ref=""');
+    expect(chapter).toContain('data-footnotes=""');
+    expect(chapter).toContain('data-footnote-backref=""');
+    expect(chapter).not.toMatch(/\sdata-footnote-ref(?=\s|>)/);
+  });
+
   it("writes cover, profile metadata, vertical progression, styles, and heading chapters", async () => {
     const zip = await JSZip.loadAsync(
       await mdiToEpub(parse("# One\n\ntext\n\n# Two\n\nmore"), {

--- a/packages/to-epub/src/index.ts
+++ b/packages/to-epub/src/index.ts
@@ -64,10 +64,7 @@ export async function mdiToEpub(
       xhtml(
         chapter.title || title,
         lang,
-        toHtml(
-          { type: "root", children: chapter.children },
-          { closeSelfClosing: true, tightSelfClosing: true }
-        )
+        xhtmlBody(chapter.children)
       )
     )
   );
@@ -198,6 +195,34 @@ function xhtml(title: string, lang: string, body: string): string {
     title
   )}</title><link rel="stylesheet" type="text/css" href="style.css"/></head><body>${body}</body></html>`;
 }
+
+/**
+ * `hast-util-to-html` deliberately emits HTML's compact boolean-attribute
+ * notation (for example, `data-footnote-ref`).  EPUB content documents are
+ * XHTML, where every attribute needs an explicit value.  Normalise these in
+ * the HAST tree before serialization so ordinary attribute values, including
+ * aria-label values containing spaces, remain intact.
+ */
+function xhtmlBody(children: HastRootContent[]): string {
+  normalizeXhtmlDataAttributes(children);
+  return toHtml(
+    { type: "root", children },
+    { closeSelfClosing: true, tightSelfClosing: true }
+  );
+}
+
+function normalizeXhtmlDataAttributes(nodes: HastRootContent[]): void {
+  for (const node of nodes) {
+    if (node.type !== "element") continue;
+    for (const [name, value] of Object.entries(node.properties ?? {})) {
+      if (name.startsWith("data") && value === true) {
+        node.properties![name] = "";
+      }
+    }
+    normalizeXhtmlDataAttributes(node.children);
+  }
+}
+
 function xml(value: string): string {
   return value
     .replaceAll("&", "&amp;")


### PR DESCRIPTION
Fixes EPUB output that uses HTML boolean data attributes for GFM footnotes. EPUB content is XHTML, so the affected attributes now have explicit empty values. Adds a regression test and validates the generated kitchen-sink EPUB as XML.