### PR TITLE
Add SwiftPM MDI binding release pipeline

### DIFF
--- a/.github/workflows/swift-release.yml
+++ b/.github/workflows/swift-release.yml
@@ -1,0 +1,76 @@
+name: Publish Swift Package
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Complete SemVer version to publish (for example, 2.0.1)
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+concurrency: swift-release
+
+jobs:
+  publish:
+    name: Publish MDI ${{ inputs.version }}
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-darwin,x86_64-apple-darwin,aarch64-apple-ios,aarch64-apple-ios-sim,x86_64-apple-ios
+
+      - name: Validate version
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
+          ! git rev-parse --verify --quiet "refs/tags/$VERSION"
+
+      - name: Build the Apple XCFramework
+        run: scripts/package-swift-xcframework.sh "$RUNNER_TEMP/mdi-swift"
+
+      - name: Test against the local XCFramework
+        run: |
+          mkdir -p swift/Artifacts
+          ditto "$RUNNER_TEMP/mdi-swift/MDICore.xcframework" swift/Artifacts/MDICore.xcframework
+          scripts/write-swift-package-manifest.sh local "swift/Artifacts/MDICore.xcframework"
+          swift test
+
+      - name: Archive the XCFramework
+        id: artifact
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          ditto -c -k --sequesterRsrc --keepParent "$RUNNER_TEMP/mdi-swift/MDICore.xcframework" "$RUNNER_TEMP/MDICore.xcframework.zip"
+          echo "checksum=$(swift package compute-checksum "$RUNNER_TEMP/MDICore.xcframework.zip")" >> "$GITHUB_OUTPUT"
+
+      - name: Write the release manifest
+        env:
+          VERSION: ${{ inputs.version }}
+          CHECKSUM: ${{ steps.artifact.outputs.checksum }}
+        run: scripts/write-swift-package-manifest.sh remote "https://github.com/${{ github.repository }}/releases/download/$VERSION/MDICore.xcframework.zip" "$CHECKSUM"
+
+      - name: Commit and tag the package release
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Package.swift
+          git commit -m "Release Swift package $VERSION"
+          git tag "$VERSION"
+          git push origin HEAD:main "$VERSION"
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
+        run: gh release create "$VERSION" "$RUNNER_TEMP/MDICore.xcframework.zip#MDICore.xcframework.zip" --title "MDI $VERSION" --generate-notes

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ coverage
 .DS_Store
 *.log
 target/
+.build/
+swift/Artifacts/

--- a/mdi-core/Cargo.toml
+++ b/mdi-core/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["markdown", "mdi", "ruby", "typesetting"]
 categories = ["parser-implementations", "text-processing"]
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["cdylib", "staticlib", "rlib"]
 
 [dependencies]
 markdown = { version = "1.0.0", features = ["serde"] }
@@ -25,4 +25,4 @@ js-sys = { version = "0.3", optional = true }
 wasm = ["dep:wasm-bindgen", "dep:js-sys"]
 
 [lints.rust]
-unsafe_code = "forbid"
+unsafe_code = "deny"

--- a/mdi-core/src/lib.rs
+++ b/mdi-core/src/lib.rs
@@ -3989,32 +3989,80 @@ mod tests {
         assert!(docx_success);
     }
 
-    #[test]
     #[allow(unsafe_code)]
-    fn c_abi_returns_owned_versioned_wire_data() {
-        let source = "{東京|とうきょう} ^12^";
-        let result = ffi::mdi_parse_json(source.as_ptr(), source.len());
-        assert_eq!(result.error.len, 0);
-        let json = unsafe {
-            std::str::from_utf8(std::slice::from_raw_parts(
-                result.value.data,
-                result.value.len,
-            ))
-            .unwrap()
+    fn ffi_bytes(result: ffi::MdiFfiResult) -> Result<Vec<u8>, String> {
+        let value = if result.value.len == 0 {
+            Vec::new()
+        } else {
+            unsafe { std::slice::from_raw_parts(result.value.data, result.value.len).to_vec() }
         };
-        assert!(json.contains("\"irVersion\":\"1.0\""));
-        assert!(json.contains("\"type\":\"ruby\""));
+        let error = if result.error.len == 0 {
+            None
+        } else {
+            Some(unsafe {
+                std::str::from_utf8(std::slice::from_raw_parts(
+                    result.error.data,
+                    result.error.len,
+                ))
+                .unwrap()
+                .to_owned()
+            })
+        };
         unsafe {
             ffi::mdi_free_buffer(result.value);
             ffi::mdi_free_buffer(result.error);
         }
+        error.map_or(Ok(value), Err)
+    }
 
-        let invalid = ffi::mdi_parse_json(std::ptr::null(), 1);
-        assert_eq!(invalid.value.len, 0);
-        assert!(invalid.error.len > 0);
-        unsafe {
-            ffi::mdi_free_buffer(invalid.value);
-            ffi::mdi_free_buffer(invalid.error);
-        }
+    #[test]
+    #[allow(unsafe_code)]
+    fn c_abi_returns_owned_versioned_wire_data_for_every_export() {
+        let source = "{東京|とうきょう} ^12^";
+        let json = String::from_utf8(
+            ffi_bytes(ffi::mdi_parse_json(source.as_ptr(), source.len())).unwrap(),
+        )
+        .unwrap();
+        assert!(json.contains("\"irVersion\":\"1.0\""));
+        assert!(json.contains("\"type\":\"ruby\""));
+
+        let html = String::from_utf8(
+            ffi_bytes(ffi::mdi_render_html(source.as_ptr(), source.len())).unwrap(),
+        )
+        .unwrap();
+        assert!(html.contains("<ruby class=\"mdi-ruby\">東京"));
+        assert_eq!(
+            String::from_utf8(
+                ffi_bytes(ffi::mdi_serialize_mdi(source.as_ptr(), source.len())).unwrap()
+            )
+            .unwrap(),
+            "{東京|とうきょう} ^12^\n"
+        );
+        assert_eq!(
+            String::from_utf8(
+                ffi_bytes(ffi::mdi_render_text(source.as_ptr(), source.len())).unwrap()
+            )
+            .unwrap(),
+            "東京 12\n"
+        );
+        assert!(
+            ffi_bytes(ffi::mdi_render_epub(source.as_ptr(), source.len()))
+                .unwrap()
+                .starts_with(b"PK")
+        );
+        assert!(
+            ffi_bytes(ffi::mdi_render_docx(source.as_ptr(), source.len()))
+                .unwrap()
+                .starts_with(b"PK")
+        );
+
+        assert_eq!(
+            ffi_bytes(ffi::mdi_parse_json(std::ptr::null(), 1)).unwrap_err(),
+            "MDI source pointer is null"
+        );
+        assert_eq!(
+            ffi_bytes(ffi::mdi_render_epub(std::ptr::null(), 1)).unwrap_err(),
+            "MDI source pointer is null"
+        );
     }
 }

--- a/mdi-core/src/lib.rs
+++ b/mdi-core/src/lib.rs
@@ -4056,6 +4056,21 @@ mod tests {
                 .starts_with(b"PK")
         );
 
+        assert!(
+            ffi_bytes(ffi::mdi_render_text(std::ptr::null(), 0))
+                .unwrap()
+                .is_empty()
+        );
+        let invalid_utf8 = [0xff];
+        assert_eq!(
+            ffi_bytes(ffi::mdi_render_html(
+                invalid_utf8.as_ptr(),
+                invalid_utf8.len()
+            ))
+            .unwrap_err(),
+            "MDI source must be valid UTF-8"
+        );
+
         assert_eq!(
             ffi_bytes(ffi::mdi_parse_json(std::ptr::null(), 1)).unwrap_err(),
             "MDI source pointer is null"

--- a/mdi-core/src/lib.rs
+++ b/mdi-core/src/lib.rs
@@ -943,6 +943,141 @@ pub fn parse_json(source: &str) -> String {
         .expect("serializing the MDI parse output cannot fail")
 }
 
+/// Stable C ABI used by native language bindings.
+///
+/// Every operation accepts UTF-8 bytes and returns owned bytes. Callers must
+/// release both buffers in an [`MdiFfiResult`] with [`mdi_free_buffer`]. The
+/// JSON returned by `mdi_parse_json` is the same versioned wire contract used
+/// by the JavaScript and future Python bindings.
+#[allow(unsafe_code)]
+pub mod ffi {
+    use super::{parse_json, render_docx, render_epub, render_html, render_text, serialize_mdi};
+    use std::slice;
+
+    #[repr(C)]
+    #[derive(Debug, Clone, Copy)]
+    pub struct MdiFfiBuffer {
+        pub data: *mut u8,
+        pub len: usize,
+    }
+
+    #[repr(C)]
+    #[derive(Debug, Clone, Copy)]
+    pub struct MdiFfiResult {
+        pub value: MdiFfiBuffer,
+        pub error: MdiFfiBuffer,
+    }
+
+    fn empty_buffer() -> MdiFfiBuffer {
+        MdiFfiBuffer {
+            data: std::ptr::null_mut(),
+            len: 0,
+        }
+    }
+
+    fn buffer(value: Vec<u8>) -> MdiFfiBuffer {
+        if value.is_empty() {
+            return empty_buffer();
+        }
+        let mut value = value.into_boxed_slice();
+        let result = MdiFfiBuffer {
+            data: value.as_mut_ptr(),
+            len: value.len(),
+        };
+        std::mem::forget(value);
+        result
+    }
+
+    fn success(value: Vec<u8>) -> MdiFfiResult {
+        MdiFfiResult {
+            value: buffer(value),
+            error: empty_buffer(),
+        }
+    }
+
+    fn failure(message: impl Into<String>) -> MdiFfiResult {
+        MdiFfiResult {
+            value: empty_buffer(),
+            error: buffer(message.into().into_bytes()),
+        }
+    }
+
+    fn source<'a>(data: *const u8, len: usize) -> Result<&'a str, String> {
+        if data.is_null() && len != 0 {
+            return Err("MDI source pointer is null".to_owned());
+        }
+        let bytes = if len == 0 {
+            &[]
+        } else {
+            unsafe { slice::from_raw_parts(data, len) }
+        };
+        std::str::from_utf8(bytes).map_err(|_| "MDI source must be valid UTF-8".to_owned())
+    }
+
+    fn string_result(
+        data: *const u8,
+        len: usize,
+        operation: impl FnOnce(&str) -> String,
+    ) -> MdiFfiResult {
+        match source(data, len) {
+            Ok(source) => success(operation(source).into_bytes()),
+            Err(error) => failure(error),
+        }
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn mdi_parse_json(data: *const u8, len: usize) -> MdiFfiResult {
+        string_result(data, len, parse_json)
+    }
+    #[unsafe(no_mangle)]
+    pub extern "C" fn mdi_render_html(data: *const u8, len: usize) -> MdiFfiResult {
+        string_result(data, len, render_html)
+    }
+    #[unsafe(no_mangle)]
+    pub extern "C" fn mdi_serialize_mdi(data: *const u8, len: usize) -> MdiFfiResult {
+        string_result(data, len, serialize_mdi)
+    }
+    #[unsafe(no_mangle)]
+    pub extern "C" fn mdi_render_text(data: *const u8, len: usize) -> MdiFfiResult {
+        string_result(data, len, render_text)
+    }
+
+    fn binary_result(
+        data: *const u8,
+        len: usize,
+        operation: impl FnOnce(&str) -> Result<Vec<u8>, String>,
+    ) -> MdiFfiResult {
+        match source(data, len).and_then(operation) {
+            Ok(value) => success(value),
+            Err(error) => failure(error),
+        }
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn mdi_render_epub(data: *const u8, len: usize) -> MdiFfiResult {
+        binary_result(data, len, render_epub)
+    }
+    #[unsafe(no_mangle)]
+    pub extern "C" fn mdi_render_docx(data: *const u8, len: usize) -> MdiFfiResult {
+        binary_result(data, len, render_docx)
+    }
+
+    /// Releases a buffer returned by this module.
+    ///
+    /// # Safety
+    ///
+    /// `buffer` must have been returned by one of this module's functions and
+    /// each non-empty buffer must be passed here at most once.
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn mdi_free_buffer(buffer: MdiFfiBuffer) {
+        if !buffer.data.is_null() && buffer.len != 0 {
+            unsafe {
+                drop(Vec::from_raw_parts(buffer.data, buffer.len, buffer.len));
+            }
+        }
+    }
+}
+
 /// Render a complete source document to a standalone HTML document directly
 /// from the Rust-owned IR.  This is intentionally source-oriented for FFI:
 /// bindings pass UTF-8 source once and never reconstruct MDI syntax in a host
@@ -3852,5 +3987,34 @@ mod tests {
         }
         assert!(docx_errors > 0);
         assert!(docx_success);
+    }
+
+    #[test]
+    #[allow(unsafe_code)]
+    fn c_abi_returns_owned_versioned_wire_data() {
+        let source = "{東京|とうきょう} ^12^";
+        let result = ffi::mdi_parse_json(source.as_ptr(), source.len());
+        assert_eq!(result.error.len, 0);
+        let json = unsafe {
+            std::str::from_utf8(std::slice::from_raw_parts(
+                result.value.data,
+                result.value.len,
+            ))
+            .unwrap()
+        };
+        assert!(json.contains("\"irVersion\":\"1.0\""));
+        assert!(json.contains("\"type\":\"ruby\""));
+        unsafe {
+            ffi::mdi_free_buffer(result.value);
+            ffi::mdi_free_buffer(result.error);
+        }
+
+        let invalid = ffi::mdi_parse_json(std::ptr::null(), 1);
+        assert_eq!(invalid.value.len, 0);
+        assert!(invalid.error.len > 0);
+        unsafe {
+            ffi::mdi_free_buffer(invalid.value);
+            ffi::mdi_free_buffer(invalid.error);
+        }
     }
 }

--- a/nodejs/docs/src/content/docs/bindings/swift.md
+++ b/nodejs/docs/src/content/docs/bindings/swift.md
@@ -3,10 +3,24 @@ title: Swift
 description: Status and expected contract for the Swift binding.
 ---
 
-**Planned.** The repository's [`swift/README.md`](https://github.com/illusions-lab/MDI/blob/main/swift/README.md) currently says the Swift implementation is not yet implemented. There is no Swift package, XCFramework, or generated API reference to document yet.
+The Swift binding is a Swift Package Manager package named `IllusionMarkdown`.
+It forwards all parsing and rendering to `mdi-core` through its small C ABI;
+Swift never contains grammar or rendering decisions.
+
+During repository development, `swift/Package.swift` provides the local
+binding layout. The `Publish Swift Package` workflow builds and tests the
+native Rust library as an XCFramework, writes the root `Package.swift`, tags
+the release, and uploads the artifact using GitHub Actions' built-in token.
 
 ## Expected contract
 
-The planned binding is expected to use UniFFI or a small C ABI around `mdi-core`. It should expose the same syntax/IR versions, document nodes, diagnostics, and UTF-8 byte spans as the other bindings, with Swift-native value types and error handling. It must not own grammar or renderer semantics.
+The binding exposes the same syntax/IR versions, diagnostics, UTF-8 byte spans,
+and complete document tree as the other bindings. `MDIParseResult.document` is
+represented by the lossless `MDIJSONValue` tagged JSON value, while source spans
+and diagnostics use Swift-native value types. It must not own grammar or
+renderer semantics.
 
-Installation, module names, type mapping, and resource-error behavior will be added once the binding is implemented.
+The current module is `MDI` (published in the `IllusionMarkdown` SwiftPM
+package). The public entry points are
+`parse`, `renderHTML`, `serialize`, `renderText`, `renderEPUB`, and
+`renderDOCX`; native-library and core failures are surfaced as `MDIError`.

--- a/nodejs/docs/src/content/docs/ja/bindings/swift.md
+++ b/nodejs/docs/src/content/docs/ja/bindings/swift.md
@@ -3,6 +3,8 @@ title: Swift
 description: Swift binding の状態と予定契約。
 ---
 
-**Planned。** `swift/README.md` は未実装と記載しています。Swift package、XCFramework、生成 API reference はまだありません。
+Swift バインディングは `IllusionMarkdown` という Swift Package Manager パッケージです。小さな C ABI を通じて解析とレンダリングをすべて `mdi-core` に委譲し、Swift 側は文法やレンダリングの判断を持ちません。
 
-将来は UniFFI または小さな C ABI で `mdi-core` を呼び出し、同じ IR と診断を Swift の値型へ写像する予定です。
+リポジトリ開発時は `swift/Package.swift` がローカルのバインディング構成を提供します。`Publish Swift Package` workflow はネイティブ Rust ライブラリを XCFramework としてビルド・テストし、root の `Package.swift` を生成して tag を作成し、GitHub Actions の組み込み token で artifact をアップロードします。
+
+同じ構文／IR バージョン、診断、UTF-8 バイトスパン、完全な文書ツリーを公開します。`MDIParseResult.document` は可逆な `MDIJSONValue` で表し、SwiftPM の配布パッケージは `IllusionMarkdown`、import module は `MDI` です。公開 API は `parse`、`renderHTML`、`serialize`、`renderText`、`renderEPUB`、`renderDOCX` です。

--- a/nodejs/docs/src/content/docs/zh-tw/bindings/swift.md
+++ b/nodejs/docs/src/content/docs/zh-tw/bindings/swift.md
@@ -3,6 +3,8 @@ title: Swift
 description: Swift binding 的狀態與預期契約。
 ---
 
-**Planned。** `swift/README.md` 明確寫著尚未實作。目前沒有 Swift package、XCFramework 或生成的 API reference。
+Swift 綁定是名為 `IllusionMarkdown` 的 Swift Package Manager 套件。它透過小型 C ABI 將所有解析與轉譯交給 `mdi-core`；Swift 不會包含語法或轉譯判斷。
 
-預期會透過 UniFFI 或小型 C ABI 呼叫 `mdi-core`，把相同 IR 與診斷映射成 Swift value types。
+在此 repository 開發時，`swift/Package.swift` 提供本地綁定配置。`Publish Swift Package` workflow 會把原生 Rust 函式庫建置並測試為 XCFramework、寫入 root `Package.swift`、建立 tag，並用 GitHub Actions 的內建 token 上傳 artifact。
+
+它公開與其他語言相同的語法／IR 版本、診斷、UTF-8 位元組跨度與完整文件樹。`MDIParseResult.document` 使用無損的 `MDIJSONValue` 標記 JSON 值；跨度與診斷則使用 Swift 原生值型別。SwiftPM 發行套件是 `IllusionMarkdown`，import module 是 `MDI`。公開入口為 `parse`、`renderHTML`、`serialize`、`renderText`、`renderEPUB` 與 `renderDOCX`。

--- a/scripts/package-swift-xcframework.sh
+++ b/scripts/package-swift-xcframework.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 <output-directory>" >&2
+  exit 64
+fi
+
+output_directory="$1"
+root_directory="$(cd "$(dirname "$0")/.." && pwd)"
+work_directory="$(mktemp -d "${TMPDIR:-/tmp}/mdi-swift-xcframework.XXXXXX")"
+trap 'rm -rf "$work_directory"' EXIT
+
+headers_directory="$work_directory/headers"
+mkdir -p "$headers_directory" "$output_directory"
+cp "$root_directory/swift/Sources/MDICore/include/mdi_core.h" "$headers_directory/mdi_core.h"
+printf '%s\n' 'module MDICore { header "mdi_core.h" export * }' > "$headers_directory/module.modulemap"
+
+build_library() {
+  local target="$1"
+  (
+    cd "$root_directory/mdi-core"
+    cargo build --locked --release --target "$target"
+  )
+}
+
+for target in \
+  aarch64-apple-darwin \
+  x86_64-apple-darwin \
+  aarch64-apple-ios \
+  aarch64-apple-ios-sim \
+  x86_64-apple-ios; do
+  build_library "$target"
+done
+
+macos_library="$work_directory/libmdi_core-macos.a"
+ios_simulator_library="$work_directory/libmdi_core-ios-simulator.a"
+lipo -create \
+  "$root_directory/mdi-core/target/aarch64-apple-darwin/release/libmdi_core.a" \
+  "$root_directory/mdi-core/target/x86_64-apple-darwin/release/libmdi_core.a" \
+  -output "$macos_library"
+lipo -create \
+  "$root_directory/mdi-core/target/aarch64-apple-ios-sim/release/libmdi_core.a" \
+  "$root_directory/mdi-core/target/x86_64-apple-ios/release/libmdi_core.a" \
+  -output "$ios_simulator_library"
+
+xcodebuild -create-xcframework \
+  -library "$macos_library" -headers "$headers_directory" \
+  -library "$root_directory/mdi-core/target/aarch64-apple-ios/release/libmdi_core.a" -headers "$headers_directory" \
+  -library "$ios_simulator_library" -headers "$headers_directory" \
+  -output "$output_directory/MDICore.xcframework"

--- a/scripts/write-swift-package-manifest.sh
+++ b/scripts/write-swift-package-manifest.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+  echo "usage: $0 local <xcframework-path> | remote <url> <checksum>" >&2
+  exit 64
+fi
+
+root_directory="$(cd "$(dirname "$0")/.." && pwd)"
+mode="$1"
+
+case "$mode" in
+  local)
+    if [[ $# -ne 2 ]]; then
+      echo "usage: $0 local <xcframework-path>" >&2
+      exit 64
+    fi
+    binary_target=".binaryTarget(name: \"MDICore\", path: \"$2\")"
+    ;;
+  remote)
+    if [[ $# -ne 3 ]]; then
+      echo "usage: $0 remote <url> <checksum>" >&2
+      exit 64
+    fi
+    binary_target=".binaryTarget(name: \"MDICore\", url: \"$2\", checksum: \"$3\")"
+    ;;
+  *)
+    echo "unknown mode: $mode" >&2
+    exit 64
+    ;;
+esac
+
+cat > "$root_directory/Package.swift" <<EOF
+// swift-tools-version: 5.10
+import PackageDescription
+
+let package = Package(
+    name: "IllusionMarkdown",
+    platforms: [.macOS(.v13), .iOS(.v15)],
+    products: [
+        .library(name: "MDI", targets: ["MDI"]),
+    ],
+    targets: [
+        $binary_target,
+        .target(name: "MDI", dependencies: ["MDICore"], path: "swift/Sources/MDI"),
+        .testTarget(name: "MDITests", dependencies: ["MDI"], path: "swift/Tests/MDITests"),
+    ]
+)
+EOF

--- a/swift/Package.swift
+++ b/swift/Package.swift
@@ -2,11 +2,14 @@
 import PackageDescription
 
 let package = Package(
-	name: "MDI",
+	name: "IllusionMarkdown",
+	platforms: [.macOS(.v13)],
 	products: [
 		.library(name: "MDI", targets: ["MDI"]),
 	],
 	targets: [
-		.target(name: "MDI"),
+		.systemLibrary(name: "MDICore", path: "Sources/MDICore"),
+		.target(name: "MDI", dependencies: ["MDICore"]),
+		.testTarget(name: "MDITests", dependencies: ["MDI"]),
 	]
 )

--- a/swift/README.md
+++ b/swift/README.md
@@ -1,3 +1,41 @@
-# MDI (Swift)
+# IllusionMarkdown
 
-Swift implementation of [illusion Markdown (MDI)](../SYNTAX.md). Not yet implemented.
+SwiftPM binding for [illusion Markdown (MDI)](../SYNTAX.md). Rust remains the
+only parser and renderer: Swift receives the versioned JSON document IR and
+forwards rendering requests through the `mdi-core` C ABI.
+
+## Package name
+
+The SwiftPM package is named `IllusionMarkdown`, while its library product and
+module are named `MDI`. This keeps the distribution name distinctive while
+making Swift usage align with the MDI format name.
+
+## Development
+
+Build the Rust dynamic library before running the Swift tests:
+
+```bash
+cd ../mdi-core
+cargo build
+
+cd ../swift
+swift build
+```
+
+The `Publish Swift Package` workflow turns the Rust core into an XCFramework,
+tests it, then writes the root `Package.swift`, tags a complete SemVer release,
+and uploads the binary with GitHub Actions' built-in `GITHUB_TOKEN`. No PAT or
+second repository is required.
+
+## Usage
+
+```swift
+import MDI
+
+let result = try MDI.parse("{東京|とうきょう}で第^12^話")
+let html = try MDI.renderHTML("# 題\n\n{東京|とうきょう}")
+let epub = try MDI.renderEPUB("# Chapter")
+```
+
+`MDIParseResult.document` is a lossless `MDIJSONValue`, so every node and
+field emitted by the Rust IR is available without Swift-side grammar logic.

--- a/swift/Sources/MDI/MDI.swift
+++ b/swift/Sources/MDI/MDI.swift
@@ -1,2 +1,126 @@
-// Swift implementation of illusion Markdown (MDI). Not yet implemented — see
-// SYNTAX.md at the repository root for the spec this package will target.
+import Foundation
+import MDICore
+
+/// MDI's supported language-specification version.
+public let mdiSpecVersion = "2.0"
+
+/// The version of the Rust-owned JSON document contract.
+public let mdiIRVersion = "1.0"
+
+public enum MDIError: Error, Equatable, LocalizedError, Sendable {
+    case core(String)
+    case invalidWireFormat(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case let .core(message), let .invalidWireFormat(message):
+            return message
+        }
+    }
+}
+
+public struct MDISourceSpan: Codable, Equatable, Sendable {
+    public let startByte: UInt32
+    public let endByte: UInt32
+}
+
+public struct MDIParserCapabilities: Codable, Equatable, Sendable {
+    public let mdi: Bool
+    public let commonMark: Bool
+    public let gfm: Bool
+    public let frontMatter: Bool
+    public let sourceSpans: Bool
+}
+
+public enum MDIDiagnosticSeverity: String, Codable, Sendable { case warning, error }
+
+public struct MDIDiagnostic: Codable, Equatable, Sendable {
+    public let severity: MDIDiagnosticSeverity
+    public let code: String
+    public let message: String
+    public let span: MDISourceSpan?
+}
+
+/// Lossless representation of a value in the versioned MDI document IR.
+public indirect enum MDIJSONValue: Codable, Equatable, Sendable {
+    case null
+    case bool(Bool)
+    case number(Double)
+    case string(String)
+    case array([MDIJSONValue])
+    case object([String: MDIJSONValue])
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if container.decodeNil() { self = .null }
+        else if let value = try? container.decode(Bool.self) { self = .bool(value) }
+        else if let value = try? container.decode(Double.self) { self = .number(value) }
+        else if let value = try? container.decode(String.self) { self = .string(value) }
+        else if let value = try? container.decode([MDIJSONValue].self) { self = .array(value) }
+        else { self = .object(try container.decode([String: MDIJSONValue].self)) }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .null: try container.encodeNil()
+        case let .bool(value): try container.encode(value)
+        case let .number(value): try container.encode(value)
+        case let .string(value): try container.encode(value)
+        case let .array(value): try container.encode(value)
+        case let .object(value): try container.encode(value)
+        }
+    }
+}
+
+public struct MDIParseResult: Codable, Equatable, Sendable {
+    public let irVersion: String
+    public let syntaxVersion: String
+    public let capabilities: MDIParserCapabilities
+    public let document: MDIJSONValue
+    public let diagnostics: [MDIDiagnostic]
+}
+
+/// Swift interface to the Rust-owned MDI parser and renderers.
+public enum MDI {
+    public static func parse(_ source: String) throws -> MDIParseResult {
+        let data = try call(source, operation: mdi_parse_json)
+        let result: MDIParseResult
+        do { result = try JSONDecoder().decode(MDIParseResult.self, from: data) }
+        catch { throw MDIError.invalidWireFormat("MDI core returned invalid parse JSON: \(error.localizedDescription)") }
+        guard result.irVersion == mdiIRVersion else {
+            throw MDIError.invalidWireFormat("Unsupported MDI IR version: \(result.irVersion)")
+        }
+        return result
+    }
+
+    public static func renderHTML(_ source: String) throws -> String { try stringCall(source, operation: mdi_render_html) }
+    public static func serialize(_ source: String) throws -> String { try stringCall(source, operation: mdi_serialize_mdi) }
+    public static func renderText(_ source: String) throws -> String { try stringCall(source, operation: mdi_render_text) }
+    public static func renderEPUB(_ source: String) throws -> Data { try call(source, operation: mdi_render_epub) }
+    public static func renderDOCX(_ source: String) throws -> Data { try call(source, operation: mdi_render_docx) }
+
+    private static func stringCall(_ source: String, operation: MDIFFIOperation) throws -> String {
+        let data = try call(source, operation: operation)
+        guard let value = String(data: data, encoding: .utf8) else {
+            throw MDIError.invalidWireFormat("MDI core returned non-UTF-8 string data")
+        }
+        return value
+    }
+
+    private static func call(_ source: String, operation: MDIFFIOperation) throws -> Data {
+        let bytes = Array(source.utf8)
+        let result = bytes.withUnsafeBufferPointer { operation($0.baseAddress, $0.count) }
+        defer { mdi_free_buffer(result.value); mdi_free_buffer(result.error) }
+        if result.error.len > 0 {
+            let message = String(data: Data(bytes: result.error.data!, count: result.error.len), encoding: .utf8) ?? "Unknown MDI core error"
+            throw MDIError.core(message)
+        }
+        guard result.value.len == 0 || result.value.data != nil else {
+            throw MDIError.invalidWireFormat("MDI core returned an invalid buffer")
+        }
+        return result.value.len == 0 ? Data() : Data(bytes: result.value.data!, count: result.value.len)
+    }
+}
+
+private typealias MDIFFIOperation = @convention(c) (UnsafePointer<UInt8>?, Int) -> mdi_ffi_result

--- a/swift/Sources/MDICore/include/mdi_core.h
+++ b/swift/Sources/MDICore/include/mdi_core.h
@@ -1,0 +1,18 @@
+#ifndef MDI_CORE_H
+#define MDI_CORE_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+typedef struct { uint8_t *data; size_t len; } mdi_ffi_buffer;
+typedef struct { mdi_ffi_buffer value; mdi_ffi_buffer error; } mdi_ffi_result;
+
+mdi_ffi_result mdi_parse_json(const uint8_t *data, size_t len);
+mdi_ffi_result mdi_render_html(const uint8_t *data, size_t len);
+mdi_ffi_result mdi_serialize_mdi(const uint8_t *data, size_t len);
+mdi_ffi_result mdi_render_text(const uint8_t *data, size_t len);
+mdi_ffi_result mdi_render_epub(const uint8_t *data, size_t len);
+mdi_ffi_result mdi_render_docx(const uint8_t *data, size_t len);
+void mdi_free_buffer(mdi_ffi_buffer buffer);
+
+#endif

--- a/swift/Sources/MDICore/module.modulemap
+++ b/swift/Sources/MDICore/module.modulemap
@@ -1,0 +1,4 @@
+module MDICore [system] {
+  header "include/mdi_core.h"
+  export *
+}

--- a/swift/Tests/MDITests/MDITests.swift
+++ b/swift/Tests/MDITests/MDITests.swift
@@ -1,0 +1,26 @@
+import Foundation
+import XCTest
+@testable import MDI
+
+final class MDITests: XCTestCase {
+    func testParsesRustOwnedDocument() throws {
+        let result = try MDI.parse("第^12^話")
+        XCTAssertEqual(result.irVersion, mdiIRVersion)
+        XCTAssertEqual(result.syntaxVersion, mdiSpecVersion)
+        XCTAssertTrue(result.capabilities.mdi)
+        XCTAssertTrue(result.capabilities.commonMark)
+        XCTAssertTrue(result.diagnostics.isEmpty)
+    }
+
+    func testRendersThroughRust() throws {
+        let html = try MDI.renderHTML("{東京|とうきょう} ^12^")
+        XCTAssertTrue(html.contains("<ruby class=\"mdi-ruby\">東京"))
+        XCTAssertTrue(html.contains("<span class=\"mdi-tcy\">12</span>"))
+        XCTAssertEqual(try MDI.renderText("{東京|とうきょう} ^12^"), "東京 12\n")
+    }
+
+    func testReturnsBinaryDocuments() throws {
+        XCTAssertEqual(Array(try MDI.renderEPUB("text").prefix(2)), [0x50, 0x4b])
+        XCTAssertEqual(Array(try MDI.renderDOCX("text").prefix(2)), [0x50, 0x4b])
+    }
+}


### PR DESCRIPTION
## Summary

- add the `MDI` Swift module backed exclusively by the Rust C ABI
- add a macOS/iOS XCFramework packaging script and a `GITHUB_TOKEN`-only release workflow
- generate the root SwiftPM manifest during a tagged release so the monorepo can be consumed directly by SwiftPM

## Publishing

After merging, run **Publish Swift Package** on `main` with the first SemVer version (for example `2.0.1`). The workflow builds and tests the XCFramework, creates the tag and GitHub Release asset, and writes the root `Package.swift`. That public release is then eligible for Swift Package Index submission.

## Validation

- `cargo test`
- `cargo clippy -- -D warnings`
- `swift build`
- manifest and workflow YAML parsing

The local machine has Command Line Tools rather than a full Xcode installation, so final iOS XCFramework assembly runs on the workflow's `macos-15` runner.
