### PR TITLE
Fix vertical DOCX heading ruby overlap

### DIFF
--- a/packages/to-docx/src/index.test.ts
+++ b/packages/to-docx/src/index.test.ts
@@ -87,6 +87,19 @@ describe("DOCX print defaults", () => {
     expect(document).toContain('<w:footnoteReference w:id="1"/>');
     expect(footnotes).toContain("縦書きの脚注");
   });
+
+  it("sizes vertical heading ruby from its heading run to prevent overlap", async () => {
+    const zip = await JSZip.loadAsync(
+      await mdiToDocx(
+        parse("---\nwriting-mode: vertical\n---\n# {鏡背|きょうはい}の雪")
+      )
+    );
+    const document = await zip.file("word/document.xml")!.async("string");
+    expect(document).toContain('<w:pStyle w:val="Heading1"/>');
+    expect(document).toContain(
+      '<w:rubyPr><w:rubyAlign w:val="center"/><w:hps w:val="20"/><w:hpsRaise w:val="32"/><w:hpsBaseText w:val="40"/>'
+    );
+  });
 });
 
 describe("mdiToDocx edge cases", () => {

--- a/packages/to-docx/src/index.ts
+++ b/packages/to-docx/src/index.ts
@@ -184,14 +184,13 @@ export async function mdiToDocx(
 
 /** Word's built-in Heading styles are blue by default; MDI uses a black print hierarchy. */
 function headingStyle(options: ResolvedExportProfile, level: number) {
-  const scale = [1.8, 1.55, 1.35, 1.2, 1.1, 1][level - 1] ?? 1;
   const before = [360, 300, 240, 180, 150, 120][level - 1] ?? 120;
   return {
     run: {
       font: options.typesetting.fontFamily,
       color: "000000",
       bold: true,
-      size: Math.round(22 * scale),
+      size: headingFontSize(level),
     },
     paragraph: {
       spacing: { before, after: 120 },
@@ -200,6 +199,11 @@ function headingStyle(options: ResolvedExportProfile, level: number) {
       outlineLevel: level - 1,
     },
   };
+}
+
+function headingFontSize(level: number): number {
+  const scale = [1.8, 1.55, 1.35, 1.2, 1.1, 1][level - 1] ?? 1;
+  return Math.round(22 * scale);
 }
 
 function customHeadingStyle(options: ResolvedExportProfile, level: number) {
@@ -262,7 +266,7 @@ function block(
           HeadingLevel.HEADING_5,
           HeadingLevel.HEADING_6,
         ][node.depth - 1],
-        children: inline(node.children, context),
+        children: inline(node.children, context, headingFontSize(node.depth)),
       }),
     ];
   if (node.type === "paragraph") return [paragraph(node.children, options, undefined, context)];
@@ -398,17 +402,21 @@ function paragraph(
 type InlineChild = TextRun | FootnoteReferenceRun | ExternalHyperlink;
 interface DocxContext { footnoteIds: Map<string, number>; }
 
-function inline(nodes: PhrasingContent[], context: DocxContext): InlineChild[] {
+function inline(
+  nodes: PhrasingContent[],
+  context: DocxContext,
+  rubyBaseTextSize = 24
+): InlineChild[] {
   return nodes.flatMap((node) => {
     if (node.type === "text") return [new TextRun(node.value)];
     if (node.type === "break" || node.type === "mdiBreak")
       return [new TextRun({ break: 1 })];
     if (node.type === "emphasis")
-      return [new TextRun({ italics: true, children: inline(node.children, context) })];
+      return [new TextRun({ italics: true, children: inline(node.children, context, rubyBaseTextSize) })];
     if (node.type === "strong")
-      return [new TextRun({ bold: true, children: inline(node.children, context) })];
+      return [new TextRun({ bold: true, children: inline(node.children, context, rubyBaseTextSize) })];
     if (node.type === "delete")
-      return [new TextRun({ strike: true, children: inline(node.children, context) })];
+      return [new TextRun({ strike: true, children: inline(node.children, context, rubyBaseTextSize) })];
     if (node.type === "inlineCode")
       return [new TextRun({ text: node.value, font: "Courier New" })];
     if (node.type === "image")
@@ -417,14 +425,14 @@ function inline(nodes: PhrasingContent[], context: DocxContext): InlineChild[] {
       return [
         new ExternalHyperlink({
           link: node.url,
-          children: inline(node.children, context),
+          children: inline(node.children, context, rubyBaseTextSize),
         }),
       ];
     if (node.type === "footnoteReference") {
       const id = context.footnoteIds.get(node.identifier);
       return id ? [new FootnoteReferenceRun(id)] : [];
     }
-    if (node.type === "mdiRuby") return [rawRun(rubyXml(node.base, node.ruby))];
+    if (node.type === "mdiRuby") return [rawRun(rubyXml(node.base, node.ruby, rubyBaseTextSize))];
     if (node.type === "mdiTcy")
       return [
         rawRun(
@@ -433,7 +441,7 @@ function inline(nodes: PhrasingContent[], context: DocxContext): InlineChild[] {
           )}</w:t></w:r>`
         ),
       ];
-    if ("children" in node) return inline(node.children as PhrasingContent[], context);
+    if ("children" in node) return inline(node.children as PhrasingContent[], context, rubyBaseTextSize);
     return [];
   });
 }
@@ -445,9 +453,12 @@ function inlineText(nodes: PhrasingContent[]): string {
 function mmToTwips(mm: number): number {
   return Math.round((mm / 25.4) * 1440);
 }
-function rubyXml(base: string, reading: string | string[]): string {
+function rubyXml(base: string, reading: string | string[], baseTextSize = 24): string {
   const text = Array.isArray(reading) ? reading.join(".") : reading;
-  return `<w:ruby><w:rubyPr><w:rubyAlign w:val="center"/><w:hps w:val="12"/><w:hpsRaise w:val="18"/><w:hpsBaseText w:val="24"/></w:rubyPr><w:rt><w:r><w:t>${xml(
+  const rubySize = Math.max(10, Math.round(baseTextSize / 2));
+  const rubyRaise =
+    baseTextSize === 24 ? 18 : Math.max(18, Math.round(baseTextSize * 0.8));
+  return `<w:ruby><w:rubyPr><w:rubyAlign w:val="center"/><w:hps w:val="${rubySize}"/><w:hpsRaise w:val="${rubyRaise}"/><w:hpsBaseText w:val="${baseTextSize}"/></w:rubyPr><w:rt><w:r><w:t>${xml(
     text
   )}</w:t></w:r></w:rt><w:rubyBase><w:r><w:t>${xml(
     base


### PR DESCRIPTION
Sizes heading ruby from the H1-H9 run size and increases the vertical offset, with a regression test for the reported 鏡背 title.