### PR TITLE
Document TXT CLI output formats

### DIFF
--- a/docs/src/content/docs/guides/getting-started.md
+++ b/docs/src/content/docs/guides/getting-started.md
@@ -1,6 +1,6 @@
 ---
 title: Getting Started
-description: Install mdi-js, parse a .mdi file, and convert it to HTML, PDF, EPUB, or DOCX.
+description: Install mdi-js, parse a .mdi file, and convert it to HTML, PDF, EPUB, DOCX, or plain text.
 ---
 
 mdi-js is a family of packages for **illusion Markdown (MDI)** — a Markdown
@@ -21,10 +21,15 @@ mdi build novel.mdi --to html
 mdi build novel.mdi --to pdf
 mdi build novel.mdi --to epub -o dist/novel.epub
 mdi build novel.mdi --to docx
+mdi build novel.mdi --to txt
+mdi build novel.mdi --to txt-ruby
 ```
 
 Without `-o`, the output file is written next to the input with the format's
 extension (`novel.mdi` → `novel.pdf`).
+
+`txt` writes basic plain text; `txt-ruby` keeps ruby as `{base|reading}`. They
+are not yet dedicated exporters for Narou or Aozora Bunko formats.
 
 :::note
 PDF output renders through a headless Chromium via

--- a/docs/src/content/docs/ja/guides/getting-started.md
+++ b/docs/src/content/docs/ja/guides/getting-started.md
@@ -21,10 +21,15 @@ mdi build novel.mdi --to html
 mdi build novel.mdi --to pdf
 mdi build novel.mdi --to epub -o dist/novel.epub
 mdi build novel.mdi --to docx
+mdi build novel.mdi --to txt
+mdi build novel.mdi --to txt-ruby
 ```
 
 `-o` を省略すると、入力ファイルと同じ場所にフォーマットの拡張子で
 出力されます（`novel.mdi` → `novel.pdf`）。
+
+`txt` は基本的なプレーンテキスト、`txt-ruby` はルビを `{base|reading}` の形で
+残す出力です。小説家になろう／青空文庫向けの専用形式は、まだ提供していません。
 
 :::note
 PDF 出力は [Playwright](https://playwright.dev) 経由のヘッドレス Chromium

--- a/docs/src/content/docs/zh-tw/guides/getting-started.md
+++ b/docs/src/content/docs/zh-tw/guides/getting-started.md
@@ -20,10 +20,15 @@ mdi build novel.mdi --to html
 mdi build novel.mdi --to pdf
 mdi build novel.mdi --to epub -o dist/novel.epub
 mdi build novel.mdi --to docx
+mdi build novel.mdi --to txt
+mdi build novel.mdi --to txt-ruby
 ```
 
 不加 `-o` 時，輸出檔會寫在輸入檔旁邊、換上對應格式的副檔名
 （`novel.mdi` → `novel.pdf`）。
+
+`txt` 輸出基本純文字；`txt-ruby` 會以 `{base|reading}` 保留ルビ。兩者目前都不是
+小説家になろう或青空文庫的專用格式。
 
 :::note
 PDF 輸出透過 [Playwright](https://playwright.dev) 的無頭 Chromium 渲染 —


### PR DESCRIPTION
Adds `txt` and `txt-ruby` to the English, Japanese, and Traditional Chinese quick-start examples. Clarifies that these are currently basic text formats, not Narou or Aozora Bunko exporters.

Verification: `pnpm build && pnpm --filter docs build && git diff --check`.