### PR TITLE
Preserve Japanese dashes in Aozora exports

### DIFF
--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -135,6 +135,20 @@ describe("text export", () => {
       await rm(directory, { recursive: true, force: true });
     }
   });
+
+  it("preserves Japanese paired dashes in Shift_JIS Aozora output", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "mdi-cli-aozora-dashes-"));
+    try {
+      const input = join(directory, "novel.mdi");
+      await writeFile(input, "彼は——振り返らなかった。");
+      const output = await build(input, "aozora");
+      const decoded = iconv.decode(await readFile(output), "shift_jis");
+      expect(decoded).toContain("彼は――振り返らなかった。");
+      expect(decoded).not.toContain("?");
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("build edge cases", () => {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -164,7 +164,19 @@ export function mdiToTextFormat(tree: Root, profile: ExportProfile | undefined, 
 }
 
 async function writeTextOutput(destination: string, text: string, format: TextOutputFormat): Promise<void> {
-  await writeFile(destination, format === "aozora" ? iconv.encode(text, "shift_jis") : text);
+  await writeFile(
+    destination,
+    format === "aozora" ? iconv.encode(normalizeAozoraShiftJis(text), "shift_jis") : text
+  );
+}
+
+/**
+ * Aozora Bunko's Shift_JIS workflow cannot encode U+2014 EM DASH.  Japanese
+ * manuscripts commonly use paired em dashes, so preserve both characters by
+ * converting each one to the Shift_JIS-compatible U+2015 HORIZONTAL BAR.
+ */
+function normalizeAozoraShiftJis(text: string): string {
+  return text.replaceAll("\u2014", "\u2015");
 }
 
 function defaultOutputPath(input: string, format: OutputFormat, extension: string): string {


### PR DESCRIPTION
Normalizes U+2014 EM DASH to Shift_JIS-compatible U+2015 HORIZONTAL BAR before writing Aozora text, with a regression test.