### PR TITLE
Expand npm package documentation

### DIFF
--- a/nodejs/packages/cli/README.md
+++ b/nodejs/packages/cli/README.md
@@ -1,6 +1,15 @@
-# @illusions-lab/mdi-cli
+# `@illusions-lab/mdi-cli`
 
-Thin command-line adapter for the Rust-authoritative MDI engine.
+Command-line interface for building complete `.mdi` documents through the
+Rust-authoritative MDI engine.
+
+## Install
+
+```sh
+npm install --global @illusions-lab/mdi-cli
+```
+
+## Build a document
 
 ```sh
 mdi build input.mdi --to html|pdf|epub|docx|txt|txt-ruby|narou|kakuyomu|aozora|txt-all \
@@ -15,6 +24,30 @@ and front matter metadata while their full profile options move into Rust.
 
 `txt-all` writes every text variant next to the input and does not accept `-o`.
 
-Part of the [MDI](https://github.com/illusions-lab/MDI) monorepo. See the root README for the full package architecture.
+## Examples
 
-Documentation: https://mdi.illusions.app/
+```sh
+# Rust renders semantic HTML.
+mdi build novel.mdi --to html -o public/novel.html
+
+# Rust produces EPUB and DOCX archives.
+mdi build novel.mdi --to epub
+mdi build novel.mdi --to docx
+
+# PDF uses Rust HTML and Chromium only for print layout.
+mdi build novel.mdi --to pdf --config print.json
+```
+
+## Architecture
+
+The CLI does not parse MDI itself. HTML, EPUB, DOCX, and text call the Rust
+engine through `@illusions-lab/mdi`; PDF gives Rust-rendered HTML to Chromium
+solely for print layout. `--config` currently configures PDF and text output.
+
+## Documentation
+
+- [CLI guide](https://mdi.illusions.app/bindings/cli/)
+- [Export profiles](https://mdi.illusions.app/guides/export-profiles/)
+- [MDI documentation](https://mdi.illusions.app/)
+
+Part of the [MDI repository](https://github.com/illusions-lab/MDI). MIT licensed.

--- a/nodejs/packages/export-profile/README.md
+++ b/nodejs/packages/export-profile/README.md
@@ -1,7 +1,34 @@
-# @illusions-lab/mdi-export-profile
+# `@illusions-lab/mdi-export-profile`
 
-Typed JavaScript representation of the export profiles accepted by the Rust
-PDF, DOCX, EPUB, HTML, and text renderers. Profiles configure presentation and
-metadata; they never change syntax rules. See the
-[export-profile guide](https://mdi.illusions.app/guides/export-profiles/) for
-configuration and CLI usage.
+Typed export-profile schema shared by MDI output adapters. A profile controls
+presentation and metadata—page geometry, typography, page numbers, EPUB
+chapters, and publication-text options—without changing MDI syntax.
+
+## Install
+
+```sh
+npm install @illusions-lab/mdi-export-profile
+```
+
+## Usage
+
+```ts
+import { parseExportProfileJson, resolveExportProfile } from "@illusions-lab/mdi-export-profile";
+
+const profile = resolveExportProfile({
+  metadata: { title: "A short work", language: "ja" },
+  typesetting: { writingMode: "vertical", fontFamily: "Noto Serif JP" },
+});
+
+const fromFile = parseExportProfileJson('{"pagination":{"pageSize":"A5"}}');
+```
+
+Use the resolved profile with the JavaScript PDF/mdast adapters or pass a JSON
+profile to `mdi build --config export.json`. Rust remains responsible for MDI
+syntax and document semantics.
+
+## Documentation
+
+- [Export-profile guide](https://mdi.illusions.app/guides/export-profiles/)
+- [API reference](https://mdi.illusions.app/api/export-profile/)
+- [MDI documentation](https://mdi.illusions.app/)

--- a/nodejs/packages/export-profile/package.json
+++ b/nodejs/packages/export-profile/package.json
@@ -8,6 +8,8 @@
     "url": "git+https://github.com/illusions-lab/MDI.git",
     "directory": "nodejs/packages/export-profile"
   },
+  "homepage": "https://mdi.illusions.app/",
+  "bugs": "https://github.com/illusions-lab/MDI/issues",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/nodejs/packages/mdast-util-mdi/README.md
+++ b/nodejs/packages/mdast-util-mdi/README.md
@@ -1,24 +1,39 @@
 # `mdast-util-mdi`
 
-Bidirectional adapter between the versioned Rust MDI document IR and mdast.
+Serialization extension and TypeScript node definitions for MDI-flavoured
+mdast trees. It lets an existing unified pipeline write MDI nodes back to
+canonical MDI source with `mdast-util-to-markdown`.
 
-```text
-Rust document IR ⇄ mdast
+## Install
+
+```sh
+npm install mdast-util-mdi mdast-util-to-markdown
 ```
 
-The IR-to-mdast direction creates CommonMark, GFM, front-matter, and MDI node
-shapes for unified-compatible tools. The mdast-to-IR direction converts a
-modified tree back into the stable wire representation; Rust then validates,
-normalizes, serializes, or renders it.
+## Usage
+
+```ts
+import { toMarkdown } from "mdast-util-to-markdown";
+import { mdiToMarkdown } from "mdast-util-mdi";
+
+const source = toMarkdown(
+  { type: "root", children: [{ type: "paragraph", children: [{ type: "mdiTcy", value: "12" }] }] },
+  { extensions: [mdiToMarkdown()] },
+);
+// ^12^\n
+```
 
 This package does not parse MDI source and contains no tokenizer, grammar
-tables, delimiter matching, or literal-fallback rules. `mdi-core` remains the
-sole executable syntax authority in both directions.
-
-Use [`@illusions-lab/mdi`](../mdi) to parse complete source documents. Use this
-package when an application needs to run mdast or unified tooling over a Rust
-parse result.
+tables, delimiter matching, or literal-fallback rules. Parse complete source
+with [`@illusions-lab/mdi`](https://www.npmjs.com/package/@illusions-lab/mdi);
+Rust remains the sole executable syntax authority.
 
 Part of the [MDI](https://github.com/illusions-lab/MDI) monorepo. See the
 [architecture documentation](https://mdi.illusions.app/guides/architecture/)
 for ownership and wire-contract details.
+
+## Documentation
+
+- [Remark / mdast adapter guide](https://mdi.illusions.app/ecosystem/remark/)
+- [API reference](https://mdi.illusions.app/api/mdast-util-mdi/)
+- [MDI documentation](https://mdi.illusions.app/)

--- a/nodejs/packages/mdi-core/README.md
+++ b/nodejs/packages/mdi-core/README.md
@@ -1,0 +1,45 @@
+# `@illusions-lab/mdi-core`
+
+Low-level WebAssembly bindings for the Rust implementation of MDI 2.0.
+This package is the executable syntax authority used by the higher-level
+[`@illusions-lab/mdi`](https://www.npmjs.com/package/@illusions-lab/mdi)
+binding: it parses complete MDI documents, validates and serializes the
+versioned document IR, and renders HTML, TXT, EPUB, and DOCX.
+
+## Install
+
+```sh
+npm install @illusions-lab/mdi-core
+```
+
+## Recommended API
+
+Most JavaScript applications should use `@illusions-lab/mdi` instead. It
+provides typed result objects and stable host-boundary checks:
+
+```sh
+npm install @illusions-lab/mdi
+```
+
+`@illusions-lab/mdi-core` is for tooling that intentionally needs the raw
+generated WASM interface, such as a custom language binding or an integration
+that transports the Rust JSON IR directly. It is not a second JavaScript
+parser and does not contain a JavaScript grammar.
+
+## Ownership boundary
+
+```text
+MDI source → Rust/WASM core → versioned document IR / rendered output
+```
+
+CommonMark, GFM, front matter, MDI extensions, escapes, nesting, diagnostics,
+and literal fallback are all decided in Rust.
+
+## Documentation
+
+- [MDI documentation](https://mdi.illusions.app/)
+- [JavaScript binding guide](https://mdi.illusions.app/bindings/javascript/)
+- [Rust core API](https://mdi.illusions.app/core/rust-api/)
+- [Source repository](https://github.com/illusions-lab/MDI)
+
+MIT licensed.

--- a/nodejs/packages/mdi-core/package.json
+++ b/nodejs/packages/mdi-core/package.json
@@ -8,7 +8,7 @@
     "url": "git+https://github.com/illusions-lab/MDI.git",
     "directory": "nodejs/packages/mdi-core"
   },
-  "homepage": "https://illusions-lab.github.io/mdi-js/",
+  "homepage": "https://mdi.illusions.app/",
   "bugs": "https://github.com/illusions-lab/MDI/issues",
   "main": "./dist/mdi_core.js",
   "types": "./dist/mdi_core.d.ts",

--- a/nodejs/packages/mdi/README.md
+++ b/nodejs/packages/mdi/README.md
@@ -4,6 +4,12 @@ The JavaScript interface to the Rust-authoritative MDI engine. Give it a
 complete `.mdi` source document and it returns the versioned document IR and
 diagnostics produced by `mdi-core`.
 
+## Install
+
+```sh
+npm install @illusions-lab/mdi
+```
+
 ```ts
 import { parse } from "@illusions-lab/mdi";
 
@@ -81,3 +87,10 @@ validation and serialization.
 The normative human-readable syntax is defined in
 [`SYNTAX.md`](https://github.com/illusions-lab/MDI/blob/main/SYNTAX.md). The
 executable syntax authority is `mdi-core`.
+
+## Documentation
+
+- [JavaScript binding guide](https://mdi.illusions.app/bindings/javascript/)
+- [Document IR and diagnostics](https://mdi.illusions.app/core/document-ir/)
+- [Rendering model](https://mdi.illusions.app/core/rendering/)
+- [MDI documentation](https://mdi.illusions.app/)

--- a/nodejs/packages/remark/README.md
+++ b/nodejs/packages/remark/README.md
@@ -2,6 +2,12 @@
 
 Unified/remark adapter for the Rust-authoritative MDI engine.
 
+## Install
+
+```sh
+npm install @illusions-lab/mdi-remark unified remark-parse remark-stringify
+```
+
 The adapter sends the complete source document to `mdi-core`, exposes the
 resulting versioned document IR as mdast to a unified pipeline, and converts a
 modified mdast tree back to Rust IR when the pipeline needs MDI serialization
@@ -15,6 +21,19 @@ It does not extend remark's tokenizer and does not implement CommonMark, GFM,
 front matter, or MDI syntax. All parsing, boundary decisions, validation,
 normalization, serialization, and renderer semantics remain in Rust.
 
+## Usage
+
+```ts
+import { unified } from "unified";
+import remarkParse from "remark-parse";
+import remarkStringify from "remark-stringify";
+import remarkMdi from "@illusions-lab/mdi-remark";
+
+const processor = unified().use(remarkParse).use(remarkMdi).use(remarkStringify);
+const tree = processor.parse("{東京|とうきょう} ^12^");
+const output = String(await processor.process("[[em:傍点]]"));
+```
+
 Use [`@illusions-lab/mdi`](../mdi) directly when unified plugins are not
 required. This package exists only to connect the same Rust parse result to the
 remark ecosystem.
@@ -22,3 +41,9 @@ remark ecosystem.
 Part of the [MDI](https://github.com/illusions-lab/MDI) monorepo. See the
 [architecture documentation](https://mdi.illusions.app/guides/architecture/)
 for ownership and wire-contract details.
+
+## Documentation
+
+- [Remark / mdast adapter guide](https://mdi.illusions.app/ecosystem/remark/)
+- [JavaScript binding guide](https://mdi.illusions.app/bindings/javascript/)
+- [MDI documentation](https://mdi.illusions.app/)

--- a/nodejs/packages/to-docx/README.md
+++ b/nodejs/packages/to-docx/README.md
@@ -1,10 +1,33 @@
 # @illusions-lab/mdi-to-docx
 
-Legacy mdast-to-DOCX compatibility adapter for unified ecosystem consumers.
-The Rust-first CLI uses `renderDocx()` from `@illusions-lab/mdi` directly.
-This package remains available for applications that need its existing
-profile-aware mdast integration surface.
+Creates a DOCX file from an MDI-flavoured mdast tree. It is a profile-aware
+compatibility adapter for unified applications and does not parse MDI source.
 
-Part of the [MDI](https://github.com/illusions-lab/MDI) monorepo. See the root README for the full package architecture.
+## Install
 
-Documentation: https://mdi.illusions.app/
+```sh
+npm install @illusions-lab/mdi-to-docx
+```
+
+## Usage
+
+```ts
+import { writeFile } from "node:fs/promises";
+import { mdiToDocx } from "@illusions-lab/mdi-to-docx";
+
+const document = await mdiToDocx(mdastTree, {
+  typesetting: { writingMode: "vertical", fontFamily: "Noto Serif JP" },
+});
+await writeFile("book.docx", document);
+```
+
+For complete `.mdi` source, use `renderDocx(source)` from
+[`@illusions-lab/mdi`](https://www.npmjs.com/package/@illusions-lab/mdi).
+The MDI CLI uses that Rust route directly.
+
+## Documentation
+
+- [Output model](https://mdi.illusions.app/ecosystem/outputs/)
+- [Export-profile guide](https://mdi.illusions.app/guides/export-profiles/)
+- [API reference](https://mdi.illusions.app/api/to-docx/)
+- [MDI documentation](https://mdi.illusions.app/)

--- a/nodejs/packages/to-epub/README.md
+++ b/nodejs/packages/to-epub/README.md
@@ -1,10 +1,33 @@
 # @illusions-lab/mdi-to-epub
 
-Legacy mdast-to-EPUB compatibility adapter for unified ecosystem consumers.
-The Rust-first CLI uses `renderEpub()` from `@illusions-lab/mdi` directly.
-This package remains available for applications that need its existing
-profile, cover, and mdast integration surface.
+Creates an EPUB 3 archive from an MDI-flavoured mdast tree. The adapter keeps
+support for profile metadata, chapter splitting, cover images, and unified
+integration; it does not parse MDI.
 
-Part of the [MDI](https://github.com/illusions-lab/MDI) monorepo. See the root README for the full package architecture.
+## Install
 
-Documentation: https://mdi.illusions.app/
+```sh
+npm install @illusions-lab/mdi-to-epub
+```
+
+## Usage
+
+```ts
+import { mdiToEpub } from "@illusions-lab/mdi-to-epub";
+
+const archive = await mdiToEpub(mdastTree, {
+  profile: { metadata: { title: "A short work" } },
+  cover: { data: coverBytes, mediaType: "image/png" },
+});
+```
+
+For complete `.mdi` source, use `renderEpub(source)` from
+[`@illusions-lab/mdi`](https://www.npmjs.com/package/@illusions-lab/mdi).
+The Rust-first CLI follows that route.
+
+## Documentation
+
+- [Output model](https://mdi.illusions.app/ecosystem/outputs/)
+- [Export-profile guide](https://mdi.illusions.app/guides/export-profiles/)
+- [API reference](https://mdi.illusions.app/api/to-epub/)
+- [MDI documentation](https://mdi.illusions.app/)

--- a/nodejs/packages/to-hast/README.md
+++ b/nodejs/packages/to-hast/README.md
@@ -1,10 +1,31 @@
 # @illusions-lab/mdi-to-hast
 
-Legacy mdast-to-HAST compatibility adapter for unified ecosystem consumers.
-It contains no MDI grammar and is not used by the Rust-first CLI. New source
-applications should use `@illusions-lab/mdi` for Rust HTML; use this package
-only when an existing unified pipeline requires HAST.
+Converts an MDI-flavoured mdast tree into HAST and exposes the matching MDI CSS
+and `remark-rehype` handler table. It is for existing unified ecosystems; it
+does not parse MDI or decide syntax.
 
-Part of the [MDI](https://github.com/illusions-lab/MDI) monorepo. See the root README for the full package architecture.
+## Install
 
-Documentation: https://mdi.illusions.app/
+```sh
+npm install @illusions-lab/mdi-to-hast
+```
+
+## Usage
+
+```ts
+import { mdiToHast, MDI_STYLESHEET } from "@illusions-lab/mdi-to-hast";
+
+const { hast, frontmatter } = mdiToHast(mdastTree);
+console.log(hast, frontmatter, MDI_STYLESHEET);
+```
+
+For complete `.mdi` source, prefer `renderHtml()` from
+[`@illusions-lab/mdi`](https://www.npmjs.com/package/@illusions-lab/mdi): Rust
+parses and renders the document directly. Use this package only when a unified
+pipeline already owns an mdast tree.
+
+## Documentation
+
+- [Remark / mdast adapter guide](https://mdi.illusions.app/ecosystem/remark/)
+- [API reference](https://mdi.illusions.app/api/to-hast/)
+- [MDI documentation](https://mdi.illusions.app/)

--- a/nodejs/packages/to-html/README.md
+++ b/nodejs/packages/to-html/README.md
@@ -1,10 +1,29 @@
 # @illusions-lab/mdi-to-html
 
-Legacy mdast-to-HTML compatibility adapter for unified ecosystem consumers.
-It does not parse MDI, but new source applications and the CLI should use
-`renderHtml()` from `@illusions-lab/mdi`, which renders complete source in
-Rust.
+Renders an MDI-flavoured mdast tree to a complete HTML document with MDI CSS
+and front-matter metadata. It is a compatibility renderer for unified users;
+it does not parse MDI source.
 
-Part of the [MDI](https://github.com/illusions-lab/MDI) monorepo. See the root README for the full package architecture.
+## Install
 
-Documentation: https://mdi.illusions.app/
+```sh
+npm install @illusions-lab/mdi-to-html
+```
+
+## Usage
+
+```ts
+import { mdiToHtml } from "@illusions-lab/mdi-to-html";
+
+const html = mdiToHtml(mdastTree);
+```
+
+For complete source documents, use `renderHtml(source)` from
+[`@illusions-lab/mdi`](https://www.npmjs.com/package/@illusions-lab/mdi).
+That route parses and renders in Rust, and is what the MDI CLI uses.
+
+## Documentation
+
+- [HTML and output model](https://mdi.illusions.app/ecosystem/outputs/)
+- [API reference](https://mdi.illusions.app/api/to-html/)
+- [MDI documentation](https://mdi.illusions.app/)

--- a/nodejs/packages/to-pdf/README.md
+++ b/nodejs/packages/to-pdf/README.md
@@ -5,6 +5,15 @@ an export profile and asks Chromium for PDF bytes. It deliberately accepts
 HTML, not MDI source: syntax parsing and semantic HTML rendering stay in
 `mdi-core`.
 
+## Install
+
+```sh
+npm install @illusions-lab/mdi @illusions-lab/mdi-to-pdf
+npx playwright install chromium
+```
+
+The Playwright browser must be installed on the host that creates PDFs.
+
 ```ts
 import { renderHtml } from "@illusions-lab/mdi";
 import { renderHtmlToPdf } from "@illusions-lab/mdi-to-pdf";
@@ -15,6 +24,19 @@ const pdf = await renderHtmlToPdf(renderHtml("# A Rust-owned document"));
 `mdiToPdf(mdast, profile)` remains available for existing unified consumers,
 but new applications should use the Rust-HTML route above.
 
-Part of the [MDI](https://github.com/illusions-lab/MDI) monorepo. See the root README for the full package architecture.
+## What this package owns
 
-Documentation: https://mdi.illusions.app/
+```text
+MDI source → Rust parser + HTML renderer → Chromium layout → PDF bytes
+```
+
+This package owns only the final print-layout step: page size, margins,
+writing mode, page numbers, and the browser process. It never receives MDI
+source and cannot make syntax or semantic-rendering decisions.
+
+## Documentation
+
+- [Rendering and Chromium boundary](https://mdi.illusions.app/core/rendering/)
+- [Export-profile guide](https://mdi.illusions.app/guides/export-profiles/)
+- [API reference](https://mdi.illusions.app/api/to-pdf/)
+- [MDI documentation](https://mdi.illusions.app/)


### PR DESCRIPTION
Adds complete npm READMEs, installation and usage examples, Rust ownership boundaries, API documentation links, and missing package metadata.