### PR TITLE
Restructure MDI docs around Rust authority

### DIFF
--- a/nodejs/docs/astro.config.mjs
+++ b/nodejs/docs/astro.config.mjs
@@ -20,7 +20,6 @@ function remarkMdiSyntax() {
 }
 
 const packages = [
-	'mdi',
 	'micromark-extension-mdi',
 	'mdast-util-mdi',
 	'remark',
@@ -29,7 +28,6 @@ const packages = [
 	'to-pdf',
 	'to-epub',
 	'to-docx',
-	'export-profile',
 	'cli',
 ];
 
@@ -77,27 +75,49 @@ export default defineConfig({
 			plugins: apiPlugins,
 			sidebar: [
 				{
-					label: 'Guides',
-					translations: { ja: 'ガイド', 'zh-TW': '指南' },
+					label: 'Learn',
+					translations: { ja: '学ぶ', 'zh-TW': '學習' },
 					items: [
+						{ label: 'What is MDI?', translations: { ja: 'MDI とは？', 'zh-TW': '什麼是 MDI？' }, slug: 'learn/what-is-mdi' },
+						{ label: 'Core concepts', translations: { ja: 'コア概念', 'zh-TW': '核心概念' }, slug: 'learn/core-concepts' },
 						{
 							label: 'Getting Started',
 							translations: { ja: 'はじめに', 'zh-TW': '快速上手' },
 							slug: 'guides/getting-started',
 						},
-						{
-							label: 'Architecture',
-							translations: { ja: 'アーキテクチャ', 'zh-TW': '架構' },
-							slug: 'guides/architecture',
-						},
-						{
-							label: 'Export Profiles',
-							translations: {
-								ja: 'エクスポート・プロファイル',
-								'zh-TW': '匯出設定檔',
-							},
-							slug: 'guides/export-profiles',
-						},
+						{ label: 'Full syntax reference', translations: { ja: '完全構文リファレンス', 'zh-TW': '完整語法參考' }, slug: 'syntax/reference' },
+					],
+				},
+				{
+					label: 'Core',
+					translations: { ja: 'コア', 'zh-TW': '核心' },
+					items: [
+						{ label: 'Rust-authoritative architecture', translations: { ja: 'Rust 主導アーキテクチャ', 'zh-TW': 'Rust 權威架構' }, slug: 'core/architecture' },
+						{ label: 'Document IR', translations: { ja: 'ドキュメント IR', 'zh-TW': '文件 IR' }, slug: 'core/document-ir' },
+						{ label: 'Diagnostics and UTF-8 source spans', translations: { ja: '診断と UTF-8 ソーススパン', 'zh-TW': '診斷與 UTF-8 原始碼 span' }, slug: 'core/diagnostics' },
+						{ label: 'Rendering model and Chromium/PDF boundary', translations: { ja: 'レンダリングと Chromium/PDF 境界', 'zh-TW': '渲染模型與 Chromium/PDF 邊界' }, slug: 'core/rendering' },
+						{ label: 'Rust Core API status', translations: { ja: 'Rust Core API の状態', 'zh-TW': 'Rust Core API 狀態' }, slug: 'core/rust-api' },
+					],
+				},
+				{
+					label: 'Bindings',
+					translations: { ja: 'バインディング', 'zh-TW': 'Bindings' },
+					items: [
+						{ label: 'JavaScript / TypeScript', translations: { ja: 'JavaScript / TypeScript', 'zh-TW': 'JavaScript / TypeScript' }, slug: 'bindings/javascript' },
+						{ label: 'Rust', translations: { ja: 'Rust', 'zh-TW': 'Rust' }, slug: 'bindings/rust' },
+						{ label: 'Python', translations: { ja: 'Python', 'zh-TW': 'Python' }, slug: 'bindings/python' },
+						{ label: 'Swift', translations: { ja: 'Swift', 'zh-TW': 'Swift' }, slug: 'bindings/swift' },
+						{ label: 'CLI', translations: { ja: 'CLI', 'zh-TW': 'CLI' }, slug: 'bindings/cli' },
+					],
+				},
+				{
+					label: 'Ecosystem',
+					translations: { ja: 'エコシステム', 'zh-TW': '生態系' },
+					items: [
+						{ label: 'Remark / mdast adapter', translations: { ja: 'Remark / mdast アダプター', 'zh-TW': 'Remark / mdast adapter' }, slug: 'ecosystem/remark' },
+						{ label: 'Export profiles', translations: { ja: 'エクスポート・プロファイル', 'zh-TW': '匯出設定檔' }, slug: 'ecosystem/export-profiles' },
+						{ label: 'HTML / TXT / EPUB / DOCX / PDF outputs', translations: { ja: 'HTML / TXT / EPUB / DOCX / PDF 出力', 'zh-TW': 'HTML / TXT / EPUB / DOCX / PDF 輸出' }, slug: 'ecosystem/outputs' },
+						{ label: 'Migration and compatibility', translations: { ja: '移行と互換性', 'zh-TW': '遷移與相容性' }, slug: 'ecosystem/compatibility' },
 					],
 				},
 				{

--- a/nodejs/docs/src/content/docs/bindings/cli.md
+++ b/nodejs/docs/src/content/docs/bindings/cli.md
@@ -1,0 +1,24 @@
+---
+title: CLI
+description: The currently shipped mdi build command and its real output formats.
+---
+
+The CLI package is `@illusions-lab/mdi-cli`. Install it with `npm install --global @illusions-lab/mdi-cli`.
+
+The implemented command shape is:
+
+```text
+mdi build <input.mdi> --to html|pdf|epub|docx|txt|txt-ruby|narou|kakuyomu|aozora|txt-all [--config export.json] [-o <output>]
+```
+
+Examples:
+
+```bash
+mdi build novel.mdi --to html
+mdi build novel.mdi --to pdf --config novel.export.json -o dist/novel.pdf
+mdi build novel.mdi --to txt-all
+```
+
+`txt-all` writes all text variants beside the input and does not accept `-o`. The current CLI implementation reads through its remark/micromark pipeline and calls the existing Node output packages. The intended future boundary is a thin CLI over Rust; the current implementation should not be read as a competing grammar authority.
+
+There is no separate `help` or `version` command in the current `cli.ts`; the usage line above is taken from the source.

--- a/nodejs/docs/src/content/docs/bindings/javascript.md
+++ b/nodejs/docs/src/content/docs/bindings/javascript.md
@@ -1,0 +1,22 @@
+---
+title: JavaScript / TypeScript
+description: The current typed Node/browser-facing interface and its Rust migration boundary.
+---
+
+`@illusions-lab/mdi` is the primary typed JavaScript package in this checkout. Install it with `npm install @illusions-lab/mdi`.
+
+```ts
+import { parse } from '@illusions-lab/mdi';
+
+const result = parse('第^12^話');
+console.log(result.syntaxVersion, result.irVersion);
+console.log(result.document, result.diagnostics);
+```
+
+The package checks the IR version and exposes `MdiSyntaxParseResult`, `MdiParserCapabilities`, `MdiSourceSpan`, `MdiDiagnostic`, and document/node types. Source spans are UTF-8 byte offsets.
+
+## Status boundary
+
+The WASM bridge calls the complete Rust parser. The Remark adapter also maps this Rust result into mdast, so normal CLI and renderer entry paths do not let micromark decide MDI syntax. Existing Node output packages remain JavaScript renderers over that mdast compatibility shape; their eventual Rust-native replacements are a separate renderer milestone.
+
+Use [Rust Core API status](/core/rust-api/) for implemented symbols and [Remark adapter](/ecosystem/remark/) when a unified pipeline is required.

--- a/nodejs/docs/src/content/docs/bindings/python.md
+++ b/nodejs/docs/src/content/docs/bindings/python.md
@@ -1,0 +1,12 @@
+---
+title: Python
+description: Status and expected contract for the Python binding.
+---
+
+**Planned.** The repository's [`python/README.md`](https://github.com/illusions-lab/MDI/blob/main/python/README.md) currently says the Python implementation is not yet implemented. There is no public Python API reference to install or call, so this site intentionally does not show one.
+
+## Expected contract
+
+The planned binding is expected to use PyO3 or an equivalent native bridge to call `mdi-core`. It should accept complete UTF-8 source, expose the versioned IR and diagnostics, map Rust errors/resources to idiomatic Python exceptions, and preserve UTF-8 byte spans. It must not implement a Python tokenizer or a second renderer.
+
+The exact package name, installation command, type mapping, and exception classes will be documented here when they exist.

--- a/nodejs/docs/src/content/docs/bindings/rust.md
+++ b/nodejs/docs/src/content/docs/bindings/rust.md
@@ -1,0 +1,18 @@
+---
+title: Rust
+description: Native access to mdi-core and the boundary between current APIs and Planned renderer contracts.
+---
+
+`mdi-core` is the executable syntax authority. In this checkout it is a Cargo crate with native and WASM-oriented crate types.
+
+```rust
+use mdi_core::{parse_document, parse_output};
+
+let document = parse_document("第^12^話");
+let output = parse_output("第^12^話");
+assert_eq!(output.syntax_version, "2.0");
+```
+
+The current public parser surface is listed on [Rust Core API status](/core/rust-api/). `parse_mdi_syntax` is a transitional compatibility helper; prefer `parse_document` or `parse_output` for new work.
+
+Native Rust APIs for the final validation, normalization, serialization, and renderer contract are Planned in the current source. Do not infer those functions from the architecture diagram.

--- a/nodejs/docs/src/content/docs/bindings/swift.md
+++ b/nodejs/docs/src/content/docs/bindings/swift.md
@@ -1,0 +1,12 @@
+---
+title: Swift
+description: Status and expected contract for the Swift binding.
+---
+
+**Planned.** The repository's [`swift/README.md`](https://github.com/illusions-lab/MDI/blob/main/swift/README.md) currently says the Swift implementation is not yet implemented. There is no Swift package, XCFramework, or generated API reference to document yet.
+
+## Expected contract
+
+The planned binding is expected to use UniFFI or a small C ABI around `mdi-core`. It should expose the same syntax/IR versions, document nodes, diagnostics, and UTF-8 byte spans as the other bindings, with Swift-native value types and error handling. It must not own grammar or renderer semantics.
+
+Installation, module names, type mapping, and resource-error behavior will be added once the binding is implemented.

--- a/nodejs/docs/src/content/docs/core/architecture.md
+++ b/nodejs/docs/src/content/docs/core/architecture.md
@@ -1,0 +1,22 @@
+---
+title: Rust-authoritative architecture
+description: One executable grammar, one versioned IR, and thin host-language interfaces.
+---
+
+MDI has two complementary authorities: `SYNTAX.md` is the normative human-readable specification, and `mdi-core` is the executable syntax/IR implementation. Shared conformance fixtures are the observable compatibility contract.
+
+```text
+.mdi source
+    ↓
+mdi-core → versioned MDI document IR → Rust-owned renderers
+    │                         ├─ JavaScript / TypeScript / WASM
+    │                         ├─ Planned Python / Swift bindings
+    │                         └─ remark / mdast adapter
+    └─ HTML + print CSS → Chromium → PDF layout
+```
+
+No binding or adapter may add grammar tables, tokenizers, literal-fallback rules, or renderer semantics. A host can convert strings, bytes, options, and object shapes only.
+
+The current Node documentation build still registers the JavaScript micromark/mdast integration so Astro can render MDI examples. This is a **temporary documentation-build implementation detail**, not a claim that JavaScript is syntax authority. The product contract remains Rust-authoritative.
+
+See the repository [ARCHITECTURE.md](https://github.com/illusions-lab/MDI/blob/main/ARCHITECTURE.md) for the complete contract.

--- a/nodejs/docs/src/content/docs/core/diagnostics.md
+++ b/nodejs/docs/src/content/docs/core/diagnostics.md
@@ -1,0 +1,19 @@
+---
+title: Diagnostics and UTF-8 source spans
+description: Stable error data that survives every MDI interface.
+---
+
+Diagnostics are part of the IR contract. A diagnostic has `severity` (`warning` or `error`), a stable `code`, a human-readable `message`, and an optional `span`.
+
+Spans are half-open byte ranges into the original UTF-8 source: `startByte` is inclusive and `endByte` is exclusive. They are not JavaScript UTF-16 offsets and must not be silently converted into character indexes.
+
+```json
+{
+  "severity": "warning",
+  "code": "MDI001",
+  "message": "example diagnostic",
+  "span": { "startByte": 10, "endByte": 16 }
+}
+```
+
+The parser currently emits `mdi.version.unsupported` when front matter declares a newer MDI version. Malformed syntax follows the specification's literal-fallback rules and is normally represented in the document tree rather than reported as an error. Consumers should still handle an empty diagnostics list and must not invent host-specific validation.

--- a/nodejs/docs/src/content/docs/core/document-ir.md
+++ b/nodejs/docs/src/content/docs/core/document-ir.md
@@ -1,0 +1,21 @@
+---
+title: Document IR
+description: The versioned language-neutral representation shared by MDI interfaces.
+---
+
+The Rust core exposes a binding-friendly envelope with `syntaxVersion`, `irVersion`, `capabilities`, `document`, and `diagnostics`. The current crate declares MDI `2.0` and IR `1.0`.
+
+The document contains a full-source span, optional ordered YAML front matter (including unknown keys), and tagged children. Source-backed nodes carry half-open UTF-8 byte spans. Inline MDI nodes include ruby, tate-chu-yoko, breaks, emphasis, no-break, warichu, and kerning; block markers include blank paragraphs and page breaks.
+
+```json
+{
+  "irVersion": "1.0",
+  "syntaxVersion": "2.0",
+  "document": { "span": { "startByte": 0, "endByte": 42 }, "children": [] },
+  "diagnostics": []
+}
+```
+
+This is a wire contract, not permission for a binding to infer grammar from object shapes. Unsupported IR versions must be rejected explicitly.
+
+Rust's `Document` uses mdast's tagged JSON shape for the document children while lowering MDI nodes in Rust. The compatibility `MdiSyntaxDocument`/`parse_mdi_syntax` helper is transitional; new integrations should use `parse_document` or `parse_output`.

--- a/nodejs/docs/src/content/docs/core/rendering.md
+++ b/nodejs/docs/src/content/docs/core/rendering.md
@@ -1,0 +1,20 @@
+---
+title: Rendering model and Chromium/PDF boundary
+description: Separate syntax and IR semantics from output layout.
+---
+
+Renderers consume the Rust document IR. Syntax is parsed once; a renderer never reparses source text or reconstructs MDI boundaries.
+
+| Output | Role |
+| --- | --- |
+| HTML | Semantic document plus MDI CSS |
+| TXT | Plain or publication-profile text |
+| EPUB | Reflowable XHTML, metadata, CSS, and package |
+| DOCX | OOXML document with profile-driven typography |
+| PDF | Rust-produced HTML/print CSS, then Chromium layout |
+
+Chromium is a layout engine, not an MDI parser. Rust owns the PDF operation boundary and asks Chromium to perform pagination and `printToPDF`; Chromium provides font shaping, vertical layout, ruby-related CSS, and page layout. It never decides whether source text is MDI.
+
+The currently shipped Node output packages still implement their public conversion paths over mdast/HAST and Playwright/JSZip/docx. Treat those as the current Node implementation status, not as the target Rust ownership contract. A Rust-native renderer/binding integration is Planned where it is not present in this checkout.
+
+Browser WASM cannot launch Chromium. Browser applications need a server or desktop host for PDF while parsing and non-process-bound work can run locally.

--- a/nodejs/docs/src/content/docs/core/rust-api.md
+++ b/nodejs/docs/src/content/docs/core/rust-api.md
@@ -1,0 +1,27 @@
+---
+title: Rust Core API status
+description: The public Rust API currently available in mdi-core, without speculative binding claims.
+---
+
+This page documents only symbols present in `mdi-core/src/lib.rs` today. It is a landing page rather than generated rustdoc. Automated `cargo doc` integration is Planned; until then, the source and this status page are the reliable entry points.
+
+## Implemented public surface
+
+- `MDI_SPEC_VERSION` = `"2.0"`
+- `MDI_IR_VERSION` = `"1.0"`
+- `parse_mdi_syntax(&str) -> MdiSyntaxDocument` — transitional MDI-only compatibility helper
+- `parse_document(&str) -> Document` — Rust document parser and IR construction
+- `parse_output(&str) -> ParseOutput` — versioned envelope with capabilities and diagnostics
+- `parse_json(&str) -> String` — serialized parse output
+- `parse_inlines(&str) -> Vec<Inline>` — inline parsing helper
+- `serialize_mdi(&str) -> String` / `serialize_mdi_document(&Document) -> String` — canonical MDI serialization
+- `render_html(&str) -> String` / `render_html_document(&Document) -> String` — standalone Rust HTML rendering
+- `render_text(&str) -> String` / `render_text_document(&Document) -> String` — deterministic plain-text rendering
+
+The public data types include `ParseOutput`, `ParserCapabilities`, `Diagnostic`, `DiagnosticSeverity`, `SourceSpan`, `Document`, `Frontmatter`, `FrontmatterEntry`, `MdiSyntaxDocument`, `MdiBlock`, `PagebreakVariant`, `Inline`, and `RubyReading`.
+
+## Not documented as implemented
+
+Validation diagnostics are exposed by `parse_output`; a separate validation-only API is not yet public. Rust `serialize_mdi`, `render_html`, and baseline `render_text` are available now. Export-profile-specific TXT, EPUB, DOCX, and Chromium-controlled PDF APIs remain Planned.
+
+See [Bindings: Rust](/bindings/rust/) for usage and [ARCHITECTURE.md](https://github.com/illusions-lab/MDI/blob/main/ARCHITECTURE.md) for the intended contract.

--- a/nodejs/docs/src/content/docs/ecosystem/compatibility.md
+++ b/nodejs/docs/src/content/docs/ecosystem/compatibility.md
@@ -1,0 +1,17 @@
+---
+title: Migration and compatibility
+description: How to move from transitional JavaScript helpers toward the Rust-authoritative contract.
+---
+
+MDI 2.0 syntax is specified in one place: [`SYNTAX.md`](https://github.com/illusions-lab/MDI/blob/main/SYNTAX.md). Package versions use the `2.0.x` line for releases implementing that specification.
+
+## Current migration notes
+
+- Prefer `parse` from `@illusions-lab/mdi` over the deprecated `parseMdiSyntax` alias.
+- Prefer Rust `parse_document` or `parse_output` over the transitional `parse_mdi_syntax` helper for new native integrations.
+- Treat `irVersion` as a wire-protocol version and reject versions a consumer does not support.
+- Preserve UTF-8 byte spans; do not reinterpret them as host-language character indexes.
+- Use remark only when unified plugins are needed; it is an adapter, not a grammar owner.
+- Python and Swift are Planned and have no API reference yet.
+
+The current docs build uses the JavaScript micromark integration to render site examples. This is an implementation detail of building the website and does not change the architecture described above.

--- a/nodejs/docs/src/content/docs/ecosystem/export-profiles.md
+++ b/nodejs/docs/src/content/docs/ecosystem/export-profiles.md
@@ -1,0 +1,16 @@
+---
+title: Export profiles
+description: Presentation settings shared by MDI output formats.
+---
+
+An export profile configures presentation; it does not change MDI syntax. The current package is `@illusions-lab/mdi-export-profile`.
+
+```json
+{
+  "metadata": { "title": "雪女", "author": "小泉八雲" },
+  "typesetting": { "writingMode": "vertical", "fontFamily": "Noto Serif JP" },
+  "pagination": { "pageSize": "A4", "charactersPerLine": 40, "linesPerPage": 34 }
+}
+```
+
+Profiles can carry metadata, writing mode, fonts, indentation, page geometry, page numbers, EPUB chapter splitting, and text-flavor settings. See the [format guide](/guides/export-profiles/) for the current TypeScript package examples.

--- a/nodejs/docs/src/content/docs/ecosystem/outputs.md
+++ b/nodejs/docs/src/content/docs/ecosystem/outputs.md
@@ -1,0 +1,16 @@
+---
+title: HTML / TXT / EPUB / DOCX / PDF outputs
+description: What each output means and where layout responsibility sits.
+---
+
+All outputs should be viewed as transformations of one MDI IR. Output formatting is not a second syntax layer.
+
+| Format | Current Node package | Output boundary |
+| --- | --- | --- |
+| HTML | `@illusions-lab/mdi-to-html` | HTML document and MDI stylesheet |
+| TXT | `@illusions-lab/mdi-cli` text formats | Plain, ruby-preserving, Narou, Kakuyomu, Aozora |
+| EPUB | `@illusions-lab/mdi-to-epub` | EPUB 3 package with reflowable XHTML |
+| DOCX | `@illusions-lab/mdi-to-docx` | OOXML document |
+| PDF | `@illusions-lab/mdi-to-pdf` | HTML/print CSS laid out by headless Chromium |
+
+The current packages are TypeScript implementations over the existing mdast/HAST layer. Rust-native renderer APIs are part of the product contract but are Planned where the current crate does not expose them. Chromium never parses MDI; it only lays out the HTML/CSS it receives.

--- a/nodejs/docs/src/content/docs/ecosystem/remark.md
+++ b/nodejs/docs/src/content/docs/ecosystem/remark.md
@@ -1,0 +1,14 @@
+---
+title: Remark / mdast adapter
+description: Connect MDI's shared document model to unified without making remark the grammar authority.
+---
+
+Remark is an ecosystem adapter, not the MDI syntax authority. It exists for applications that need unified plugins and mdast-shaped data.
+
+```text
+complete source → Rust-owned parse/IR → mdast ⇄ unified plugins
+```
+
+The adapter parses by sending the complete source to `@illusions-lab/mdi`, then maps the returned Rust IR to mdast. `remark-gfm` and `remark-frontmatter` are retained only for mdast serialization handlers; their parser hooks are not used.
+
+`@illusions-lab/mdi-remark` does not register a micromark MDI tokenizer or an mdast MDI parser. It is a one-way compatibility adapter today: conversion of an edited mdast tree back into canonical MDI awaits the Rust serializer API.

--- a/nodejs/docs/src/content/docs/ja/bindings/cli.md
+++ b/nodejs/docs/src/content/docs/ja/bindings/cli.md
@@ -1,0 +1,12 @@
+---
+title: CLI
+description: 現在実装されている mdi build コマンド。
+---
+
+`npm install --global @illusions-lab/mdi-cli` でインストールします。
+
+```text
+mdi build <input.mdi> --to html|pdf|epub|docx|txt|txt-ruby|narou|kakuyomu|aozora|txt-all [--config export.json] [-o <output>]
+```
+
+現在の CLI は remark/micromark と既存の Node 出力 package を使います。Rust を薄く呼び出す将来の境界は Planned であり、CLI は独自の構文権威ではありません。個別の `help` / `version` command は現在の source にありません。

--- a/nodejs/docs/src/content/docs/ja/bindings/javascript.md
+++ b/nodejs/docs/src/content/docs/ja/bindings/javascript.md
@@ -1,0 +1,14 @@
+---
+title: JavaScript / TypeScript
+description: 現在の型付き JavaScript インターフェース。
+---
+
+`@illusions-lab/mdi` を `npm install @illusions-lab/mdi` でインストールし、完全なソースを `parse` に渡します。
+
+```ts
+import { parse } from '@illusions-lab/mdi';
+const result = parse('第^12^話');
+console.log(result.document, result.diagnostics);
+```
+
+IR version と UTF-8 byte span を保持します。remark/micromark と CLI の既存 TypeScript 経路は互換性のため残っていますが、独立した構文権威ではありません。

--- a/nodejs/docs/src/content/docs/ja/bindings/python.md
+++ b/nodejs/docs/src/content/docs/ja/bindings/python.md
@@ -1,0 +1,8 @@
+---
+title: Python
+description: Python binding の状態と予定契約。
+---
+
+**Planned。** リポジトリの `python/README.md` は未実装と記載しています。インストール可能な package や公開 API はまだないため、架空の API reference は提供しません。
+
+将来は PyO3 等で `mdi-core` を呼び出し、同じ IR、診断、UTF-8 byte span、例外契約を公開する予定です。Python 側に tokenizer は置きません。

--- a/nodejs/docs/src/content/docs/ja/bindings/rust.md
+++ b/nodejs/docs/src/content/docs/ja/bindings/rust.md
@@ -1,0 +1,14 @@
+---
+title: Rust
+description: mdi-core のネイティブ API。
+---
+
+`mdi-core` は MDI 構文の実行可能な権威です。
+
+```rust
+use mdi_core::{parse_document, parse_output};
+let document = parse_document("第^12^話");
+let output = parse_output("第^12^話");
+```
+
+現在の API は[Core API の状態](/ja/core/rust-api/)に記載しています。最終的な renderer API は Planned です。

--- a/nodejs/docs/src/content/docs/ja/bindings/swift.md
+++ b/nodejs/docs/src/content/docs/ja/bindings/swift.md
@@ -1,0 +1,8 @@
+---
+title: Swift
+description: Swift binding の状態と予定契約。
+---
+
+**Planned。** `swift/README.md` は未実装と記載しています。Swift package、XCFramework、生成 API reference はまだありません。
+
+将来は UniFFI または小さな C ABI で `mdi-core` を呼び出し、同じ IR と診断を Swift の値型へ写像する予定です。

--- a/nodejs/docs/src/content/docs/ja/core/architecture.md
+++ b/nodejs/docs/src/content/docs/ja/core/architecture.md
@@ -1,0 +1,13 @@
+---
+title: Rust 主導アーキテクチャ
+description: 一つの実行可能な構文、バージョン付き IR、薄いインターフェース。
+---
+
+`SYNTAX.md` は人間向けの規範、`mdi-core` は実行可能な構文と IR の実装です。各バインディングと adapter は、構文規則や renderer の意味を持ちません。
+
+```text
+.mdi → mdi-core → versioned document IR → bindings / adapters / renderers
+                                      └→ HTML + print CSS → Chromium → PDF
+```
+
+Astro のドキュメントビルドでは MDI 例を表示するため JavaScript の micromark/mdast 統合を登録しています。これは一時的なビルド実装であり、JavaScript が構文の権威だという意味ではありません。

--- a/nodejs/docs/src/content/docs/ja/core/diagnostics.md
+++ b/nodejs/docs/src/content/docs/ja/core/diagnostics.md
@@ -1,0 +1,8 @@
+---
+title: 診断と UTF-8 ソーススパン
+description: すべての MDI インターフェースで保持する診断データです。
+---
+
+診断は `severity`、安定した `code`、`message`、任意の `span` を持ちます。span は元の UTF-8 ソースに対する半開 byte 範囲であり、JavaScript の UTF-16 index ではありません。
+
+現在の移行中 Rust parser は診断フィールドを wire contract に保持しますが、通常の不正入力に対する診断をまだ出力しません。利用側は空の配列を含め、将来の安定した code を受け取れるようにしてください。

--- a/nodejs/docs/src/content/docs/ja/core/document-ir.md
+++ b/nodejs/docs/src/content/docs/ja/core/document-ir.md
@@ -1,0 +1,10 @@
+---
+title: ドキュメント IR
+description: 言語に依存しない、バージョン付きの MDI 表現です。
+---
+
+IR は `syntaxVersion`、`irVersion`、`capabilities`、`document`、`diagnostics` を含みます。現在の Rust crate は MDI `2.0` と IR `1.0` を宣言します。
+
+文書にはフロントマター、タグ付きの子ノード、元の UTF-8 ソースに対する半開 byte span が含まれます。バインディングはこの wire shape を各言語の型へ写像し、未知の IR バージョンを推測で受け入れてはいけません。
+
+互換用の `parse_mdi_syntax` は移行用です。新しい統合では `parse_document` または `parse_output` を使用します。

--- a/nodejs/docs/src/content/docs/ja/core/rendering.md
+++ b/nodejs/docs/src/content/docs/ja/core/rendering.md
@@ -1,0 +1,8 @@
+---
+title: レンダリングと Chromium/PDF 境界
+description: 構文・IR の意味と出力レイアウトを分離します。
+---
+
+HTML、TXT、EPUB、DOCX、PDF は同じ IR から生成されます。Chromium は MDI を解析せず、Rust が生成した HTML と print CSS をレイアウトし、`printToPDF` を実行するだけです。
+
+現在の Node 出力パッケージは mdast/HAST と Playwright、JSZip、docx を使う実装です。Rust-native renderer API は、crate に存在しない部分については Planned です。

--- a/nodejs/docs/src/content/docs/ja/core/rust-api.md
+++ b/nodejs/docs/src/content/docs/ja/core/rust-api.md
@@ -1,0 +1,10 @@
+---
+title: Rust Core API の状態
+description: 現在の mdi-core 公開 API と未実装の契約。
+---
+
+このページは `mdi-core/src/lib.rs` に現在存在する公開 API だけを記載します。自動 rustdoc のサイト統合は Planned です。
+
+実装済みの主な関数は `parse_mdi_syntax`（移行用）、`parse_document`、`parse_output`、`parse_json`、`parse_inlines` です。`MDI_SPEC_VERSION` は `2.0`、`MDI_IR_VERSION` は `1.0` です。
+
+最終的な validate、normalize、serialize、Rust-native renderer 関数は現在の crate にないため、実装済み API としては扱いません。

--- a/nodejs/docs/src/content/docs/ja/ecosystem/compatibility.md
+++ b/nodejs/docs/src/content/docs/ja/ecosystem/compatibility.md
@@ -1,0 +1,8 @@
+---
+title: 移行と互換性
+description: Rust 主導契約へ移行する際の注意点。
+---
+
+MDI 2.0 の規範は [`SYNTAX.md`](https://github.com/illusions-lab/MDI/blob/main/SYNTAX.md) 一つです。新しい JavaScript 統合では `parseMdiSyntax` より `parse`、Rust では `parse_mdi_syntax` より `parse_document` または `parse_output` を優先します。
+
+IR version を検査し、UTF-8 byte span を保持してください。Python と Swift は Planned で、API reference はまだありません。サイトビルドの JavaScript parser 登録は一時的な実装詳細です。

--- a/nodejs/docs/src/content/docs/ja/ecosystem/export-profiles.md
+++ b/nodejs/docs/src/content/docs/ja/ecosystem/export-profiles.md
@@ -1,0 +1,12 @@
+---
+title: エクスポート・プロファイル
+description: 出力形式で共有する表示設定。
+---
+
+Export profile は metadata、writing mode、font、margin、page size、page number、EPUB 分割、text flavor を設定します。構文を変更するものではありません。
+
+```json
+{ "typesetting": { "writingMode": "vertical" }, "pagination": { "pageSize": "A4" } }
+```
+
+[既存のガイド](/ja/guides/export-profiles/)には現在の TypeScript package の例があります。

--- a/nodejs/docs/src/content/docs/ja/ecosystem/outputs.md
+++ b/nodejs/docs/src/content/docs/ja/ecosystem/outputs.md
@@ -1,0 +1,6 @@
+---
+title: HTML / TXT / EPUB / DOCX / PDF 出力
+description: 各出力形式とレイアウト境界。
+---
+
+すべての出力は同じ MDI IR の変換です。現在の Node package は mdast/HAST 層で実装されています。PDF の Chromium は HTML/print CSS をレイアウトするだけで、MDI を解析しません。Rust-native renderer は未公開の部分では Planned です。

--- a/nodejs/docs/src/content/docs/ja/ecosystem/remark.md
+++ b/nodejs/docs/src/content/docs/ja/ecosystem/remark.md
@@ -1,0 +1,8 @@
+---
+title: Remark / mdast アダプター
+description: remark は MDI 構文の権威ではありません。
+---
+
+Remark は unified plugin と mdast が必要な場合の adapter です。理想的な境界は `source → Rust IR → mdast ⇄ unified plugins` です。remark 自身が MDI tokenizer、grammar、fallback を持つことはありません。
+
+現在の Node checkout では互換性のため micromark/mdast 統合を登録しています。これは移行中の実装詳細です。

--- a/nodejs/docs/src/content/docs/ja/learn/core-concepts.md
+++ b/nodejs/docs/src/content/docs/ja/learn/core-concepts.md
@@ -1,0 +1,13 @@
+---
+title: コア概念
+description: すべての MDI インターフェースが共有する概念です。
+---
+
+MDI は、構文、バージョン付き文書 IR、診断、レンダリング出力の 3 層で考えます。バインディングは型名を各言語に合わせても、意味を変更しません。
+
+- 完全な UTF-8 ソースは Rust コアへ渡します。
+- IR には構文バージョン、IR バージョン、ノード、フロントマター、ソーススパンが含まれます。
+- 診断は severity、安定した code、message、UTF-8 byte span を持ちます。
+- Export profile は表示設定であり、構文を変更しません。
+
+[Document IR](/ja/core/document-ir/)、[診断](/ja/core/diagnostics/)、[レンダリング](/ja/core/rendering/)へ進んでください。

--- a/nodejs/docs/src/content/docs/ja/learn/what-is-mdi.md
+++ b/nodejs/docs/src/content/docs/ja/learn/what-is-mdi.md
@@ -1,0 +1,20 @@
+---
+title: MDI とは？
+description: Rust を唯一の構文実装とする、日本語組版向け Markdown 拡張です。
+---
+
+MDI（illusion Markdown）は、標準 Markdown にルビ、縦書き、縦中横、傍点、割注、改ページなどの日本語組版機能を加えた形式です。
+
+構文と文書の意味は `mdi-core` が決定します。`SYNTAX.md` は規範的な仕様書であり、JavaScript、Python、Swift、CLI、remark はその契約を利用する薄いインターフェースです。
+
+```mdi
+---
+mdi: "2.0"
+title: 雪女
+writing-mode: vertical
+---
+
+{雪女|ゆきおんな}が第^12^話に現れた。
+```
+
+構文、概念、出力を分けて学ぶには、[コア概念](/ja/learn/core-concepts/)と[完全構文リファレンス](/ja/syntax/reference/)を参照してください。

--- a/nodejs/docs/src/content/docs/ja/syntax/reference.md
+++ b/nodejs/docs/src/content/docs/ja/syntax/reference.md
@@ -1,0 +1,20 @@
+---
+title: 完全構文リファレンス
+description: MDI 2.0 の規範的な構文仕様への入口です。
+---
+
+完全な規範はリポジトリの [`SYNTAX.md`](https://github.com/illusions-lab/MDI/blob/main/SYNTAX.md) に一つだけ維持しています。このページはサイトの入口とクイックリファレンスです。
+
+| 機能 | 推奨記法 | 意味 |
+| --- | --- | --- |
+| ルビ | `{base|reading}` | 親文字に読みを付ける |
+| 縦中横 | `^12^` | 縦書き内の短い横組み |
+| 傍点 | `[[em:text]]` | 強調点を付ける |
+| 改行抑止 | `[[no-break:text]]` | 句の途中で改行しない |
+| 改ページ | `[[pagebreak]]` | 新しいページを開始する |
+
+```markdown
+{東京|とうきょう}の第^12^話。[[em:重要]]な語です。[[br]]次の行。
+```
+
+正確な境界、入れ子、エスケープ、フォールバックは[完全な `SYNTAX.md`](https://github.com/illusions-lab/MDI/blob/main/SYNTAX.md)だけを参照してください。[ショーケース](/ja/syntax/showcase/)は出力例であり、構文の権威ではありません。

--- a/nodejs/docs/src/content/docs/learn/core-concepts.md
+++ b/nodejs/docs/src/content/docs/learn/core-concepts.md
@@ -1,0 +1,26 @@
+---
+title: Core concepts
+description: The shared concepts that every MDI language interface must preserve.
+---
+
+MDI has one shared vocabulary across languages. A host package may rename a function idiomatically, but it must preserve the same source, IR, diagnostic, and rendering semantics.
+
+## Source and grammar
+
+`mdi-core` receives the complete UTF-8 document. MDI boundaries depend on Markdown context, so an implementation must not tokenize isolated fragments or let a host parser decide whether `^12^` or `[[em:...]]` is syntax.
+
+## Document IR
+
+The IR carries syntax and IR versions, front matter, tagged document nodes, and source spans. Bindings map this wire shape to native objects; Rust enum names are not a second language-level specification. See [Document IR](/core/document-ir/).
+
+## Diagnostics
+
+Recoverable problems are data: severity, stable code, message, and an optional half-open UTF-8 byte span. See [Diagnostics](/core/diagnostics/).
+
+## Profiles and output
+
+An export profile controls presentation such as page size, writing mode, fonts, margins, metadata, and text flavor. It does not alter grammar. Renderers consume the IR; [Chromium only performs PDF layout](/core/rendering/).
+
+## Thin interfaces
+
+JavaScript/TypeScript is the currently usable package surface. Python and Swift are Planned bindings. Remark is an adapter to mdast, not an MDI parser.

--- a/nodejs/docs/src/content/docs/learn/what-is-mdi.md
+++ b/nodejs/docs/src/content/docs/learn/what-is-mdi.md
@@ -1,0 +1,32 @@
+---
+title: What is MDI?
+description: MDI is a Markdown-based format for Japanese typography with one Rust-owned grammar.
+---
+
+MDI (illusion Markdown) is a Markdown extension for Japanese typography: ruby, vertical writing, tate-chu-yoko, emphasis dots, warichu, page breaks, and related document features.
+
+The important product boundary is ownership: `mdi-core` is the executable authority for MDI syntax and document meaning. `SYNTAX.md` is the normative human-readable specification. JavaScript, Python, Swift, CLI, editors, and ecosystem adapters are interfaces around that contract.
+
+## A small document
+
+```mdi
+---
+mdi: "2.0"
+title: 雪女
+writing-mode: vertical
+---
+
+# 第一章
+
+{雪女|ゆきおんな}が第^12^話に現れた。[[em:決して]]忘れない。
+```
+
+The source is still Markdown. MDI constructs are meaningful only where the syntax specification permits them; code spans and fenced code keep MDI-looking text literal.
+
+## Three layers
+
+1. **Syntax**: the source notation and its boundary/fallback rules.
+2. **Concepts and IR**: the versioned, language-neutral document tree and diagnostics.
+3. **Rendering output**: deterministic transformations from the IR to HTML, text, EPUB, DOCX, and PDF.
+
+Start with [Core concepts](/learn/core-concepts/) and then read the [full syntax reference](/syntax/reference/).

--- a/nodejs/docs/src/content/docs/syntax/reference.md
+++ b/nodejs/docs/src/content/docs/syntax/reference.md
@@ -1,0 +1,48 @@
+---
+title: Full syntax reference
+description: The complete MDI 2.0 syntax contract, with a readable quick reference and canonical source.
+---
+
+This page is the website entry point for the complete MDI 2.0 syntax. The normative reference is maintained as [`SYNTAX.md`](https://github.com/illusions-lab/MDI/blob/main/SYNTAX.md) in the repository so the specification has one source and cannot drift between locales or generated site copies.
+
+## Quick reference
+
+| Feature | Recommended form | Meaning |
+| --- | --- | --- |
+| Front matter | YAML between `---` markers | Document metadata and writing mode |
+| Ruby | `{base|reading}` | Reading attached to a base string |
+| Tate-chu-yoko | `^12^` | Short horizontal run in vertical text |
+| Boten | `[[em:text]]` | Emphasis dots; `[[em:○:text]]` selects a mark |
+| No-break | `[[no-break:text]]` | Keep a phrase together |
+| Line break | `[[br]]` | Explicit break inside a paragraph |
+| Blank paragraph | `[[blank]]` | Preserve an empty paragraph |
+| Warichu | `[[warichu:text]]` | Inline split annotation |
+| Kerning | `[[kern:-0.1em:text]]` | Explicit character spacing |
+| Block alignment | `[[align:center]]` etc. | Align a block |
+| Page break | `[[pagebreak]]` | Start a new page |
+| Footnotes | Markdown footnote syntax | Define and reference notes |
+| Escapes | `\^`, `\[`, `\{` and documented CJK escapes | Keep delimiters literal |
+
+## Read the specification by concern
+
+- **Syntax**: delimiters, nesting, grapheme counting, escaping, fallback, and parsing order are defined only by `SYNTAX.md`.
+- **Concepts**: the resulting document tree and diagnostics are described in [Document IR](/core/document-ir/) and [Diagnostics](/core/diagnostics/).
+- **Rendering output**: HTML/CSS examples in the specification describe an output contract, not another parser. See [outputs](/ecosystem/outputs/).
+
+## A copyable example
+
+```markdown
+---
+mdi: "2.0"
+title: サンプル
+lang: ja
+writing-mode: vertical
+---
+
+# 章題
+
+{東京|とうきょう}の第^12^話。[[em:○:重要]]な語を
+[[no-break:ひとまとまり]]として扱う。[[br]]次の行。
+```
+
+For every edge case and the exact normative wording, use the [complete `SYNTAX.md` reference](https://github.com/illusions-lab/MDI/blob/main/SYNTAX.md). The [live showcase](/syntax/showcase/) is illustrative output, not the grammar authority.

--- a/nodejs/docs/src/content/docs/zh-tw/bindings/cli.md
+++ b/nodejs/docs/src/content/docs/zh-tw/bindings/cli.md
@@ -1,0 +1,12 @@
+---
+title: CLI
+description: 目前實作的 mdi build 指令。
+---
+
+以 `npm install --global @illusions-lab/mdi-cli` 安裝。
+
+```text
+mdi build <input.mdi> --to html|pdf|epub|docx|txt|txt-ruby|narou|kakuyomu|aozora|txt-all [--config export.json] [-o <output>]
+```
+
+目前 CLI 使用 remark/micromark 與既有 Node 輸出 package。未來以 Rust 為後端的薄 CLI 邊界是 Planned；CLI 不是獨立語法權威。目前 source 沒有獨立的 `help` / `version` command。

--- a/nodejs/docs/src/content/docs/zh-tw/bindings/javascript.md
+++ b/nodejs/docs/src/content/docs/zh-tw/bindings/javascript.md
@@ -1,0 +1,14 @@
+---
+title: JavaScript / TypeScript
+description: 目前的型別化 JavaScript 接口。
+---
+
+以 `npm install @illusions-lab/mdi` 安裝，將完整 source 傳給 `parse`：
+
+```ts
+import { parse } from '@illusions-lab/mdi';
+const result = parse('第^12^話');
+console.log(result.document, result.diagnostics);
+```
+
+接口保留 IR version 與 UTF-8 byte span。Remark adapter 也使用這個 Rust 結果映射 mdast，因此一般 CLI 與 renderer 的入口不讓 micromark 決定 MDI 語法。既有 Node output package 仍是消費該 mdast 相容形狀的 JavaScript renderer；Rust-native renderer 是另一個里程碑。

--- a/nodejs/docs/src/content/docs/zh-tw/bindings/python.md
+++ b/nodejs/docs/src/content/docs/zh-tw/bindings/python.md
@@ -1,0 +1,8 @@
+---
+title: Python
+description: Python binding 的狀態與預期契約。
+---
+
+**Planned。** repository 的 `python/README.md` 明確寫著尚未實作。目前沒有可安裝的 package 或公開 API，因此本網站不建立虛假的 API reference。
+
+預期 binding 會透過 PyO3 等方式呼叫 `mdi-core`，保留相同的 IR、診斷、UTF-8 byte span 與例外契約；Python 不會自行實作 tokenizer。

--- a/nodejs/docs/src/content/docs/zh-tw/bindings/rust.md
+++ b/nodejs/docs/src/content/docs/zh-tw/bindings/rust.md
@@ -1,0 +1,14 @@
+---
+title: Rust
+description: mdi-core 的原生 API。
+---
+
+`mdi-core` 是 MDI 語法的可執行權威。
+
+```rust
+use mdi_core::{parse_document, parse_output};
+let document = parse_document("第^12^話");
+let output = parse_output("第^12^話");
+```
+
+目前 API 請看[Rust Core API 狀態](/zh-tw/core/rust-api/)。最終 renderer API 尚為 Planned。

--- a/nodejs/docs/src/content/docs/zh-tw/bindings/swift.md
+++ b/nodejs/docs/src/content/docs/zh-tw/bindings/swift.md
@@ -1,0 +1,8 @@
+---
+title: Swift
+description: Swift binding 的狀態與預期契約。
+---
+
+**Planned。** `swift/README.md` 明確寫著尚未實作。目前沒有 Swift package、XCFramework 或生成的 API reference。
+
+預期會透過 UniFFI 或小型 C ABI 呼叫 `mdi-core`，把相同 IR 與診斷映射成 Swift value types。

--- a/nodejs/docs/src/content/docs/zh-tw/core/architecture.md
+++ b/nodejs/docs/src/content/docs/zh-tw/core/architecture.md
@@ -1,0 +1,13 @@
+---
+title: Rust 權威架構
+description: 單一可執行語法、版本化 IR 與薄接口。
+---
+
+`SYNTAX.md` 是人類可讀的規範，`mdi-core` 是可執行的語法與 IR 實作。所有 binding 與 adapter 都不得持有語法規則或 renderer 意義。
+
+```text
+.mdi → mdi-core → versioned document IR → bindings / adapters / renderers
+                                      └→ HTML + print CSS → Chromium → PDF
+```
+
+Astro 文件建置目前註冊 JavaScript micromark/mdast 整合以顯示 MDI 範例；這是暫時的文件建置實作，不代表 JavaScript 是語法權威。

--- a/nodejs/docs/src/content/docs/zh-tw/core/diagnostics.md
+++ b/nodejs/docs/src/content/docs/zh-tw/core/diagnostics.md
@@ -1,0 +1,8 @@
+---
+title: 診斷與 UTF-8 原始碼 span
+description: 所有 MDI 接口都必須保留的診斷資料。
+---
+
+診斷包含 `severity`、穩定的 `code`、`message` 與可選的 `span`。span 是原始 UTF-8 source 的半開 byte 範圍，不是 JavaScript UTF-16 index。
+
+front matter 宣告比支援版本更新的 MDI 時，parser 會輸出 `mdi.version.unsupported`。其他 malformed syntax 依規格採 literal fallback，通常直接呈現在文件樹而不是報錯。使用端仍應處理空 diagnostics，且不得自行加入 host-specific validation。

--- a/nodejs/docs/src/content/docs/zh-tw/core/document-ir.md
+++ b/nodejs/docs/src/content/docs/zh-tw/core/document-ir.md
@@ -1,0 +1,10 @@
+---
+title: 文件 IR
+description: 各語言接口共享的版本化、中立表示。
+---
+
+IR 包含 `syntaxVersion`、`irVersion`、`capabilities`、`document` 與 `diagnostics`。目前 Rust crate 宣告 MDI `2.0` 與 IR `1.0`。
+
+文件包含 front matter、tagged children 與原始 UTF-8 source 的半開 byte span。binding 應映射 wire shape，不應猜測未知 IR version 的意義。
+
+`parse_mdi_syntax` 是過渡相容 helper；新的整合應使用 `parse_document` 或 `parse_output`。

--- a/nodejs/docs/src/content/docs/zh-tw/core/rendering.md
+++ b/nodejs/docs/src/content/docs/zh-tw/core/rendering.md
@@ -1,0 +1,8 @@
+---
+title: 渲染模型與 Chromium/PDF 邊界
+description: 分離語法與 IR 意義和輸出排版。
+---
+
+HTML、TXT、EPUB、DOCX、PDF 都從同一份 IR 轉換。Chromium 不解析 MDI，只負責 Rust 產生的 HTML 與 print CSS 的排版和 `printToPDF`。
+
+目前 Node 輸出 package 使用 mdast/HAST、Playwright、JSZip 與 docx。Rust-native renderer API 在目前 crate 尚未提供的部分均為 Planned。

--- a/nodejs/docs/src/content/docs/zh-tw/core/rust-api.md
+++ b/nodejs/docs/src/content/docs/zh-tw/core/rust-api.md
@@ -1,0 +1,10 @@
+---
+title: Rust Core API 狀態
+description: mdi-core 目前公開的 API 與尚未完成的契約。
+---
+
+本頁只記錄 `mdi-core/src/lib.rs` 目前存在的公開 API。自動 rustdoc 整合是 Planned。
+
+目前主要函式包括 `parse_mdi_syntax`（過渡 helper）、`parse_document`、`parse_output`、`parse_json`、`parse_inlines`、`serialize_mdi`、`serialize_mdi_document`、`render_html`、`render_html_document`、`render_text` 與 `render_text_document`；`MDI_SPEC_VERSION` 為 `2.0`，`MDI_IR_VERSION` 為 `1.0`。
+
+`parse_output` 提供 validation diagnostics；獨立 validate API 尚未公開。Rust 的 MDI serializer、HTML renderer 與 baseline plain-text renderer 已可使用；export-profile-specific TXT、EPUB、DOCX 及 Rust 控制 Chromium 的 PDF API 仍是 Planned。

--- a/nodejs/docs/src/content/docs/zh-tw/ecosystem/compatibility.md
+++ b/nodejs/docs/src/content/docs/zh-tw/ecosystem/compatibility.md
@@ -1,0 +1,8 @@
+---
+title: 遷移與相容性
+description: 移向 Rust 權威契約時的注意事項。
+---
+
+MDI 2.0 規範只有一份：[`SYNTAX.md`](https://github.com/illusions-lab/MDI/blob/main/SYNTAX.md)。新的 JavaScript 整合優先用 `parse`，Rust 優先用 `parse_document` 或 `parse_output`。
+
+請檢查 IR version、保留 UTF-8 byte span，只有需要 unified plugin 時才使用 remark。Python 與 Swift 尚為 Planned。文件站建置中的 JavaScript parser 註冊只是暫時實作細節。

--- a/nodejs/docs/src/content/docs/zh-tw/ecosystem/export-profiles.md
+++ b/nodejs/docs/src/content/docs/zh-tw/ecosystem/export-profiles.md
@@ -1,0 +1,12 @@
+---
+title: 匯出設定檔
+description: 各輸出格式共享的呈現設定。
+---
+
+Export profile 可設定 metadata、writing mode、font、margin、page size、page number、EPUB 分章與 text flavor，但不改變語法。
+
+```json
+{ "typesetting": { "writingMode": "vertical" }, "pagination": { "pageSize": "A4" } }
+```
+
+目前 TypeScript package 的範例請看[既有指南](/zh-tw/guides/export-profiles/)。

--- a/nodejs/docs/src/content/docs/zh-tw/ecosystem/outputs.md
+++ b/nodejs/docs/src/content/docs/zh-tw/ecosystem/outputs.md
@@ -1,0 +1,6 @@
+---
+title: HTML / TXT / EPUB / DOCX / PDF 輸出
+description: 各輸出格式與排版邊界。
+---
+
+所有輸出都是同一份 MDI IR 的轉換。現有 Node package 在 mdast/HAST 層實作；PDF 的 Chromium 只排版 HTML/print CSS，不解析 MDI。尚未由 crate 提供的 Rust-native renderer 均為 Planned。

--- a/nodejs/docs/src/content/docs/zh-tw/ecosystem/remark.md
+++ b/nodejs/docs/src/content/docs/zh-tw/ecosystem/remark.md
@@ -1,0 +1,8 @@
+---
+title: Remark / mdast adapter
+description: 將 MDI 文件模型接到 unified，但不讓 remark 成為語法權威。
+---
+
+Remark 是需要 unified plugin 與 mdast 時使用的 adapter，不是 MDI parser。它把完整 source 交給 `@illusions-lab/mdi`，再把 Rust IR 映射為 mdast。
+
+它不註冊 micromark MDI tokenizer 或 mdast MDI parser。`remark-gfm` 與 `remark-frontmatter` 只保留 mdast 序列化 handler；其 parser hook 不會被使用。由編輯後 mdast 回寫 canonical MDI 仍等待 Rust serializer API。

--- a/nodejs/docs/src/content/docs/zh-tw/learn/core-concepts.md
+++ b/nodejs/docs/src/content/docs/zh-tw/learn/core-concepts.md
@@ -1,0 +1,13 @@
+---
+title: 核心概念
+description: 所有 MDI 語言接口都必須共享的概念。
+---
+
+MDI 分成語法、版本化文件 IR、診斷與 rendering output 三層。binding 可以使用主機語言慣用的名稱，但不能改變意義。
+
+- 完整 UTF-8 原始碼交給 Rust core。
+- IR 包含 syntax version、IR version、節點、front matter 與 source spans。
+- 診斷包含 severity、穩定 code、message 與 UTF-8 byte span。
+- export profile 是呈現設定，不會改變語法。
+
+請閱讀[文件 IR](/zh-tw/core/document-ir/)、[診斷](/zh-tw/core/diagnostics/)與[渲染模型](/zh-tw/core/rendering/)。

--- a/nodejs/docs/src/content/docs/zh-tw/learn/what-is-mdi.md
+++ b/nodejs/docs/src/content/docs/zh-tw/learn/what-is-mdi.md
@@ -1,0 +1,20 @@
+---
+title: 什麼是 MDI？
+description: 以 Rust 為唯一語法實作的日本語組版 Markdown 擴充格式。
+---
+
+MDI（illusion Markdown）在標準 Markdown 上加入 ruby、直排、縱中橫、傍點、割注與分頁等日本語組版功能。
+
+`mdi-core` 決定語法與文件意義；`SYNTAX.md` 是規範文件。JavaScript、Python、Swift、CLI 與 remark 都只是使用這份契約的薄接口。
+
+```mdi
+---
+mdi: "2.0"
+title: 雪女
+writing-mode: vertical
+---
+
+{雪女|ゆきおんな}が第^12^話に現れた。
+```
+
+請從[核心概念](/zh-tw/learn/core-concepts/)與[完整語法參考](/zh-tw/syntax/reference/)開始。

--- a/nodejs/docs/src/content/docs/zh-tw/syntax/reference.md
+++ b/nodejs/docs/src/content/docs/zh-tw/syntax/reference.md
@@ -1,0 +1,20 @@
+---
+title: 完整語法參考
+description: MDI 2.0 規範語法的網站入口。
+---
+
+完整規範只維護在 repository 的 [`SYNTAX.md`](https://github.com/illusions-lab/MDI/blob/main/SYNTAX.md)，避免不同 locale 產生漂移。本頁是網站入口與快速參考。
+
+| 功能 | 建議寫法 | 意義 |
+| --- | --- | --- |
+| Ruby | `{base|reading}` | 為文字附加讀音 |
+| 縱中橫 | `^12^` | 直排中的短橫排文字 |
+| 傍點 | `[[em:text]]` | 加上強調點 |
+| 禁止斷行 | `[[no-break:text]]` | 保持片語完整 |
+| 分頁 | `[[pagebreak]]` | 開始新頁 |
+
+```markdown
+{東京|とうきょう}的第^12^話。[[em:重要]]的文字。[[br]]下一行。
+```
+
+精確的邊界、巢狀、escape 與 fallback 請以[完整 `SYNTAX.md`](https://github.com/illusions-lab/MDI/blob/main/SYNTAX.md)為準。[展示頁](/zh-tw/syntax/showcase/)只是輸出示例，不是語法權威。


### PR DESCRIPTION
## Summary

- Restructure the documentation around Rust as the only executable syntax authority.
- Add Learn, Core, Bindings, and Ecosystem information architecture.
- Add English, Japanese, and Traditional Chinese locale pages.
- Document Python and Swift as Planned, and record the current Node/remark migration boundary.
- Preserve TypeDoc generation and add a hand-written Rust Core API status landing page.
- Align the homepage card grid.

## Validation

- `pnpm --dir nodejs/docs build` ✅
- 343 pages generated, including all required locale and root-relative routes.
- Root-relative link audit ✅
- `git diff --check` ✅
