### PR TITLE
Improve Python package metadata and README

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,7 +13,8 @@ permissions:
   id-token: write
 
 concurrency:
-  group: pages
+  # A main deployment must not cancel documentation builds required by a PR.
+  group: pages-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/nodejs/docs/src/content/docs/bindings/python.md
+++ b/nodejs/docs/src/content/docs/bindings/python.md
@@ -23,3 +23,6 @@ JSON-compatible Python dictionaries. Source spans are UTF-8 byte offsets.
 `serialize_mdi`, `render_text`, `render_text_format`, `render_epub`, and
 `render_docx` also delegate directly to `mdi-core`; Python contains no MDI
 tokenizer or renderer.
+
+The package README and PyPI metadata link to this page as the official Python
+API documentation.

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -102,7 +102,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "illusion-markdown-python"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "mdi-core",
  "pyo3",

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "illusion-markdown-python"
-version = "2.0.1"
+version = "2.0.2"
 edition = "2024"
 license = "MIT"
 publish = false

--- a/python/README.md
+++ b/python/README.md
@@ -1,25 +1,79 @@
 # illusion-markdown
 
-Python bindings for [illusion Markdown (MDI)](../SYNTAX.md). The package is a
-thin PyO3 interface over the repository's Rust `mdi-core`; it does not parse
-or render MDI in Python.
+[![PyPI](https://img.shields.io/pypi/v/illusion-markdown?style=flat-square)](https://pypi.org/project/illusion-markdown/)
+[![Python](https://img.shields.io/pypi/pyversions/illusion-markdown?style=flat-square)](https://pypi.org/project/illusion-markdown/)
+[![License](https://img.shields.io/pypi/l/illusion-markdown?style=flat-square)](https://github.com/illusions-lab/MDI/blob/main/LICENSE)
+
+Official Python bindings for [illusion Markdown (MDI)](https://mdi.illusions.app/).
+`illusion-markdown` parses complete MDI documents, returns the versioned
+document IR, and renders HTML, text, EPUB, and DOCX through the canonical
+Rust implementation. Python is an ergonomic API layer only: it does not carry
+a second Markdown parser or renderer.
+
+**[Read the Python API documentation →](https://mdi.illusions.app/bindings/python/)**
+
+## Install
 
 ```bash
 pip install illusion-markdown
 ```
 
+The PyPI distribution is `illusion-markdown`; the Python import namespace is
+`mdi`. Python 3.10 or newer is required.
+
+## Quick start
+
 ```python
 import mdi
 
-result = mdi.parse("{東京|とうきょう} ^12^")
-html = mdi.render_html("# 題\n\n{東京|とうきょう}")
-epub = mdi.render_epub("# Chapter\n\ntext")
+source = """---
+title: 東京の夜
+lang: ja
+---
+
+# {東京|とうきょう}の夜
+
+第^12^話
+"""
+
+result = mdi.parse(source)
+print(result["document"]["children"][0]["type"])
+
+html = mdi.render_html(source)
+open("book.html", "w", encoding="utf-8").write(html)
 ```
 
-`parse()` returns the versioned, JSON-compatible MDI document IR with UTF-8
-byte spans and recoverable diagnostics. The package also exposes
-`serialize_mdi`, `render_text`, `render_text_format`, `render_epub`, and
-`render_docx`.
+`parse()` returns a JSON-compatible dictionary with the MDI syntax version,
+IR version, parser capabilities, document tree, and recoverable diagnostics.
+Every source-backed span is a half-open UTF-8 byte range.
 
-The PyPI distribution is named `illusion-markdown`; the import namespace is
-`mdi`.
+## API
+
+| Function | Result |
+| --- | --- |
+| `mdi.parse(source)` | Versioned document IR and diagnostics. |
+| `mdi.serialize_mdi(source)` | Canonical MDI/Markdown source. |
+| `mdi.render_html(source)` | A standalone HTML document. |
+| `mdi.render_text(source)` | Deterministic plain text. |
+| `mdi.render_text_format(source, format)` | TXT, ruby, Narou, Kakuyomu, or Aozora text. |
+| `mdi.render_epub(source)` | EPUB 3 archive bytes. |
+| `mdi.render_docx(source)` | DOCX archive bytes. |
+
+```python
+epub_bytes = mdi.render_epub("# Chapter\n\nText")
+with open("book.epub", "wb") as output:
+    output.write(epub_bytes)
+```
+
+See the **[official Python documentation](https://mdi.illusions.app/bindings/python/)**
+for API details, the complete MDI syntax, output formats, and architecture.
+
+## Platform support
+
+Prebuilt wheels are published for macOS (Intel and Apple Silicon), Linux x64,
+and Windows x64. A source distribution is also available for other platforms
+with a supported Rust toolchain.
+
+## License
+
+[MIT](https://github.com/illusions-lab/MDI/blob/main/LICENSE)

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "illusion-markdown"
-version = "2.0.1"
+version = "2.0.2"
 description = "Python bindings for illusion Markdown (MDI), backed by the Rust core."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -26,7 +26,7 @@ build-backend = "maturin"
 
 [project.urls]
 Homepage = "https://github.com/illusions-lab/MDI"
-Documentation = "https://illusions-lab.github.io/mdi-js/"
+Documentation = "https://mdi.illusions.app/bindings/python/"
 Repository = "https://github.com/illusions-lab/MDI"
 Issues = "https://github.com/illusions-lab/MDI/issues"
 


### PR DESCRIPTION
Expands the PyPI README with installation, quick start, API, and platform guidance. Points package metadata to the official Python documentation and releases version 2.0.2.