### PR TITLE
Fix documentation site links

### DIFF
--- a/nodejs/docs/src/content/docs/guides/getting-started.md
+++ b/nodejs/docs/src/content/docs/guides/getting-started.md
@@ -155,5 +155,5 @@ The adapter contains no tokenizer, grammar rules, or syntax fallback. When an
 mdast tree is converted back, Rust validates it and creates the document IR
 used by serializers and renderers.
 
-See [Architecture](/MDI/guides/architecture/) for the complete ownership and
+See [Architecture](/guides/architecture/) for the complete ownership and
 wire-contract rules.

--- a/nodejs/docs/src/content/docs/index.mdx
+++ b/nodejs/docs/src/content/docs/index.mdx
@@ -6,7 +6,7 @@ hero:
   tagline: One Rust parser for illusion Markdown (MDI), with consistent HTML, PDF, EPUB, DOCX, and text output.
   actions:
     - text: Getting Started
-      link: /MDI/guides/getting-started/
+      link: /guides/getting-started/
       icon: right-arrow
     - text: MDI 2.0 Specification
       link: https://github.com/illusions-lab/MDI/blob/main/SYNTAX.md
@@ -25,7 +25,7 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
 	<Card title="Japanese typography, for real" icon="translate">
 		Ruby (ルビ), tate-chu-yoko (縦中横), boten (傍点), warichu
 		(割注), kerning, and vertical writing — parsed as first-class syntax,
-		not post-processing hacks. See the [live showcase](/MDI/syntax/showcase/):
+		not post-processing hacks. See the [live showcase](/syntax/showcase/):
 		this site renders MDI with its own parser.
 	</Card>
 	<Card title="Thin language interfaces" icon="puzzle">

--- a/nodejs/docs/src/content/docs/ja/guides/getting-started.md
+++ b/nodejs/docs/src/content/docs/ja/guides/getting-started.md
@@ -163,4 +163,4 @@ MDI として再出力する場合は、mdast を文書 IR に戻してから、
 `serializeMdi` または各 renderer に渡します。
 
 パッケージの責務と完全な契約については、
-[アーキテクチャ](/MDI/ja/guides/architecture/)を参照してください。
+[アーキテクチャ](/ja/guides/architecture/)を参照してください。

--- a/nodejs/docs/src/content/docs/ja/index.mdx
+++ b/nodejs/docs/src/content/docs/ja/index.mdx
@@ -6,7 +6,7 @@ hero:
   tagline: illusion Markdown (MDI) を単一の Rust パーサで解析し、HTML・PDF・EPUB・DOCX・テキストへ一貫して出力します。
   actions:
     - text: はじめに
-      link: /MDI/ja/guides/getting-started/
+      link: /ja/guides/getting-started/
       icon: right-arrow
     - text: MDI 2.0 仕様書
       link: https://github.com/illusions-lab/MDI/blob/main/SYNTAX.md
@@ -24,7 +24,7 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
 	</Card>
 	<Card title="本物の日本語組版" icon="translate">
 		ルビ・縦中横・傍点・割注・字間調整・縦書き — 後処理ハックではなく、
-		第一級の構文として解析されます。[ライブ・ショーケース](/MDI/ja/syntax/showcase/)
+		第一級の構文として解析されます。[ライブ・ショーケース](/ja/syntax/showcase/)
 		をご覧ください。このサイト自体が MDI のパーサで MDI を描画しています。
 	</Card>
 	<Card title="薄い言語インターフェース" icon="puzzle">

--- a/nodejs/docs/src/content/docs/zh-tw/guides/getting-started.md
+++ b/nodejs/docs/src/content/docs/zh-tw/guides/getting-started.md
@@ -153,4 +153,4 @@ Adapter 只在 Rust IR 與 mdast 之間轉換資料。它不包含 tokenizer、g
 table 或 fallback parser，也不能改變 MDI 的邊界判定。若要再輸出 MDI，應先
 把 mdast 映射回文件 IR，再交給 Rust 的 `serializeMdi` 或其他 renderer。
 
-套件的責任邊界與完整契約見[架構](/MDI/zh-tw/guides/architecture/)。
+套件的責任邊界與完整契約見[架構](/zh-tw/guides/architecture/)。

--- a/nodejs/docs/src/content/docs/zh-tw/index.mdx
+++ b/nodejs/docs/src/content/docs/zh-tw/index.mdx
@@ -6,7 +6,7 @@ hero:
   tagline: illusion Markdown (MDI) 的單一 Rust 解析器，以及一致的 HTML、PDF、EPUB、DOCX、文字輸出。
   actions:
     - text: 快速上手
-      link: /MDI/zh-tw/guides/getting-started/
+      link: /zh-tw/guides/getting-started/
       icon: right-arrow
     - text: MDI 2.0 規範
       link: https://github.com/illusions-lab/MDI/blob/main/SYNTAX.md
@@ -23,7 +23,7 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
 	</Card>
 	<Card title="貨真價實的日文排版" icon="translate">
 		ルビ（注音假名）、縦中横、傍點、割注、字距調整、直書 — 全部作為
-		第一級語法解析，不是後處理補丁。看看[即時渲染展示](/MDI/zh-tw/syntax/showcase/)：
+		第一級語法解析，不是後處理補丁。看看[即時渲染展示](/zh-tw/syntax/showcase/)：
 		本網站就是用 MDI 自己的解析器渲染 MDI 的。
 	</Card>
 	<Card title="薄語言接口" icon="puzzle">


### PR DESCRIPTION
## What changed
- Corrected legacy `/MDI/` internal links in all three localized homepages and getting-started guides.

## Why
The custom-domain deployment serves pages from the domain root; the old GitHub Pages project path returned 404.

## Validation
- `pnpm --dir nodejs/docs build`