### PR TITLE
Fix Aozora text encoding

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -34,7 +34,8 @@
     "mdast-util-mdi": "workspace:*",
     "remark-parse": "^11.0.0",
     "unified": "^11.0.0",
-    "@types/mdast": "^4.0.0"
+    "@types/mdast": "^4.0.0",
+    "iconv-lite": "^0.6.3"
   },
   "devDependencies": {
     "tsup": "^8.3.0",

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -5,6 +5,7 @@ import { join, resolve } from "node:path";
 import { promisify } from "node:util";
 import { describe, expect, it } from "vitest";
 import JSZip from "jszip";
+import iconv from "iconv-lite";
 import { build, loadExportProfile, mdiToText, mdiToTextFormat, parseArgs } from "./index.js";
 import { unified } from "unified";
 import remarkParse from "remark-parse";
@@ -119,7 +120,7 @@ describe("text export", () => {
     const directory = await mkdtemp(join(tmpdir(), "mdi-cli-text-all-"));
     try {
       const input = join(directory, "kitchen-sink.mdi");
-      await writeFile(input, "{東京|とうきょう}");
+      await writeFile(input, "{東京|とうきょう}\n\n次");
       await expect(build(input, "txt-all")).resolves.toEqual([
         join(directory, "kitchen-sink.txt"),
         join(directory, "kitchen-sink_ruby.txt"),
@@ -127,7 +128,9 @@ describe("text export", () => {
         join(directory, "kitchen-sink_kakuyomu.txt"),
         join(directory, "kitchen-sink_aozora.txt"),
       ]);
-      expect(await readFile(join(directory, "kitchen-sink_aozora.txt"), "utf8")).toContain("｜東京《とうきょう》");
+      const aozora = await readFile(join(directory, "kitchen-sink_aozora.txt"));
+      expect(iconv.decode(aozora, "shift_jis")).toContain("｜東京《とうきょう》");
+      expect(aozora.includes(Buffer.from("\r\n"))).toBe(true);
     } finally {
       await rm(directory, { recursive: true, force: true });
     }
@@ -252,7 +255,9 @@ describe("vertical Kitchen Sink export artifacts", () => {
       expect(await epubZip.file("OEBPS/package.opf")!.async("string")).toContain('page-progression-direction="rtl"');
       expect(textOutputs).toHaveLength(5);
       expect(await readFile(join(directory, "kitchen-sink_ruby.txt"), "utf8")).toContain("{東京|とうきょう}");
-      expect(await readFile(join(directory, "kitchen-sink_aozora.txt"), "utf8")).toContain("｜東京《とうきょう》");
+      expect(
+        iconv.decode(await readFile(join(directory, "kitchen-sink_aozora.txt")), "shift_jis")
+      ).toContain("｜東京《とうきょう》");
     } finally {
       await rm(directory, { recursive: true, force: true });
     }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,5 +1,6 @@
 import { readFile, writeFile } from "node:fs/promises";
 import { dirname, extname, resolve } from "node:path";
+import iconv from "iconv-lite";
 import { unified } from "unified";
 import remarkParse from "remark-parse";
 import remarkMdi from "@illusions-lab/mdi-remark";
@@ -62,7 +63,7 @@ export async function build(
     const outputs = await Promise.all(
       TEXT_OUTPUT_FORMATS.map(async (textFormat) => {
         const destination = defaultOutputPath(input, textFormat, "txt");
-        await writeFile(destination, mdiToTextFormat(tree, resolvedOptions.profile, textFormat));
+        await writeTextOutput(destination, mdiToTextFormat(tree, resolvedOptions.profile, textFormat), textFormat);
         return resolve(destination);
       })
     );
@@ -89,7 +90,11 @@ export async function build(
   const destination =
     resolvedOptions.output ??
     defaultOutputPath(input, format, extension);
-  await writeFile(destination, result);
+  if (isTextFormat(format)) {
+    await writeTextOutput(destination, result as string, format);
+  } else {
+    await writeFile(destination, result);
+  }
   return resolve(destination);
 }
 
@@ -156,6 +161,10 @@ export function mdiToTextFormat(tree: Root, profile: ExportProfile | undefined, 
   const prefix = settings.fullwidthSpaceIndent ? "　".repeat(settings.indentCount) : "";
   const text = renderText(tree, format, prefix);
   return format === "aozora" ? text.replaceAll("\n", "\r\n") : text;
+}
+
+async function writeTextOutput(destination: string, text: string, format: TextOutputFormat): Promise<void> {
+  await writeFile(destination, format === "aozora" ? iconv.encode(text, "shift_jis") : text);
 }
 
 function defaultOutputPath(input: string, format: OutputFormat, extension: string): string {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
       '@types/mdast':
         specifier: ^4.0.0
         version: 4.0.4
+      iconv-lite:
+        specifier: ^0.6.3
+        version: 0.6.3
       mdast-util-mdi:
         specifier: workspace:*
         version: link:../mdast-util-mdi
@@ -2283,6 +2286,10 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
 
   iconv-lite@0.7.3:
     resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
@@ -5563,6 +5570,10 @@ snapshots:
   i18next@26.3.6(typescript@5.9.3):
     optionalDependencies:
       typescript: 5.9.3
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
 
   iconv-lite@0.7.3:
     dependencies:


### PR DESCRIPTION
Writes Aozora text exports as Shift_JIS with CRLF, and verifies the bytes in unit and vertical Kitchen Sink artifact tests.