### PR TITLE
Point JavaScript packages to binding documentation

### DIFF
--- a/nodejs/packages/cli/README.md
+++ b/nodejs/packages/cli/README.md
@@ -48,6 +48,6 @@ solely for print layout. `--config` currently configures PDF and text output.
 
 - [CLI guide](https://mdi.illusions.app/bindings/cli/)
 - [Export profiles](https://mdi.illusions.app/guides/export-profiles/)
-- [MDI documentation](https://mdi.illusions.app/)
+- [JavaScript documentation](https://mdi.illusions.app/bindings/javascript/)
 
 Part of the [MDI repository](https://github.com/illusions-lab/MDI). MIT licensed.

--- a/nodejs/packages/cli/package.json
+++ b/nodejs/packages/cli/package.json
@@ -8,7 +8,7 @@
     "url": "git+https://github.com/illusions-lab/MDI.git",
     "directory": "nodejs/packages/cli"
   },
-  "homepage": "https://mdi.illusions.app/",
+  "homepage": "https://mdi.illusions.app/bindings/javascript/",
   "bugs": "https://github.com/illusions-lab/MDI/issues",
   "type": "module",
   "bin": {

--- a/nodejs/packages/export-profile/README.md
+++ b/nodejs/packages/export-profile/README.md
@@ -31,4 +31,4 @@ syntax and document semantics.
 
 - [Export-profile guide](https://mdi.illusions.app/guides/export-profiles/)
 - [API reference](https://mdi.illusions.app/api/export-profile/)
-- [MDI documentation](https://mdi.illusions.app/)
+- [JavaScript documentation](https://mdi.illusions.app/bindings/javascript/)

--- a/nodejs/packages/export-profile/package.json
+++ b/nodejs/packages/export-profile/package.json
@@ -8,7 +8,7 @@
     "url": "git+https://github.com/illusions-lab/MDI.git",
     "directory": "nodejs/packages/export-profile"
   },
-  "homepage": "https://mdi.illusions.app/",
+  "homepage": "https://mdi.illusions.app/bindings/javascript/",
   "bugs": "https://github.com/illusions-lab/MDI/issues",
   "type": "module",
   "main": "./dist/index.js",

--- a/nodejs/packages/mdast-util-mdi/README.md
+++ b/nodejs/packages/mdast-util-mdi/README.md
@@ -36,4 +36,4 @@ for ownership and wire-contract details.
 
 - [Remark / mdast adapter guide](https://mdi.illusions.app/ecosystem/remark/)
 - [API reference](https://mdi.illusions.app/api/mdast-util-mdi/)
-- [MDI documentation](https://mdi.illusions.app/)
+- [JavaScript documentation](https://mdi.illusions.app/bindings/javascript/)

--- a/nodejs/packages/mdast-util-mdi/package.json
+++ b/nodejs/packages/mdast-util-mdi/package.json
@@ -8,7 +8,7 @@
     "url": "git+https://github.com/illusions-lab/MDI.git",
     "directory": "nodejs/packages/mdast-util-mdi"
   },
-  "homepage": "https://mdi.illusions.app/",
+  "homepage": "https://mdi.illusions.app/bindings/javascript/",
   "bugs": "https://github.com/illusions-lab/MDI/issues",
   "type": "module",
   "main": "./dist/index.js",

--- a/nodejs/packages/mdi-core/README.md
+++ b/nodejs/packages/mdi-core/README.md
@@ -37,7 +37,7 @@ and literal fallback are all decided in Rust.
 
 ## Documentation
 
-- [MDI documentation](https://mdi.illusions.app/)
+- [JavaScript documentation](https://mdi.illusions.app/bindings/javascript/)
 - [JavaScript binding guide](https://mdi.illusions.app/bindings/javascript/)
 - [Rust core API](https://mdi.illusions.app/core/rust-api/)
 - [Source repository](https://github.com/illusions-lab/MDI)

--- a/nodejs/packages/mdi-core/package.json
+++ b/nodejs/packages/mdi-core/package.json
@@ -8,7 +8,7 @@
     "url": "git+https://github.com/illusions-lab/MDI.git",
     "directory": "nodejs/packages/mdi-core"
   },
-  "homepage": "https://mdi.illusions.app/",
+  "homepage": "https://mdi.illusions.app/bindings/javascript/",
   "bugs": "https://github.com/illusions-lab/MDI/issues",
   "main": "./dist/mdi_core.js",
   "types": "./dist/mdi_core.d.ts",

--- a/nodejs/packages/mdi/README.md
+++ b/nodejs/packages/mdi/README.md
@@ -93,4 +93,4 @@ executable syntax authority is `mdi-core`.
 - [JavaScript binding guide](https://mdi.illusions.app/bindings/javascript/)
 - [Document IR and diagnostics](https://mdi.illusions.app/core/document-ir/)
 - [Rendering model](https://mdi.illusions.app/core/rendering/)
-- [MDI documentation](https://mdi.illusions.app/)
+- [JavaScript documentation](https://mdi.illusions.app/bindings/javascript/)

--- a/nodejs/packages/mdi/package.json
+++ b/nodejs/packages/mdi/package.json
@@ -8,7 +8,7 @@
     "url": "git+https://github.com/illusions-lab/MDI.git",
     "directory": "nodejs/packages/mdi"
   },
-  "homepage": "https://mdi.illusions.app/",
+  "homepage": "https://mdi.illusions.app/bindings/javascript/",
   "bugs": "https://github.com/illusions-lab/MDI/issues",
   "type": "module",
   "main": "./dist/index.js",

--- a/nodejs/packages/remark/README.md
+++ b/nodejs/packages/remark/README.md
@@ -46,4 +46,4 @@ for ownership and wire-contract details.
 
 - [Remark / mdast adapter guide](https://mdi.illusions.app/ecosystem/remark/)
 - [JavaScript binding guide](https://mdi.illusions.app/bindings/javascript/)
-- [MDI documentation](https://mdi.illusions.app/)
+- [JavaScript documentation](https://mdi.illusions.app/bindings/javascript/)

--- a/nodejs/packages/remark/package.json
+++ b/nodejs/packages/remark/package.json
@@ -8,7 +8,7 @@
     "url": "git+https://github.com/illusions-lab/MDI.git",
     "directory": "nodejs/packages/remark"
   },
-  "homepage": "https://mdi.illusions.app/",
+  "homepage": "https://mdi.illusions.app/bindings/javascript/",
   "bugs": "https://github.com/illusions-lab/MDI/issues",
   "type": "module",
   "main": "./dist/index.js",

--- a/nodejs/packages/to-docx/README.md
+++ b/nodejs/packages/to-docx/README.md
@@ -30,4 +30,4 @@ The MDI CLI uses that Rust route directly.
 - [Output model](https://mdi.illusions.app/ecosystem/outputs/)
 - [Export-profile guide](https://mdi.illusions.app/guides/export-profiles/)
 - [API reference](https://mdi.illusions.app/api/to-docx/)
-- [MDI documentation](https://mdi.illusions.app/)
+- [JavaScript documentation](https://mdi.illusions.app/bindings/javascript/)

--- a/nodejs/packages/to-docx/package.json
+++ b/nodejs/packages/to-docx/package.json
@@ -8,7 +8,7 @@
     "url": "git+https://github.com/illusions-lab/MDI.git",
     "directory": "nodejs/packages/to-docx"
   },
-  "homepage": "https://mdi.illusions.app/",
+  "homepage": "https://mdi.illusions.app/bindings/javascript/",
   "bugs": "https://github.com/illusions-lab/MDI/issues",
   "type": "module",
   "main": "./dist/index.js",

--- a/nodejs/packages/to-epub/README.md
+++ b/nodejs/packages/to-epub/README.md
@@ -30,4 +30,4 @@ The Rust-first CLI follows that route.
 - [Output model](https://mdi.illusions.app/ecosystem/outputs/)
 - [Export-profile guide](https://mdi.illusions.app/guides/export-profiles/)
 - [API reference](https://mdi.illusions.app/api/to-epub/)
-- [MDI documentation](https://mdi.illusions.app/)
+- [JavaScript documentation](https://mdi.illusions.app/bindings/javascript/)

--- a/nodejs/packages/to-epub/package.json
+++ b/nodejs/packages/to-epub/package.json
@@ -8,7 +8,7 @@
     "url": "git+https://github.com/illusions-lab/MDI.git",
     "directory": "nodejs/packages/to-epub"
   },
-  "homepage": "https://mdi.illusions.app/",
+  "homepage": "https://mdi.illusions.app/bindings/javascript/",
   "bugs": "https://github.com/illusions-lab/MDI/issues",
   "type": "module",
   "main": "./dist/index.js",

--- a/nodejs/packages/to-hast/README.md
+++ b/nodejs/packages/to-hast/README.md
@@ -28,4 +28,4 @@ pipeline already owns an mdast tree.
 
 - [Remark / mdast adapter guide](https://mdi.illusions.app/ecosystem/remark/)
 - [API reference](https://mdi.illusions.app/api/to-hast/)
-- [MDI documentation](https://mdi.illusions.app/)
+- [JavaScript documentation](https://mdi.illusions.app/bindings/javascript/)

--- a/nodejs/packages/to-hast/package.json
+++ b/nodejs/packages/to-hast/package.json
@@ -8,7 +8,7 @@
     "url": "git+https://github.com/illusions-lab/MDI.git",
     "directory": "nodejs/packages/to-hast"
   },
-  "homepage": "https://mdi.illusions.app/",
+  "homepage": "https://mdi.illusions.app/bindings/javascript/",
   "bugs": "https://github.com/illusions-lab/MDI/issues",
   "type": "module",
   "main": "./dist/index.js",

--- a/nodejs/packages/to-html/README.md
+++ b/nodejs/packages/to-html/README.md
@@ -26,4 +26,4 @@ That route parses and renders in Rust, and is what the MDI CLI uses.
 
 - [HTML and output model](https://mdi.illusions.app/ecosystem/outputs/)
 - [API reference](https://mdi.illusions.app/api/to-html/)
-- [MDI documentation](https://mdi.illusions.app/)
+- [JavaScript documentation](https://mdi.illusions.app/bindings/javascript/)

--- a/nodejs/packages/to-html/package.json
+++ b/nodejs/packages/to-html/package.json
@@ -8,7 +8,7 @@
     "url": "git+https://github.com/illusions-lab/MDI.git",
     "directory": "nodejs/packages/to-html"
   },
-  "homepage": "https://mdi.illusions.app/",
+  "homepage": "https://mdi.illusions.app/bindings/javascript/",
   "bugs": "https://github.com/illusions-lab/MDI/issues",
   "type": "module",
   "main": "./dist/index.js",

--- a/nodejs/packages/to-pdf/README.md
+++ b/nodejs/packages/to-pdf/README.md
@@ -39,4 +39,4 @@ source and cannot make syntax or semantic-rendering decisions.
 - [Rendering and Chromium boundary](https://mdi.illusions.app/core/rendering/)
 - [Export-profile guide](https://mdi.illusions.app/guides/export-profiles/)
 - [API reference](https://mdi.illusions.app/api/to-pdf/)
-- [MDI documentation](https://mdi.illusions.app/)
+- [JavaScript documentation](https://mdi.illusions.app/bindings/javascript/)

--- a/nodejs/packages/to-pdf/package.json
+++ b/nodejs/packages/to-pdf/package.json
@@ -8,7 +8,7 @@
     "url": "git+https://github.com/illusions-lab/MDI.git",
     "directory": "nodejs/packages/to-pdf"
   },
-  "homepage": "https://mdi.illusions.app/",
+  "homepage": "https://mdi.illusions.app/bindings/javascript/",
   "bugs": "https://github.com/illusions-lab/MDI/issues",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Updates every JavaScript package README and npm homepage to the canonical JavaScript binding documentation entry point: https://mdi.illusions.app/bindings/javascript/.