### PR TITLE
Fix export artifacts and add publication text targets

### DIFF
--- a/docs/src/content/docs/guides/getting-started.md
+++ b/docs/src/content/docs/guides/getting-started.md
@@ -23,13 +23,19 @@ mdi build novel.mdi --to epub -o dist/novel.epub
 mdi build novel.mdi --to docx
 mdi build novel.mdi --to txt
 mdi build novel.mdi --to txt-ruby
+mdi build novel.mdi --to narou
+mdi build novel.mdi --to kakuyomu
+mdi build novel.mdi --to aozora
+mdi build novel.mdi --to txt-all
 ```
 
 Without `-o`, the output file is written next to the input with the format's
 extension (`novel.mdi` → `novel.pdf`).
 
-`txt` writes basic plain text; `txt-ruby` keeps ruby as `{base|reading}`. They
-are not yet dedicated exporters for Narou or Aozora Bunko formats.
+`txt` writes basic plain text; `txt-ruby` keeps ruby as `{base|reading}`.
+`narou`, `kakuyomu`, and `aozora` target their respective Japanese publishing
+notations. `txt-all` writes all five text variants beside the input without
+overwriting them.
 
 :::note
 PDF output renders through a headless Chromium via

--- a/docs/src/content/docs/ja/guides/getting-started.md
+++ b/docs/src/content/docs/ja/guides/getting-started.md
@@ -23,13 +23,18 @@ mdi build novel.mdi --to epub -o dist/novel.epub
 mdi build novel.mdi --to docx
 mdi build novel.mdi --to txt
 mdi build novel.mdi --to txt-ruby
+mdi build novel.mdi --to narou
+mdi build novel.mdi --to kakuyomu
+mdi build novel.mdi --to aozora
+mdi build novel.mdi --to txt-all
 ```
 
 `-o` を省略すると、入力ファイルと同じ場所にフォーマットの拡張子で
 出力されます（`novel.mdi` → `novel.pdf`）。
 
 `txt` は基本的なプレーンテキスト、`txt-ruby` はルビを `{base|reading}` の形で
-残す出力です。小説家になろう／青空文庫向けの専用形式は、まだ提供していません。
+残す出力です。`narou`、`kakuyomu`、`aozora` は各投稿先向けの記法を出力します。
+`txt-all` は五つのテキスト形式を、互いに上書きせず入力ファイルの隣に出力します。
 
 :::note
 PDF 出力は [Playwright](https://playwright.dev) 経由のヘッドレス Chromium

--- a/docs/src/content/docs/zh-tw/guides/getting-started.md
+++ b/docs/src/content/docs/zh-tw/guides/getting-started.md
@@ -22,13 +22,18 @@ mdi build novel.mdi --to epub -o dist/novel.epub
 mdi build novel.mdi --to docx
 mdi build novel.mdi --to txt
 mdi build novel.mdi --to txt-ruby
+mdi build novel.mdi --to narou
+mdi build novel.mdi --to kakuyomu
+mdi build novel.mdi --to aozora
+mdi build novel.mdi --to txt-all
 ```
 
 不加 `-o` 時，輸出檔會寫在輸入檔旁邊、換上對應格式的副檔名
 （`novel.mdi` → `novel.pdf`）。
 
-`txt` 輸出基本純文字；`txt-ruby` 會以 `{base|reading}` 保留ルビ。兩者目前都不是
-小説家になろう或青空文庫的專用格式。
+`txt` 輸出基本純文字；`txt-ruby` 會以 `{base|reading}` 保留ルビ。`narou`、
+`kakuyomu`、`aozora` 分別輸出對應投稿平台的記法；`txt-all` 會在原稿旁一次輸出
+五種文字格式，且不互相覆寫。
 
 :::note
 PDF 輸出透過 [Playwright](https://playwright.dev) 的無頭 Chromium 渲染 —

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -40,6 +40,7 @@
     "tsup": "^8.3.0",
     "typescript": "^5.6.0",
     "vitest": "^2.1.0",
-    "@types/node": "^20.0.0"
+    "@types/node": "^20.0.0",
+    "jszip": "^3.10.1"
   }
 }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -4,7 +4,7 @@ import { build, loadExportProfile, parseArgs } from "./index.js";
 const args = parseArgs(process.argv.slice(3));
 if (!args || process.argv[2] !== "build") {
   console.error(
-    "Usage: mdi build <input.mdi> --to html|pdf|epub|docx|txt|txt-ruby [--config export.json] [-o <output>]"
+    "Usage: mdi build <input.mdi> --to html|pdf|epub|docx|txt|txt-ruby|narou|kakuyomu|aozora|txt-all [--config export.json] [-o <output>]"
   );
   process.exitCode = 1;
 } else {
@@ -13,7 +13,7 @@ if (!args || process.argv[2] !== "build") {
       output: args.output,
       profile: await loadExportProfile(args.config),
     });
-    console.log(`Written ${output}`);
+    for (const path of Array.isArray(output) ? output : [output]) console.log(`Written ${path}`);
   } catch (error: unknown) {
     console.error(error instanceof Error ? error.message : String(error));
     process.exitCode = 1;

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -4,7 +4,8 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { promisify } from "node:util";
 import { describe, expect, it } from "vitest";
-import { build, loadExportProfile, mdiToText, parseArgs } from "./index.js";
+import JSZip from "jszip";
+import { build, loadExportProfile, mdiToText, mdiToTextFormat, parseArgs } from "./index.js";
 import { unified } from "unified";
 import remarkParse from "remark-parse";
 import remarkMdi from "@illusions-lab/mdi-remark";
@@ -75,6 +76,61 @@ describe("text export", () => {
       mdiToText(tree, { text: { fullwidthSpaceIndent: true, indentCount: 2 } })
     ).toBe("題\n　　東京\n\n　　次");
     expect(mdiToText(tree, undefined, true)).toContain("{東京|とうきょう}");
+  });
+
+  it("renders stable golden text for every text target", () => {
+    const processor = unified().use(remarkParse).use(remarkMdi);
+    const tree = processor.runSync(
+      processor.parse(
+        "# 題\n\n{東京|とうきょう}と[[em:強調]]。[^n]\n\n[^n]: 注の本文"
+      )
+    ) as import("mdast").Root;
+    expect(mdiToTextFormat(tree, undefined, "txt")).toBe("題\n東京と強調。");
+    expect(mdiToTextFormat(tree, undefined, "txt-ruby")).toBe(
+      "題\n{東京|とうきょう}と強調。"
+    );
+    expect(mdiToTextFormat(tree, undefined, "narou")).toBe(
+      "題\n｜東京《とうきょう》と強調。［注1］\n\nFootnotes\n1. 注の本文"
+    );
+    expect(mdiToTextFormat(tree, undefined, "kakuyomu")).toBe(
+      "題\n｜東京《とうきょう》と《《強調》》。［注1］\n\nFootnotes\n1. 注の本文"
+    );
+    expect(mdiToTextFormat(tree, undefined, "aozora")).toBe(
+      "題［＃「題」は大見出し］\r\n｜東京《とうきょう》と強調［＃「強調」に傍点］。［注1］\r\n\r\nFootnotes\r\n1. 注の本文"
+    );
+  });
+
+  it("uses non-colliding default filenames for text targets", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "mdi-cli-text-names-"));
+    try {
+      const input = join(directory, "kitchen-sink.mdi");
+      await writeFile(input, "text");
+      await expect(build(input, "txt")).resolves.toBe(join(directory, "kitchen-sink.txt"));
+      await expect(build(input, "txt-ruby")).resolves.toBe(join(directory, "kitchen-sink_ruby.txt"));
+      await expect(build(input, "narou")).resolves.toBe(join(directory, "kitchen-sink_narou.txt"));
+      await expect(build(input, "kakuyomu")).resolves.toBe(join(directory, "kitchen-sink_kakuyomu.txt"));
+      await expect(build(input, "aozora")).resolves.toBe(join(directory, "kitchen-sink_aozora.txt"));
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("writes every text target with txt-all", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "mdi-cli-text-all-"));
+    try {
+      const input = join(directory, "kitchen-sink.mdi");
+      await writeFile(input, "{東京|とうきょう}");
+      await expect(build(input, "txt-all")).resolves.toEqual([
+        join(directory, "kitchen-sink.txt"),
+        join(directory, "kitchen-sink_ruby.txt"),
+        join(directory, "kitchen-sink_narou.txt"),
+        join(directory, "kitchen-sink_kakuyomu.txt"),
+        join(directory, "kitchen-sink_aozora.txt"),
+      ]);
+      expect(await readFile(join(directory, "kitchen-sink_aozora.txt"), "utf8")).toContain("｜東京《とうきょう》");
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
   });
 });
 
@@ -160,4 +216,45 @@ describe("CLI command output", () => {
       await rm(directory, { recursive: true, force: true });
     }
   });
+});
+
+describe("vertical Kitchen Sink export artifacts", () => {
+  it("preserves the full fixture across PDF, DOCX, EPUB, and all text targets", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "mdi-cli-vertical-kitchen-"));
+    try {
+      const source = (await readFile(
+        new URL("../../../examples/kitchen-sink.mdi", import.meta.url),
+        "utf8"
+      )).replace("writing-mode: horizontal", "writing-mode: vertical");
+      const input = join(directory, "kitchen-sink.mdi");
+      await writeFile(input, source);
+      const [html, pdf, docx, epub, textOutputs] = await Promise.all([
+        build(input, "html"),
+        build(input, "pdf"),
+        build(input, "docx"),
+        build(input, "epub"),
+        build(input, "txt-all"),
+      ]);
+      const htmlOutput = await readFile(html, "utf8");
+      expect(htmlOutput).toContain("writing-mode: vertical-rl");
+      expect(htmlOutput).toContain('<ruby class="mdi-ruby">');
+      expect(htmlOutput).toContain("data-footnotes");
+      expect((await readFile(pdf)).subarray(0, 5).toString()).toBe("%PDF-");
+      const docxZip = await JSZip.loadAsync(await readFile(docx));
+      const document = await docxZip.file("word/document.xml")!.async("string");
+      expect(document).toContain('w:textDirection w:val="tbRl"');
+      expect(document).toContain("<w:ruby ");
+      expect(document).toContain("<w:eastAsianLayout");
+      expect(document).toContain('<w:footnoteReference w:id="1"/>');
+      expect(await docxZip.file("word/footnotes.xml")!.async("string")).toContain("後に事実と判明する。");
+      const epubZip = await JSZip.loadAsync(await readFile(epub));
+      expect(await epubZip.file("OEBPS/style.css")!.async("string")).toContain("writing-mode:vertical-rl");
+      expect(await epubZip.file("OEBPS/package.opf")!.async("string")).toContain('page-progression-direction="rtl"');
+      expect(textOutputs).toHaveLength(5);
+      expect(await readFile(join(directory, "kitchen-sink_ruby.txt"), "utf8")).toContain("{東京|とうきょう}");
+      expect(await readFile(join(directory, "kitchen-sink_aozora.txt"), "utf8")).toContain("｜東京《とうきょう》");
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  }, 60_000);
 });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -19,22 +19,55 @@ export type OutputFormat =
   | "epub"
   | "docx"
   | "txt"
-  | "txt-ruby";
+  | "txt-ruby"
+  | "narou"
+  | "kakuyomu"
+  | "aozora"
+  | "txt-all";
+type TextOutputFormat = Extract<OutputFormat, "txt" | "txt-ruby" | "narou" | "kakuyomu" | "aozora">;
+const TEXT_OUTPUT_FORMATS: readonly TextOutputFormat[] = ["txt", "txt-ruby", "narou", "kakuyomu", "aozora"];
 export interface BuildOptions {
   output?: string;
   profile?: ExportProfile;
 }
 
+export function build(
+  input: string,
+  format: "txt-all",
+  options?: BuildOptions | string
+): Promise<string[]>;
+export function build(
+  input: string,
+  format: Exclude<OutputFormat, "txt-all">,
+  options?: BuildOptions | string
+): Promise<string>;
+export function build(
+  input: string,
+  format: OutputFormat,
+  options?: BuildOptions | string
+): Promise<string | string[]>;
 export async function build(
   input: string,
   format: OutputFormat,
   options: BuildOptions | string = {}
-): Promise<string> {
+): Promise<string | string[]> {
   const resolvedOptions =
     typeof options === "string" ? { output: options } : options;
   const source = await readFile(input, "utf8");
   const processor = unified().use(remarkParse).use(remarkMdi);
   const tree = processor.runSync(processor.parse(source)) as Root;
+  if (format === "txt-all") {
+    if (resolvedOptions.output)
+      throw new Error("--to txt-all does not accept -o; it writes all text formats next to the input file");
+    const outputs = await Promise.all(
+      TEXT_OUTPUT_FORMATS.map(async (textFormat) => {
+        const destination = defaultOutputPath(input, textFormat, "txt");
+        await writeFile(destination, mdiToTextFormat(tree, resolvedOptions.profile, textFormat));
+        return resolve(destination);
+      })
+    );
+    return outputs;
+  }
   const result =
     format === "html"
       ? (await import("@illusions-lab/mdi-to-html")).mdiToHtml(tree)
@@ -51,11 +84,11 @@ export async function build(
         })
       : format === "docx"
       ? await exportDocx(tree, resolvedOptions.profile)
-      : mdiToText(tree, resolvedOptions.profile, format === "txt-ruby");
-  const extension = format === "txt-ruby" ? "txt" : format;
+      : mdiToTextFormat(tree, resolvedOptions.profile, format);
+  const extension = isTextFormat(format) ? "txt" : format;
   const destination =
     resolvedOptions.output ??
-    input.slice(0, input.length - extname(input).length) + `.${extension}`;
+    defaultOutputPath(input, format, extension);
   await writeFile(destination, result);
   return resolve(destination);
 }
@@ -114,10 +147,24 @@ export function mdiToText(
   const prefix = settings.fullwidthSpaceIndent
     ? "　".repeat(settings.indentCount)
     : "";
-  return tree.children
-    .map((node) => textBlock(node, ruby, prefix))
-    .filter((value) => value !== undefined)
-    .join("\n");
+  return renderText(tree, ruby ? "txt-ruby" : "txt", prefix);
+}
+
+/** Text renderers for ordinary plain text and Japanese publication platforms. */
+export function mdiToTextFormat(tree: Root, profile: ExportProfile | undefined, format: TextOutputFormat): string {
+  const settings = resolveExportProfile(profile).text;
+  const prefix = settings.fullwidthSpaceIndent ? "　".repeat(settings.indentCount) : "";
+  const text = renderText(tree, format, prefix);
+  return format === "aozora" ? text.replaceAll("\n", "\r\n") : text;
+}
+
+function defaultOutputPath(input: string, format: OutputFormat, extension: string): string {
+  const stem = input.slice(0, input.length - extname(input).length);
+  const suffix = format === "txt" ? "" : isTextFormat(format) ? `_${format.replace("txt-", "")}` : "";
+  return `${stem}${suffix}.${extension}`;
+}
+function isTextFormat(format: OutputFormat): format is TextOutputFormat {
+  return TEXT_OUTPUT_FORMATS.includes(format as TextOutputFormat);
 }
 
 async function loadCover(
@@ -155,39 +202,45 @@ async function exportDocx(
   return (await import("@illusions-lab/mdi-to-docx")).mdiToDocx(tree, profile);
 }
 
-function textBlock(
-  node: RootContent,
-  ruby: boolean,
-  prefix: string
-): string | undefined {
-  if (node.type === "paragraph")
-    return `${prefix}${inlineText(node.children, ruby)}`;
-  if (node.type === "heading") return inlineText(node.children, ruby);
-  if (node.type === "list")
-    return node.children
-      .map((item) =>
-        item.children
-          .filter((child) => child.type === "paragraph")
-          .map((child) => `${prefix}${inlineText(child.children, ruby)}`)
-          .join("\n")
-      )
-      .join("\n");
-  if (node.type === "mdiBlank" || node.type === "mdiPagebreak") return "";
-  return undefined;
+function renderText(tree: Root, format: TextOutputFormat, prefix: string): string {
+  const defs = new Map(tree.children.filter((node) => node.type === "footnoteDefinition").map((node) => [node.identifier, node]));
+  const blocks = tree.children.flatMap((node) => textBlock(node, format, prefix, defs));
+  const footnotes = format === "txt" || format === "txt-ruby" ? [] : [...defs.values()].map((node, index) => `${index + 1}. ${node.children.map((child) => child.type === "paragraph" ? inlineText(child.children, format, defs) : "").join(" ")}`);
+  return [...blocks, ...(footnotes.length ? ["", "Footnotes", ...footnotes] : [])].join("\n");
 }
-function inlineText(nodes: PhrasingContent[], ruby: boolean): string {
+function textBlock(node: RootContent, format: TextOutputFormat, prefix: string, defs: Map<string, Extract<RootContent, { type: "footnoteDefinition" }>>): string[] {
+  if (node.type === "footnoteDefinition") return [];
+  if (node.type === "paragraph") return [`${prefix}${inlineText(node.children, format, defs)}`];
+  if (node.type === "heading") {
+    const value = inlineText(node.children, format, defs);
+    if (format === "aozora") return [`${value}［＃「${value}」は${node.depth === 1 ? "大" : node.depth === 2 ? "中" : "小"}見出し］`];
+    return [value];
+  }
+  if (node.type === "list") return node.children.flatMap((item, index) => item.children.flatMap((child) => child.type === "paragraph" ? [`${prefix}${node.ordered ? `${index + 1}. ` : "- "}${inlineText(child.children, format, defs)}`] : textBlock(child, format, prefix, defs)));
+  if (node.type === "blockquote") return node.children.flatMap((child) => textBlock(child, format, prefix, defs));
+  if (node.type === "code") return node.value.split("\n");
+  if (node.type === "table") return node.children.map((row) => row.children.map((cell) => inlineText(cell.children, format, defs)).join("\t"));
+  if (node.type === "thematicBreak") return ["――――――"];
+  if (node.type === "mdiBlank" || node.type === "mdiPagebreak") return [""];
+  return [];
+}
+function inlineText(nodes: PhrasingContent[], format: TextOutputFormat, defs: Map<string, Extract<RootContent, { type: "footnoteDefinition" }>>): string {
   return nodes
     .map((node) => {
       if (node.type === "text") return node.value;
       if (node.type === "break" || node.type === "mdiBreak") return "\n";
       if (node.type === "mdiRuby")
-        return ruby
-          ? `{${node.base}|${
-              Array.isArray(node.ruby) ? node.ruby.join(".") : node.ruby
-            }}`
-          : node.base;
+        return format === "txt" ? node.base : format === "txt-ruby" ? `{${node.base}|${Array.isArray(node.ruby) ? node.ruby.join(".") : node.ruby}}` : `｜${node.base}《${Array.isArray(node.ruby) ? node.ruby.join("") : node.ruby}》`;
+      if (node.type === "mdiEm") {
+        const value = inlineText(node.children as PhrasingContent[], format, defs);
+        return format === "aozora" ? `${value}［＃「${value}」に傍点］` : format === "kakuyomu" ? `《《${value}》》` : value;
+      }
+      if (node.type === "mdiTcy") return node.value;
+      if (node.type === "inlineCode") return node.value;
+      if (node.type === "image") return node.alt ? `[画像: ${node.alt}]` : "[画像]";
+      if (node.type === "footnoteReference") return format === "txt" || format === "txt-ruby" ? "" : `［注${[...defs.keys()].indexOf(node.identifier) + 1}］`;
       if ("children" in node)
-        return inlineText(node.children as PhrasingContent[], ruby);
+        return inlineText(node.children as PhrasingContent[], format, defs);
       return "";
     })
     .join("");
@@ -199,6 +252,10 @@ function isFormat(value: string): value is OutputFormat {
     value === "epub" ||
     value === "docx" ||
     value === "txt" ||
-    value === "txt-ruby"
+    value === "txt-ruby" ||
+    value === "narou" ||
+    value === "kakuyomu" ||
+    value === "aozora" ||
+    value === "txt-all"
   );
 }

--- a/packages/to-docx/src/index.test.ts
+++ b/packages/to-docx/src/index.test.ts
@@ -70,6 +70,23 @@ describe("DOCX print defaults", () => {
       /w:styleId="Heading1"[\s\S]*?w:color w:val="000000"/
     );
   });
+
+  it("keeps vertical writing, ruby, tcy, and footnotes in one real DOCX package", async () => {
+    const zip = await JSZip.loadAsync(
+      await mdiToDocx(
+        parse(
+          "---\nwriting-mode: vertical\n---\n{東京|とうきょう}^12^脚注[^n]\n\n[^n]: 縦書きの脚注"
+        )
+      )
+    );
+    const document = await zip.file("word/document.xml")!.async("string");
+    const footnotes = await zip.file("word/footnotes.xml")!.async("string");
+    expect(document).toContain('w:textDirection w:val="tbRl"');
+    expect(document).toContain("<w:ruby ");
+    expect(document).toContain("<w:eastAsianLayout");
+    expect(document).toContain('<w:footnoteReference w:id="1"/>');
+    expect(footnotes).toContain("縦書きの脚注");
+  });
 });
 
 describe("mdiToDocx edge cases", () => {
@@ -99,8 +116,14 @@ describe("mdiToDocx edge cases", () => {
     const document = await zip.file("word/document.xml")!.async("string");
     expect(document).toContain("code");
     expect(document).toContain("link text");
+    expect(await zip.file("word/_rels/document.xml.rels")!.async("string")).toContain(
+      'Target="https://example.com" TargetMode="External"'
+    );
     expect(document).toContain("[Image: diagram]");
-    expect(document).toContain("[a]");
+    expect(document).toContain('<w:footnoteReference w:id="1"/>');
+    expect(await zip.file("word/footnotes.xml")!.async("string")).toContain(
+      "definition"
+    );
   });
 
   it("maps quotes, fenced code, and thematic breaks to their print styles", async () => {

--- a/packages/to-docx/src/index.ts
+++ b/packages/to-docx/src/index.ts
@@ -1,7 +1,9 @@
 import {
   AlignmentType,
   Document,
+  ExternalHyperlink,
   Footer,
+  FootnoteReferenceRun,
   HeadingLevel,
   Header,
   ImportedXmlComponent,
@@ -38,7 +40,15 @@ export async function mdiToDocx(
     profile,
     tree.data?.frontmatter?.writingMode
   );
-  const children = tree.children.flatMap((node) => block(node, options));
+  const definitions = tree.children.filter(
+    (node): node is Extract<RootContent, { type: "footnoteDefinition" }> =>
+      node.type === "footnoteDefinition"
+  );
+  const footnoteIds = new Map(
+    definitions.map((definition, index) => [definition.identifier, index + 1])
+  );
+  const context: DocxContext = { footnoteIds };
+  const children = tree.children.flatMap((node) => block(node, options, context));
   const dimensions = PAGE_DIMENSIONS[options.pagination.pageSize];
   const widthMm = options.pagination.landscape
     ? dimensions.height
@@ -70,6 +80,18 @@ export async function mdiToDocx(
   const document = new Document({
     title: options.metadata.title ?? tree.data?.frontmatter?.title,
     creator: options.metadata.author ?? tree.data?.frontmatter?.author,
+    footnotes: Object.fromEntries(
+      definitions.map((definition, index) => [
+        String(index + 1),
+        {
+          children: definition.children.flatMap((child) =>
+            child.type === "paragraph"
+              ? [new Paragraph({ children: inline(child.children, context) })]
+              : []
+          ),
+        },
+      ])
+    ),
     styles: {
       default: {
         document: {
@@ -226,7 +248,8 @@ function pageNumberSection(
 
 function block(
   node: RootContent,
-  options: ResolvedExportProfile
+  options: ResolvedExportProfile,
+  context: DocxContext
 ): Array<Paragraph | DocxTable> {
   if (node.type === "heading")
     return [
@@ -239,10 +262,10 @@ function block(
           HeadingLevel.HEADING_5,
           HeadingLevel.HEADING_6,
         ][node.depth - 1],
-        children: inline(node.children),
+        children: inline(node.children, context),
       }),
     ];
-  if (node.type === "paragraph") return [paragraph(node.children, options)];
+  if (node.type === "paragraph") return [paragraph(node.children, options, undefined, context)];
   if (node.type === "list")
     return node.children.flatMap((item) =>
       item.children
@@ -251,7 +274,7 @@ function block(
           (n) =>
             new Paragraph({
               style: "MdiList",
-              children: inline(n.children),
+              children: inline(n.children, context),
               bullet: { level: 0 },
             })
         )
@@ -259,8 +282,8 @@ function block(
   if (node.type === "blockquote")
     return node.children.flatMap((child) =>
       child.type === "paragraph"
-        ? [paragraph(child.children, options, "MdiQuote")]
-        : block(child, options)
+        ? [paragraph(child.children, options, "MdiQuote", context)]
+        : block(child, options, context)
     );
   if (node.type === "code")
     return [
@@ -284,7 +307,7 @@ function block(
         children: [new TextRun("— — —")],
       }),
     ];
-  if (node.type === "table") return [tableBlock(node, options)];
+  if (node.type === "table") return [tableBlock(node, options, context)];
   if (node.type === "mdiPagebreak")
     return [new Paragraph({ children: [new PageBreak()] })];
   if (node.type === "mdiBlank") return [new Paragraph("")];
@@ -293,7 +316,8 @@ function block(
 
 function tableBlock(
   node: Extract<RootContent, { type: "table" }>,
-  options: ResolvedExportProfile
+  options: ResolvedExportProfile,
+  context: DocxContext
 ): DocxTable {
   const columns = Math.max(1, ...node.children.map((row) => row.children.length));
   const dimensions = PAGE_DIMENSIONS[options.pagination.pageSize];
@@ -316,10 +340,9 @@ function tableBlock(
                 width: { size: columnWidth, type: WidthType.DXA },
                 children: [
                   new Paragraph({
-                    children:
-                      rowIndex === 0
-                        ? [new TextRun({ bold: true, children: inline(cell.children) })]
-                        : inline(cell.children),
+                    children: rowIndex === 0
+                      ? [new TextRun({ text: inlineText(cell.children), bold: true })]
+                      : inline(cell.children, context),
                   }),
                 ],
               })
@@ -332,7 +355,8 @@ function tableBlock(
 function paragraph(
   nodes: PhrasingContent[],
   options: ResolvedExportProfile,
-  style?: string
+  style: string | undefined,
+  context: DocxContext
 ): Paragraph {
   const fontSizeMm = (() => {
     const dimensions = PAGE_DIMENSIONS[options.pagination.pageSize];
@@ -367,27 +391,39 @@ function paragraph(
                 ),
               }),
         },
-    children: [...prefix, ...inline(nodes)],
+    children: [...prefix, ...inline(nodes, context)],
   });
 }
 
-function inline(nodes: PhrasingContent[]): TextRun[] {
+type InlineChild = TextRun | FootnoteReferenceRun | ExternalHyperlink;
+interface DocxContext { footnoteIds: Map<string, number>; }
+
+function inline(nodes: PhrasingContent[], context: DocxContext): InlineChild[] {
   return nodes.flatMap((node) => {
     if (node.type === "text") return [new TextRun(node.value)];
     if (node.type === "break" || node.type === "mdiBreak")
       return [new TextRun({ break: 1 })];
     if (node.type === "emphasis")
-      return [new TextRun({ italics: true, children: inline(node.children) })];
+      return [new TextRun({ italics: true, children: inline(node.children, context) })];
     if (node.type === "strong")
-      return [new TextRun({ bold: true, children: inline(node.children) })];
+      return [new TextRun({ bold: true, children: inline(node.children, context) })];
     if (node.type === "delete")
-      return [new TextRun({ strike: true, children: inline(node.children) })];
+      return [new TextRun({ strike: true, children: inline(node.children, context) })];
     if (node.type === "inlineCode")
       return [new TextRun({ text: node.value, font: "Courier New" })];
     if (node.type === "image")
       return [new TextRun({ text: node.alt ? `[Image: ${node.alt}]` : "[Image]" })];
-    if (node.type === "footnoteReference")
-      return [new TextRun({ text: `[${node.label ?? node.identifier}]`, superScript: true })];
+    if (node.type === "link")
+      return [
+        new ExternalHyperlink({
+          link: node.url,
+          children: inline(node.children, context),
+        }),
+      ];
+    if (node.type === "footnoteReference") {
+      const id = context.footnoteIds.get(node.identifier);
+      return id ? [new FootnoteReferenceRun(id)] : [];
+    }
     if (node.type === "mdiRuby") return [rawRun(rubyXml(node.base, node.ruby))];
     if (node.type === "mdiTcy")
       return [
@@ -397,9 +433,13 @@ function inline(nodes: PhrasingContent[]): TextRun[] {
           )}</w:t></w:r>`
         ),
       ];
-    if ("children" in node) return inline(node.children as PhrasingContent[]);
+    if ("children" in node) return inline(node.children as PhrasingContent[], context);
     return [];
   });
+}
+
+function inlineText(nodes: PhrasingContent[]): string {
+  return nodes.map((node) => node.type === "text" ? node.value : "children" in node ? inlineText(node.children as PhrasingContent[]) : "").join("");
 }
 
 function mmToTwips(mm: number): number {

--- a/packages/to-epub/src/index.test.ts
+++ b/packages/to-epub/src/index.test.ts
@@ -141,5 +141,6 @@ describe("mdiToEpub edge cases", () => {
     ).toBe(2);
     expect(css).toContain("font-family:Noto Serif JP");
     expect(css).toContain("text-indent:2em");
+    expect(css).toContain("writing-mode:vertical-rl");
   });
 });

--- a/packages/to-pdf/src/index.test.ts
+++ b/packages/to-pdf/src/index.test.ts
@@ -42,6 +42,7 @@ describe("PDF export profile", () => {
     expect(html).toContain("@page{size:210mm 297mm;margin:25.4mm 25.4mm 25.4mm 25.4mm}");
     expect(html).not.toContain("body{padding:");
     expect(html).toContain("html{writing-mode:horizontal-tb!important");
+    expect(html).toContain("p+h1,p+h2,p+h3,p+h4,p+h5,p+h6{padding-top:.75em}");
   });
   it("applies margins through @page so every forced page receives them", () => {
     const html = applyPdfProfile(

--- a/packages/to-pdf/src/index.ts
+++ b/packages/to-pdf/src/index.ts
@@ -84,7 +84,7 @@ export function applyPdfProfile(
     typesetting.fontFamily
   )};font-size:${fontSize}mm;line-height:${lineHeight};writing-mode:${writingMode};text-orientation:mixed;color:#000}p{margin:0 0 .75em;text-indent:${
     typesetting.fullwidthSpaceIndent ? "0" : `${typesetting.textIndentEm}em`
-  }}h1,h2,h3,h4,h5,h6{color:#000;break-after:avoid;margin:0 0 .75em;line-height:1.25}h1{font-size:1.6em}h2{font-size:1.35em}h3{font-size:1.15em}a{color:inherit;text-decoration:none}.mdi-pagebreak,.mdi-pagebreak-right,.mdi-pagebreak-left{background:transparent}</style>`;
+  }}h1,h2,h3,h4,h5,h6{color:#000;break-after:avoid;margin:0 0 .75em;line-height:1.25}p+h1,p+h2,p+h3,p+h4,p+h5,p+h6{padding-top:.75em}h1{font-size:1.6em}h2{font-size:1.35em}h3{font-size:1.15em}a{color:inherit;text-decoration:none}.mdi-pagebreak,.mdi-pagebreak-right,.mdi-pagebreak-left{background:transparent}</style>`;
   return html
     .replace("</head>", `${css}</head>`)
     .replace(/(<p(?:\s[^>]*)?>)(?!\s*<\/p>)/g, `$1${fullwidth}`);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,9 @@ importers:
       '@types/node':
         specifier: ^20.0.0
         version: 20.19.43
+      jszip:
+        specifier: ^3.10.1
+        version: 3.10.1
       tsup:
         specifier: ^8.3.0
         version: 8.5.1(postcss@8.5.19)(typescript@5.9.3)(yaml@2.9.0)


### PR DESCRIPTION
## Output fixes
- restore native Word footnotes, valid external hyperlinks, and visible DOCX table headers
- prevent PDF heading overlap after page-break variants
- add actual vertical Kitchen Sink export artifact regression coverage

## Text targets
- add `narou`, `kakuyomu`, `aozora`, and `txt-all`
- use non-colliding default filenames for every text target
- document the new CLI options

## Verification
- `pnpm test && pnpm typecheck && pnpm build && git diff --check`
- generated Kitchen Sink PDF/DOCX/EPUB/HTML and all five text outputs; rendered PDF page 6; checked DOCX footnotes and EPUB XML.