### PR TITLE
Require successful Codecov uploads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
           files: ./nodejs/**/coverage/lcov.info
           flags: nodejs
           name: nodejs
-          fail_ci_if_error: false
+          fail_ci_if_error: true
 
   rust-native:
     name: Rust (${{ matrix.platform }})
@@ -97,4 +97,4 @@ jobs:
           files: ./mdi-core/lcov.info
           flags: rust
           name: rust
-          fail_ci_if_error: false
+          fail_ci_if_error: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,12 +31,15 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          # npm trusted publishing requires Node >= 22.14 and npm >= 11.5.1.
+          node-version: 24
           cache: pnpm
           cache-dependency-path: nodejs/pnpm-lock.yaml
           registry-url: https://registry.npmjs.org
 
       - run: pnpm install --frozen-lockfile
+
+      - run: npm install --global npm@^11.5.1
 
       - name: Calculate next patch versions
         id: versions
@@ -50,8 +53,6 @@ jobs:
         run: node scripts/publish-versioned-packages.mjs
         env:
           RELEASE_PACKAGES: ${{ steps.versions.outputs.publishedPackages }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_CONFIG_PROVENANCE: true
 
       - name: Create GitHub Releases with downloadable tarballs
         if: steps.publish.outputs.published == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,11 +41,15 @@ jobs:
       - name: Calculate next patch versions
         id: versions
         run: node scripts/compute-release-versions.mjs
+        env:
+          # A manual recovery run with no base SHA safely releases no packages.
+          RELEASE_BASE_SHA: ${{ github.event.before || github.sha }}
 
       - name: Publish next patch versions
         id: publish
         run: node scripts/publish-versioned-packages.mjs
         env:
+          RELEASE_PACKAGES: ${{ steps.versions.outputs.publishedPackages }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
 

--- a/LICENSE-SPEC
+++ b/LICENSE-SPEC
@@ -1,24 +1,21 @@
-This is free and unencumbered software released into the public domain.
+MIT License
 
-Anyone is free to copy, modify, publish, use, compile, sell, or
-distribute this software, either in source code form or as a compiled
-binary, for any purpose, commercial or non-commercial, and by any
-means.
+Copyright (c) 2026 Iktahana
 
-In jurisdictions that recognize copyright laws, the author or authors
-of this software dedicate any and all copyright interest in the
-software to the public domain. We make this dedication for the benefit
-of the public at large and to the detriment of our heirs and
-successors. We intend this dedication to be an overt act of
-relinquishment in perpetuity of all present and future rights to this
-software under copyright law.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
-OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
-ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-OTHER DEALINGS IN THE SOFTWARE.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-For more information, please refer to <https://unlicense.org>
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,77 @@
+# MDI
+
+[English](./README.md)
+
+[![codecov](https://codecov.io/github/illusions-lab/MDI/graph/badge.svg?token=J6GJZW744R)](https://codecov.io/github/illusions-lab/MDI)
+
+**illusion Markdown（MDI）** は、日本語組版のための Markdown 拡張フォーマットです。標準 Markdown を維持したまま、ルビ、縦中横、傍点、割注、縦書きなどを追加します。
+
+このリポジトリは、[MDI 2.0 仕様](./SYNTAX.md)、Rust 実装、言語バインディング、レンダラー、開発ツールの正規リポジトリです。
+
+ドキュメント：<https://mdi.illusions.app/>
+
+## アーキテクチャ
+
+Rust は MDI 構文と文書セマンティクスにおける唯一の実行可能な権威です。CommonMark、GFM、front matter、MDI 拡張をバージョン化された文書 IR に解析します。JavaScript、Python、Swift はこの実装の薄いホストインターフェースです。
+
+`mdi-core` は、解析、検証、正規化、シリアライズ、決定論的な HTML、TXT、EPUB、DOCX レンダリングを担当します。PDF は Rust が生成した HTML を使い、ホスト側の Chromium adapter は印刷レイアウトだけを担当し、MDI を解析しません。
+
+責務の規則とインターフェース契約は [ARCHITECTURE.md](./ARCHITECTURE.md) を参照してください。
+
+## リポジトリ構成
+
+| ディレクトリ | 責務 |
+| --- | --- |
+| [`mdi-core/`](./mdi-core) | Rust パーサー、バージョン化 IR、検証、シリアライズ、決定論的レンダラー。 |
+| [`nodejs/`](./nodejs) | JavaScript/WASM バインディング、生態系 adapter、CLI、ドキュメント。 |
+| [`python/`](./python) | `mdi-core` の PyO3 バインディング。 |
+| [`swift/`](./swift) | `mdi-core` の UniFFI または C ABI バインディング。 |
+
+## Node.js パッケージ
+
+| パッケージ | 用途 |
+| --- | --- |
+| [`@illusions-lab/mdi`](./nodejs/packages/mdi) | Rust を基盤とする主要な型付き JavaScript API。 |
+| [`@illusions-lab/mdi-core`](./nodejs/packages/mdi-core) | 生成された低レベル WebAssembly bridge。 |
+| [`@illusions-lab/mdi-cli`](./nodejs/packages/cli) | Rust を利用するコマンドライン adapter。 |
+| [`@illusions-lab/mdi-to-pdf`](./nodejs/packages/to-pdf) | Rust HTML を Chromium でレイアウトする adapter。 |
+| [`@illusions-lab/mdi-remark`](./nodejs/packages/remark)、[`mdast-util-mdi`](./nodejs/packages/mdast-util-mdi)、[`micromark-extension-mdi`](./nodejs/packages/micromark-extension-mdi) | Unified 生態系向け互換 adapter。 |
+| [`@illusions-lab/mdi-to-hast`](./nodejs/packages/to-hast)、[`@illusions-lab/mdi-to-html`](./nodejs/packages/to-html)、[`@illusions-lab/mdi-to-epub`](./nodejs/packages/to-epub)、[`@illusions-lab/mdi-to-docx`](./nodejs/packages/to-docx) | 既存利用者向けに残す公開互換 adapter。 |
+| [`@illusions-lab/mdi-export-profile`](./nodejs/packages/export-profile) | 共通の型付き出力 profile 設定。 |
+
+## 開発
+
+```bash
+cd nodejs
+pnpm install
+pnpm build
+pnpm test
+```
+
+```bash
+cd mdi-core
+cargo build
+cargo test
+```
+
+WASM bridge のビルドには、`wasm32-unknown-unknown` Rust target と `wasm-pack` も必要です。Node workspace の build は自動的に実行します。CI は Rust core を Linux、macOS、Windows の x64 と ARM64 でテストし、Chromium PDF 出力を含む JavaScript 結合テストを Linux x64 で実行します。
+
+## リリース
+
+パッケージバージョンは `<MDI 仕様バージョン>.<パッケージのリリース番号>` です。MDI 2.0 では `2.0.1` から始まります。通常のリリースには patch Changeset を使います。`main` へのマージ後、GitHub Actions が設定済みの npm token を使ってパッケージをビルド・公開します。
+
+```bash
+cd nodejs
+pnpm changeset
+pnpm version
+```
+
+MDI 仕様バージョンを上げるには、`nodejs/` から `pnpm bump-spec-version 2.1` を実行します。
+
+## 関連プロジェクト
+
+- [illusions-lab/milkdown-mdi](https://github.com/illusions-lab/milkdown-mdi) — MDI 構文と縦書き表示のための Milkdown エディタ plugin。
+
+## ライセンス
+
+プロジェクトのコードと MDI 仕様はすべて MIT ライセンスです。[LICENSE](./LICENSE) と [LICENSE-SPEC](./LICENSE-SPEC) を参照してください。

--- a/README.ja.md
+++ b/README.ja.md
@@ -58,7 +58,7 @@ WASM bridge のビルドには、`wasm32-unknown-unknown` Rust target と `wasm-
 
 ## リリース
 
-パッケージバージョンは `<MDI 仕様バージョン>.<パッケージのリリース番号>` です。MDI 2.0 では `2.0.1` から始まります。通常のリリースには patch Changeset を使います。`main` へのマージ後、GitHub Actions が設定済みの npm token を使ってパッケージをビルド・公開します。
+パッケージバージョンは `<MDI 仕様バージョン>.<パッケージのリリース番号>` です。MDI 2.0 では `2.0.1` から始まります。通常のリリースには patch Changeset を使います。`main` へのマージ後、GitHub Actions が npm Trusted Publishing（OIDC）でパッケージをビルド・公開します。
 
 ```bash
 cd nodejs

--- a/README.md
+++ b/README.md
@@ -180,6 +180,4 @@ Every package's version is `<MDI spec version>.<package release number>` — the
 
 ## License
 
-The Node.js tooling (`nodejs/`) and the Rust core (`mdi-core/`) are MIT — see [LICENSE](./LICENSE).
-
-The MDI specification ([`SYNTAX.md`](./SYNTAX.md)) is public domain — see [LICENSE-SPEC](./LICENSE-SPEC).
+All project code and the MDI specification ([`SYNTAX.md`](./SYNTAX.md)) are licensed under MIT — see [LICENSE](./LICENSE) and [LICENSE-SPEC](./LICENSE-SPEC).

--- a/README.md
+++ b/README.md
@@ -1,127 +1,45 @@
 # MDI
 
+[日本語](./README.ja.md)
+
 [![codecov](https://codecov.io/github/illusions-lab/MDI/graph/badge.svg?token=J6GJZW744R)](https://codecov.io/github/illusions-lab/MDI)
 
-**illusion Markdown (MDI)** is a Markdown extension format for Japanese typography — ruby, tate-chu-yoko, boten, warichu, vertical writing, and more, inherited on top of standard Markdown.
+**illusion Markdown (MDI)** is a Markdown extension for Japanese typography. It adds ruby, tate-chu-yoko, boten, warichu, vertical writing, and related features while retaining standard Markdown.
 
-**illusion Markdown（MDI）** は、日本語組版のための Markdown 拡張フォーマットです。ルビ・縦中横・傍点・割注・縦書きなどを、標準 Markdown を継承しつつ拡張します。
+This is the canonical repository for the [MDI 2.0 specification](./SYNTAX.md), the Rust implementation, language bindings, renderers, and developer tools.
 
-This repository is the canonical home of the **MDI 2.0 spec**
-([SYNTAX.md](./SYNTAX.md)), the Rust implementation, language bindings,
-renderers, and developer tools.
+Documentation: <https://mdi.illusions.app/>
 
-本リポジトリは **MDI 2.0 仕様書**（[SYNTAX.md](./SYNTAX.md)）、Rust
-実装、各言語バインディング、レンダラー、開発ツールの正規リポジトリです。
+## Architecture
 
-Rust is the **only executable authority** for MDI syntax and document
-semantics. It parses the complete document grammar—CommonMark, GFM, front
-matter, and MDI extensions—into one versioned document IR. JavaScript, Python,
-and Swift expose thin interfaces to the same Rust implementation.
+Rust is the single executable authority for MDI syntax and document semantics. It parses CommonMark, GFM, front matter, and MDI extensions into a versioned document IR. JavaScript, Python, and Swift are thin host interfaces over that implementation.
 
-本專案採用 **Rust 單一權威架構**：CommonMark、GFM、front matter 與 MDI
-擴充語法均由 Rust 解析為同一份版本化文件 IR；JavaScript、Python、Swift
-僅提供薄接口。完整的權責與接口契約請見
-[`ARCHITECTURE.md`](./ARCHITECTURE.md)。
+`mdi-core` owns parsing, validation, normalization, serialization, and deterministic HTML, TXT, EPUB, and DOCX rendering. PDF uses Rust-produced HTML; a host Chromium adapter performs only print layout and never parses MDI.
 
-**📖 Documentation / ドキュメント: https://mdi.illusions.app/** — guides, a live-rendered syntax showcase, and generated API reference (English / 日本語 / 正體中文). Built from [`nodejs/docs/`](./nodejs/docs).
+See [ARCHITECTURE.md](./ARCHITECTURE.md) for ownership rules and interface contracts.
 
----
+## Repository layout
 
-## Repository layout / リポジトリ構成
+| Directory | Responsibility |
+| --- | --- |
+| [`mdi-core/`](./mdi-core) | Rust parser, versioned IR, validation, serialization, and deterministic renderers. |
+| [`nodejs/`](./nodejs) | JavaScript/WASM bindings, ecosystem adapters, CLI, and documentation. |
+| [`python/`](./python) | PyO3 binding to `mdi-core`. |
+| [`swift/`](./swift) | UniFFI or C-ABI binding to `mdi-core`. |
 
-Every language package exposes the same Rust implementation; no package owns
-an independent grammar or renderer semantics.
+## Node.js packages
 
-各言語向けパッケージは、独立した構文実装を持たず、単一の Rust 実装へ
-接続する薄いバインディングです。
+| Package | Purpose |
+| --- | --- |
+| [`@illusions-lab/mdi`](./nodejs/packages/mdi) | Primary typed JavaScript API backed by Rust. |
+| [`@illusions-lab/mdi-core`](./nodejs/packages/mdi-core) | Generated low-level WebAssembly bridge. |
+| [`@illusions-lab/mdi-cli`](./nodejs/packages/cli) | Rust-backed command-line adapter. |
+| [`@illusions-lab/mdi-to-pdf`](./nodejs/packages/to-pdf) | Chromium layout adapter for Rust-rendered HTML. |
+| [`@illusions-lab/mdi-remark`](./nodejs/packages/remark), [`mdast-util-mdi`](./nodejs/packages/mdast-util-mdi), [`micromark-extension-mdi`](./nodejs/packages/micromark-extension-mdi) | Unified ecosystem compatibility adapters. |
+| [`@illusions-lab/mdi-to-hast`](./nodejs/packages/to-hast), [`@illusions-lab/mdi-to-html`](./nodejs/packages/to-html), [`@illusions-lab/mdi-to-epub`](./nodejs/packages/to-epub), [`@illusions-lab/mdi-to-docx`](./nodejs/packages/to-docx) | Legacy public compatibility adapters. |
+| [`@illusions-lab/mdi-export-profile`](./nodejs/packages/export-profile) | Shared typed export-profile configuration. |
 
-| Directory | Language | Responsibility |
-|-----------|----------|----------------|
-| [`mdi-core/`](./mdi-core) | Rust | Complete parser, versioned document IR, validation, normalization, serialization, and deterministic HTML/TXT/EPUB/DOCX renderers. |
-| [`nodejs/`](./nodejs) | Node.js / TypeScript | JavaScript and WebAssembly bindings, ecosystem adapters, CLI, and documentation. |
-| [`swift/`](./swift) | Swift | Native binding to `mdi-core` through UniFFI or a small C ABI. |
-| [`python/`](./python) | Python | Native binding to `mdi-core` through PyO3. |
-
----
-
-## Packages / パッケージ構成 (`nodejs/`)
-
-| Package | Layer | Description |
-|---------|-------|-------------|
-| [`@illusions-lab/mdi`](./nodejs/packages/mdi) | JavaScript binding | Primary typed API for parsing, validation, normalization, serialization, and rendering through Rust. |
-| [`@illusions-lab/mdi-core`](./nodejs/packages/mdi-core) | WebAssembly bridge | Generated low-level WebAssembly interface used by JavaScript packages. |
-| [`micromark-extension-mdi`](./nodejs/packages/micromark-extension-mdi) | Ecosystem adapter | Presents Rust-owned parse results through micromark-compatible events; contains no grammar rules. |
-| [`mdast-util-mdi`](./nodejs/packages/mdast-util-mdi) | Ecosystem adapter | Maps between the versioned Rust document IR and MDAST object shapes. |
-| [`@illusions-lab/mdi-remark`](./nodejs/packages/remark) | Remark adapter | Lets unified pipelines consume the Rust document IR as MDAST without giving remark syntax authority. |
-| [`@illusions-lab/mdi-export-profile`](./nodejs/packages/export-profile) | Configuration | Shared typed export profiles; PDF and text use them now, Rust EPUB/DOCX parity follows. |
-| [`@illusions-lab/mdi-to-hast`](./nodejs/packages/to-hast) | HAST adapter | Legacy public mdast/HAST compatibility adapter for unified ecosystem consumers. |
-| [`@illusions-lab/mdi-to-html`](./nodejs/packages/to-html) | HTML adapter | Legacy public mdast/HAST compatibility adapter. |
-| [`@illusions-lab/mdi-to-pdf`](./nodejs/packages/to-pdf) | Layout adapter | Sends Rust-rendered HTML to Chromium; Chromium never parses MDI. |
-| [`@illusions-lab/mdi-to-epub`](./nodejs/packages/to-epub) | EPUB adapter | Legacy public mdast compatibility adapter. |
-| [`@illusions-lab/mdi-to-docx`](./nodejs/packages/to-docx) | DOCX adapter | Legacy public mdast compatibility adapter. |
-| [`@illusions-lab/mdi-cli`](./nodejs/packages/cli) | CLI | `mdi build input.mdi --to html\|pdf\|epub\|docx\|txt...` — thin Rust-backed command-line adapter. |
-
-### Why this split / なぜこの分割か
-
-`mdi-core` owns meaning and deterministic output. Language packages only make
-that functionality natural to use in a host ecosystem: typed objects in
-JavaScript, MDAST/HAST for unified, Python objects through PyO3, and Swift
-types through UniFFI. This separation prevents the same syntax rule from
-acquiring different meanings in different languages.
-
-`mdi-core` が文書の意味と決定論的な出力を担い、各言語パッケージはその
-機能を JavaScript の型、unified の MDAST/HAST、PyO3、UniFFI など各環境に
-適した形で公開するだけです。これにより、同じ構文が言語ごとに異なる意味を
-持つことを防ぎます。
-
----
-
-## Architecture / アーキテクチャ
-
-The architecture is deliberately simple: source enters Rust once, and all
-language packages consume the same versioned document IR. Deterministic
-renderers live in Rust. PDF uses HTML generated by Rust, with a host
-Chromium adapter responsible only for print layout.
-
-```mermaid
-flowchart TD
-  source[".mdi source"] --> core
-  subgraph rustCore["Rust — single executable authority"]
-    core["parser<br/>CommonMark · GFM · MDI · front matter"] --> ir["versioned MDI document IR"]
-    ir --> renderers["HTML · TXT · EPUB · DOCX · MDI"]
-    renderers --> html["Rust HTML"]
-  end
-
-  subgraph bindings["Thin language bindings — no grammar rules"]
-    js["JavaScript / WASM"]
-    py["Python / PyO3"]
-    swift["Swift / UniFFI"]
-    ecosystem["mdast / remark adapters"]
-  end
-
-  ir --> js
-  ir -.-> py
-  ir -.-> swift
-  ir -.-> ecosystem
-  html --> chromium["Host Chromium layout adapter"] --> pdf["PDF bytes"]
-
-  classDef rustcore fill:#fde7e7,stroke:#ea4335,color:#202124
-  classDef binding fill:#f3e8fd,stroke:#a142f4,color:#202124
-  classDef output fill:#fef7e0,stroke:#f9ab00,color:#202124
-  class core,ir,renderers,html rustcore
-  class js,py,swift,ecosystem binding
-  class pdf output
-```
-
-The complete ownership rules, IR contract, parser invariants, and renderer
-boundaries are documented in [`ARCHITECTURE.md`](./ARCHITECTURE.md).
-
----
-
-## Development / 開発
-
-`nodejs/` is a [pnpm](https://pnpm.io) + [Turborepo](https://turbo.build)
-monorepo; `mdi-core/` is an independent Cargo project.
+## Development
 
 ```bash
 cd nodejs
@@ -136,48 +54,24 @@ cargo build
 cargo test
 ```
 
-Rebuilding the wasm bridge needs a `wasm32-unknown-unknown` Rust target and
-`wasm-pack` in addition to the plain `cargo build`/`cargo test` toolchain
-above; `pnpm build` in `nodejs/` runs it as part of the normal workspace
-build.
+Building the WASM bridge also requires the `wasm32-unknown-unknown` Rust target and `wasm-pack`; the Node workspace build runs it automatically. CI tests the Rust core on Linux, macOS, and Windows for x64 and ARM64, and runs the JavaScript integration suite including Chromium PDF output on Linux x64.
 
-CI runs the Rust core natively on Linux, macOS, and Windows for both x64 and
-ARM64. The JavaScript integration suite, including Chromium PDF output, runs
-on Linux x64. Every language binding runs the shared parser, diagnostic, and
-renderer conformance fixtures.
+## Releases
 
-### Versioning / バージョニング
+Package versions use `<MDI spec version>.<package release number>`; for MDI 2.0, releases begin at `2.0.1`. Use a patch Changeset for ordinary releases. Merging to `main` makes GitHub Actions build and publish packages with its configured npm token.
 
-Every package's version is `<MDI spec version>.<package release number>` — the major.minor pair always equals the MDI spec version this repository implements (`2.0`), and the patch number is each package's own independent release count, **starting at `.1`** (never `.0`) for the first release under a given spec version. For example the first release under MDI 2.0 is `2.0.1`; a later fix to just `@illusions-lab/mdi-to-docx` might be `2.0.7` while `@illusions-lab/mdi-to-html` is still `2.0.3` — patch numbers are independent per package, only major.minor is shared.
+```bash
+cd nodejs
+pnpm changeset
+pnpm version
+```
 
-すべてのパッケージのバージョンは `<MDI 仕様バージョン>.<パッケージ自身のリリース回数>` です。major.minor はこのリポジトリが対応する MDI 仕様バージョン（現在 `2.0`）に常に一致し、patch は各パッケージが独自にカウントするリリース回数で、そのバージョンで最初のリリースは `.0` ではなく **`.1` から始まります**。例えば MDI 2.0 対応の初回リリースは `2.0.1`。以降、`@illusions-lab/mdi-to-docx` だけ修正を重ねて `2.0.7` になっても `@illusions-lab/mdi-to-html` は `2.0.3` のまま、というように patch は各パッケージ独立です。
+For an MDI specification version bump, run `pnpm bump-spec-version 2.1` from `nodejs/`.
 
-- **Ordinary releases** (same spec version): use Changesets as normal — always choose a **patch** bump, never minor/major.  
-  **通常のリリース**（同じ仕様バージョン内）: 通常どおり Changesets を使い、常に **patch** bump のみを選びます（minor/major は使いません）。
+## Related project
 
-  ```bash
-  cd nodejs
-  pnpm changeset       # record what changed; always pick "patch"
-  pnpm version         # apply pending changesets and commit the result
-  # Merge to main: GitHub Actions builds and publishes with its NPM_TOKEN.
-  ```
-
-- **Spec version bump** (e.g. MDI 2.0 → 2.1): Changesets has no concept of "MDI spec version," so this is a separate, explicit step — it rewrites every package's version to `<new spec version>.1` regardless of each package's prior patch count.  
-  **仕様バージョンの引き上げ**（例: MDI 2.0 → 2.1）: Changesets は「MDI 仕様バージョン」という概念を知らないため、これは別の明示的な手順です。各パッケージの直前の patch 数に関係なく、全パッケージのバージョンを `<新しい仕様バージョン>.1` へ書き換えます。
-
-  ```bash
-  cd nodejs
-  pnpm bump-spec-version 2.1
-  ```
-
----
-
-## Related projects / 関連プロジェクト
-
-- [illusions-lab/milkdown-mdi](https://github.com/illusions-lab/milkdown-mdi) — Milkdown editor plugins for MDI syntax support and vertical writing (縦書き) display.
-
----
+- [illusions-lab/milkdown-mdi](https://github.com/illusions-lab/milkdown-mdi) — Milkdown editor plugins for MDI syntax and vertical-writing display.
 
 ## License
 
-All project code and the MDI specification ([`SYNTAX.md`](./SYNTAX.md)) are licensed under MIT — see [LICENSE](./LICENSE) and [LICENSE-SPEC](./LICENSE-SPEC).
+All project code and the MDI specification are licensed under MIT. See [LICENSE](./LICENSE) and [LICENSE-SPEC](./LICENSE-SPEC).

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Building the WASM bridge also requires the `wasm32-unknown-unknown` Rust target 
 
 ## Releases
 
-Package versions use `<MDI spec version>.<package release number>`; for MDI 2.0, releases begin at `2.0.1`. Use a patch Changeset for ordinary releases. Merging to `main` makes GitHub Actions build and publish packages with its configured npm token.
+Package versions use `<MDI spec version>.<package release number>`; for MDI 2.0, releases begin at `2.0.1`. Use a patch Changeset for ordinary releases. Merging to `main` makes GitHub Actions build and publish packages through npm Trusted Publishing (OIDC).
 
 ```bash
 cd nodejs

--- a/README.md
+++ b/README.md
@@ -2,7 +2,19 @@
 
 [日本語](./README.ja.md)
 
-[![codecov](https://codecov.io/github/illusions-lab/MDI/graph/badge.svg?token=J6GJZW744R)](https://codecov.io/github/illusions-lab/MDI)
+[![CI](https://img.shields.io/github/actions/workflow/status/illusions-lab/MDI/ci.yml/CI?branch=main&style=for-the-badge&logo=githubactions&logoColor=white&label=CI)](https://github.com/illusions-lab/MDI/actions/workflows/ci.yml)
+[![Docs](https://img.shields.io/github/actions/workflow/status/illusions-lab/MDI/docs.yml/Docs?branch=main&style=for-the-badge&logo=readthedocs&logoColor=white&label=docs)](https://github.com/illusions-lab/MDI/actions/workflows/docs.yml)
+[![Release](https://img.shields.io/github/actions/workflow/status/illusions-lab/MDI/release.yml/Release?branch=main&style=for-the-badge&logo=github&logoColor=white&label=release)](https://github.com/illusions-lab/MDI/actions/workflows/release.yml)
+[![codecov](https://img.shields.io/codecov/c/github/illusions-lab/MDI?style=for-the-badge&logo=codecov&logoColor=white)](https://app.codecov.io/gh/illusions-lab/MDI)
+
+[![npm version](https://img.shields.io/npm/v/%40illusions-lab%2Fmdi?style=for-the-badge&logo=npm&logoColor=white&label=npm)](https://www.npmjs.com/package/@illusions-lab/mdi)
+[![npm downloads](https://img.shields.io/npm/dm/%40illusions-lab%2Fmdi?style=for-the-badge&logo=npm&logoColor=white&label=downloads)](https://www.npmjs.com/package/@illusions-lab/mdi)
+[![Latest release](https://img.shields.io/github/v/release/illusions-lab/MDI?display_name=tag&sort=semver&style=for-the-badge&logo=github&logoColor=white)](https://github.com/illusions-lab/MDI/releases)
+
+[![License](https://img.shields.io/github/license/illusions-lab/MDI?style=for-the-badge&logo=opensourceinitiative&logoColor=white)](./LICENSE)
+[![Last commit](https://img.shields.io/github/last-commit/illusions-lab/MDI?style=for-the-badge&logo=git&logoColor=white)](https://github.com/illusions-lab/MDI/commits/main)
+[![Repository size](https://img.shields.io/github/repo-size/illusions-lab/MDI?style=for-the-badge&logo=github&logoColor=white)](https://github.com/illusions-lab/MDI)
+[![GitHub stars](https://img.shields.io/github/stars/illusions-lab/MDI?style=for-the-badge&logo=github&logoColor=white)](https://github.com/illusions-lab/MDI/stargazers)
 
 **illusion Markdown (MDI)** is a Markdown extension for Japanese typography. It adds ruby, tate-chu-yoko, boten, warichu, vertical writing, and related features while retaining standard Markdown.
 

--- a/nodejs/docs/mdi-2.0-announcement.md
+++ b/nodejs/docs/mdi-2.0-announcement.md
@@ -5,7 +5,7 @@
 MDI は、標準 Markdown（CommonMark / GFM）の記法をすべて継承したうえで、ルビ・縦中横・傍点・割注など、プレーンな Markdown では表現しにくい日本語組版の要素を、HTML タグなしの簡潔な記法で書けるようにしたフォーマットです。見た目の制御は CSS に委ね、原稿には**意味だけを書く**——という Markdown 本来の思想を、日本語組版の世界に持ち込むことを目指しています。
 
 - 仕様書: [SYNTAX.md](https://github.com/illusions-lab/MDI/blob/main/SYNTAX.md)
-- リポジトリ: [illusions-lab/MDI](https://github.com/illusions-lab/MDI)（仕様はパブリックドメイン / Unlicense）
+- リポジトリ: [illusions-lab/MDI](https://github.com/illusions-lab/MDI)（仕様を含め MIT ライセンス）
 - MDI 1.0 の仕様は [`spec/v1.0`](https://github.com/illusions-lab/MDI/tree/spec/v1.0) ブランチに保存されています
 
 ---
@@ -187,7 +187,7 @@ MDI 2.0 仕様と並行して、公式ツール群を開発しています。
 
 ## さいごに
 
-MDI の仕様はパブリックドメイン（Unlicense）で公開しています。エディタ、静的サイトジェネレータ、変換ツール——どんなソフトウェアでも、許諾なしに自由に実装できます。
+MDI の仕様を含むプロジェクト全体は MIT ライセンスで公開しています。エディタ、静的サイトジェネレータ、変換ツールにも利用・実装できます。
 
 日本語で物語を書くすべての人に、「組版を記述できる原稿フォーマット」を。
 

--- a/nodejs/packages/export-profile/package.json
+++ b/nodejs/packages/export-profile/package.json
@@ -5,7 +5,8 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/illusions-lab/MDI"
+    "url": "git+https://github.com/illusions-lab/MDI.git",
+    "directory": "nodejs/packages/export-profile"
   },
   "type": "module",
   "main": "./dist/index.js",

--- a/nodejs/scripts/compute-release-versions.mjs
+++ b/nodejs/scripts/compute-release-versions.mjs
@@ -1,11 +1,16 @@
 import { appendFileSync, readFileSync, writeFileSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { globSync } from "node:fs";
-import { join } from "node:path";
+import { join, relative } from "node:path";
 
 const root = new URL("..", import.meta.url).pathname;
 const dryRun = process.argv.includes("--dry-run");
-const packages = globSync(join(root, "packages", "*", "package.json"))
+const baseArgument = process.argv.indexOf("--base");
+const baseRef =
+  baseArgument >= 0
+    ? process.argv[baseArgument + 1]
+    : process.env.RELEASE_BASE_SHA;
+const allPackages = globSync(join(root, "packages", "*", "package.json"))
   .map((manifestPath) => ({
     manifestPath,
     manifest: JSON.parse(readFileSync(manifestPath, "utf8")),
@@ -13,6 +18,61 @@ const packages = globSync(join(root, "packages", "*", "package.json"))
   .filter(({ manifest }) => !manifest.private)
   .sort(({ manifest: a }, { manifest: b }) => a.name.localeCompare(b.name));
 
+if (!baseRef) {
+  throw new Error(
+    "A release base commit is required. Pass --base <commit> or set RELEASE_BASE_SHA."
+  );
+}
+
+const changedFiles = execFileSync(
+  "git",
+  ["diff", "--name-only", `${baseRef}...HEAD`],
+  { cwd: root, encoding: "utf8" }
+)
+  .trim()
+  .split("\n")
+  .filter(Boolean);
+const changedPackages = new Set();
+
+for (const file of changedFiles) {
+  const nodejsRelative = relative(root, join(root, "..", file));
+  const packageMatch = nodejsRelative.match(/^packages\/([^/]+)\//);
+  if (packageMatch) {
+    const entry = allPackages.find(
+      ({ manifestPath }) =>
+        relative(root, manifestPath).startsWith(`packages/${packageMatch[1]}/`)
+    );
+    if (entry) changedPackages.add(entry.manifest.name);
+  }
+  if (file.startsWith("mdi-core/")) {
+    const core = allPackages.find(
+      ({ manifest }) => manifest.name === "@illusions-lab/mdi-core"
+    );
+    if (core) changedPackages.add(core.manifest.name);
+  }
+}
+
+const releaseNames = new Set(changedPackages);
+let expanded = true;
+while (expanded) {
+  expanded = false;
+  for (const { manifest } of allPackages) {
+    const dependencies = {
+      ...manifest.dependencies,
+      ...manifest.optionalDependencies,
+      ...manifest.peerDependencies,
+    };
+    if (
+      !releaseNames.has(manifest.name) &&
+      Object.keys(dependencies).some((name) => releaseNames.has(name))
+    ) {
+      releaseNames.add(manifest.name);
+      expanded = true;
+    }
+  }
+}
+
+const packages = allPackages.filter(({ manifest }) => releaseNames.has(manifest.name));
 const released = [];
 
 for (const { manifestPath, manifest } of packages) {
@@ -74,7 +134,9 @@ if (process.env.GITHUB_OUTPUT) {
 }
 
 console.log(
-  `${dryRun ? "Would release" : "Prepared release"} ${released
-    .map(({ name, version }) => `${name}@${version}`)
-    .join(", ")}`
+  released.length === 0
+    ? "No publishable package changes in this commit range."
+    : `${dryRun ? "Would release" : "Prepared release"} ${released
+        .map(({ name, version }) => `${name}@${version}`)
+        .join(", ")}`
 );

--- a/nodejs/scripts/compute-release-versions.mjs
+++ b/nodejs/scripts/compute-release-versions.mjs
@@ -33,6 +33,7 @@ const changedFiles = execFileSync(
   .split("\n")
   .filter(Boolean);
 const changedPackages = new Set();
+const dependencyRoots = new Set();
 
 for (const file of changedFiles) {
   const nodejsRelative = relative(root, join(root, "..", file));
@@ -42,13 +43,23 @@ for (const file of changedFiles) {
       ({ manifestPath }) =>
         relative(root, manifestPath).startsWith(`packages/${packageMatch[1]}/`)
     );
-    if (entry) changedPackages.add(entry.manifest.name);
+    if (entry) {
+      changedPackages.add(entry.manifest.name);
+      // A package.json-only change is packaging metadata (for example a
+      // repository URL or license) and must not force consumer releases.
+      if (nodejsRelative !== `packages/${packageMatch[1]}/package.json`) {
+        dependencyRoots.add(entry.manifest.name);
+      }
+    }
   }
   if (file.startsWith("mdi-core/")) {
     const core = allPackages.find(
       ({ manifest }) => manifest.name === "@illusions-lab/mdi-core"
     );
-    if (core) changedPackages.add(core.manifest.name);
+    if (core) {
+      changedPackages.add(core.manifest.name);
+      dependencyRoots.add(core.manifest.name);
+    }
   }
 }
 
@@ -64,9 +75,10 @@ while (expanded) {
     };
     if (
       !releaseNames.has(manifest.name) &&
-      Object.keys(dependencies).some((name) => releaseNames.has(name))
+      Object.keys(dependencies).some((name) => dependencyRoots.has(name))
     ) {
       releaseNames.add(manifest.name);
+      dependencyRoots.add(manifest.name);
       expanded = true;
     }
   }

--- a/nodejs/scripts/publish-versioned-packages.mjs
+++ b/nodejs/scripts/publish-versioned-packages.mjs
@@ -8,10 +8,12 @@ const manifests = globSync(join(root, "packages", "*", "package.json"));
 const pending = [];
 const releasePackages = [];
 const dryRun = process.argv.includes("--dry-run");
+const selectedPackages = JSON.parse(process.env.RELEASE_PACKAGES ?? "[]");
+const selectedNames = new Set(selectedPackages.map(({ name }) => name));
 
 for (const manifestPath of manifests) {
   const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
-  if (manifest.private) continue;
+  if (manifest.private || !selectedNames.has(manifest.name)) continue;
   releasePackages.push({ name: manifest.name, version: manifest.version });
   try {
     execFileSync(
@@ -41,10 +43,7 @@ if (process.env.GITHUB_OUTPUT) {
   // A manual dispatch is also used to repair/create GitHub Releases for
   // versions already on npm. The release script is idempotent and skips tags
   // that already exist.
-  appendFileSync(
-    process.env.GITHUB_OUTPUT,
-    `published=${releasePackages.length > 0}\n`
-  );
+  appendFileSync(process.env.GITHUB_OUTPUT, `published=${pending.length > 0}\n`);
   appendFileSync(
     process.env.GITHUB_OUTPUT,
     `publishedPackages=${JSON.stringify(releasePackages)}\n`

--- a/nodejs/scripts/publish-versioned-packages.mjs
+++ b/nodejs/scripts/publish-versioned-packages.mjs
@@ -32,7 +32,10 @@ for (const manifestPath of manifests) {
 if (pending.length > 0 && !dryRun) {
   execFileSync("pnpm", ["run", "build"], { cwd: root, stdio: "inherit" });
   for (const { manifestPath } of pending) {
-    execFileSync("pnpm", ["publish", "--no-git-checks", "--access", "public"], {
+    // npm CLI detects GitHub Actions OIDC and exchanges it for a short-lived
+    // publish credential. Do not replace this with pnpm publish: trusted
+    // publishing authentication is implemented by npm itself.
+    execFileSync("npm", ["publish", "--access", "public"], {
       cwd: dirname(manifestPath),
       stdio: "inherit",
     });


### PR DESCRIPTION
Standardizes the specification license as MIT and makes Node/Rust Codecov upload failures fail CI so coverage integration problems are visible.