### PR TITLE
Fix wasm build in release CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,8 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: jetli/wasm-pack-action@v0.4.0
+
       - uses: pnpm/action-setup@v4
         with:
           version: 9.15.0


### PR DESCRIPTION
Adds the missing wasm-pack setup to the Release workflow so @illusions-lab/mdi-core can be built and published by CI.