### PR TITLE
Expand Swift tests and document SwiftPM usage

### DIFF
--- a/swift/README.md
+++ b/swift/README.md
@@ -10,6 +10,25 @@ The SwiftPM package is named `IllusionMarkdown`, while its library product and
 module are named `MDI`. This keeps the distribution name distinctive while
 making Swift usage align with the MDI format name.
 
+## Install with SwiftPM
+
+Add the package to your `Package.swift`:
+
+```swift
+dependencies: [
+    .package(url: "https://github.com/illusions-lab/MDI.git", from: "2.0.1"),
+]
+```
+
+Then depend on the `MDI` product and import it in Swift:
+
+```swift
+import MDI
+```
+
+See the [Swift binding documentation](https://mdi.illusions.app/bindings/swift/)
+for the complete API reference and examples.
+
 ## Development
 
 Build the Rust dynamic library before running the Swift tests:
@@ -22,10 +41,10 @@ cd ../swift
 swift build
 ```
 
-The `Publish Swift Package` workflow turns the Rust core into an XCFramework,
-tests it, then writes the root `Package.swift`, tags a complete SemVer release,
-and uploads the binary with GitHub Actions' built-in `GITHUB_TOKEN`. No PAT or
-second repository is required.
+The `Publish Swift Package` workflow first prepares an XCFramework and opens a
+manifest pull request. After that PR is merged, it publishes that exact artifact
+with GitHub Actions' built-in `GITHUB_TOKEN`. No PAT or second repository is
+required.
 
 ## Usage
 

--- a/swift/Tests/MDITests/MDITests.swift
+++ b/swift/Tests/MDITests/MDITests.swift
@@ -12,6 +12,19 @@ final class MDITests: XCTestCase {
         XCTAssertTrue(result.diagnostics.isEmpty)
     }
 
+    func testParsePreservesDocumentStructureAndUnicode() throws {
+        let result = try MDI.parse("# 見出し\n\n{東京|とうきょう}で第^12^話")
+        guard case let .object(document) = result.document else {
+            return XCTFail("expected the document root to be an object")
+        }
+
+        XCTAssertEqual(document["type"], .string("document"))
+        guard case let .array(children)? = document["children"] else {
+            return XCTFail("expected document children")
+        }
+        XCTAssertFalse(children.isEmpty)
+    }
+
     func testRendersThroughRust() throws {
         let html = try MDI.renderHTML("{東京|とうきょう} ^12^")
         XCTAssertTrue(html.contains("<ruby class=\"mdi-ruby\">東京"))
@@ -19,8 +32,55 @@ final class MDITests: XCTestCase {
         XCTAssertEqual(try MDI.renderText("{東京|とうきょう} ^12^"), "東京 12\n")
     }
 
+    func testSerializesMDIThroughRust() throws {
+        let mdi = try MDI.serialize("{東京|とうきょう} ^12^")
+        XCTAssertTrue(mdi.contains("{東京|とうきょう}"))
+        XCTAssertTrue(mdi.contains("^12^"))
+    }
+
     func testReturnsBinaryDocuments() throws {
-        XCTAssertEqual(Array(try MDI.renderEPUB("text").prefix(2)), [0x50, 0x4b])
-        XCTAssertEqual(Array(try MDI.renderDOCX("text").prefix(2)), [0x50, 0x4b])
+        let epub = try MDI.renderEPUB("# Chapter\n\nText")
+        let docx = try MDI.renderDOCX("# Chapter\n\nText")
+
+        XCTAssertGreaterThan(epub.count, 100)
+        XCTAssertGreaterThan(docx.count, 100)
+        XCTAssertEqual(Array(epub.prefix(2)), [0x50, 0x4b])
+        XCTAssertEqual(Array(docx.prefix(2)), [0x50, 0x4b])
+    }
+
+    func testJSONValueRoundTripsEveryVariant() throws {
+        let value: MDIJSONValue = .object([
+            "null": .null,
+            "bool": .bool(true),
+            "number": .number(12.5),
+            "string": .string("東京"),
+            "array": .array([.string("nested"), .bool(false)]),
+        ])
+
+        let data = try JSONEncoder().encode(value)
+        XCTAssertEqual(try JSONDecoder().decode(MDIJSONValue.self, from: data), value)
+    }
+
+    func testPublicValueTypesDecodeFromDocumentIR() throws {
+        let json = """
+        {
+          "irVersion": "1.0",
+          "syntaxVersion": "2.0",
+          "capabilities": {"mdi": true, "commonMark": true, "gfm": true, "frontMatter": true, "sourceSpans": false},
+          "document": {"type": "document", "children": []},
+          "diagnostics": [{"severity": "warning", "code": "example", "message": "example diagnostic", "span": {"startByte": 1, "endByte": 2}}]
+        }
+        """
+        let result = try JSONDecoder().decode(MDIParseResult.self, from: Data(json.utf8))
+
+        XCTAssertEqual(result.irVersion, mdiIRVersion)
+        XCTAssertEqual(result.capabilities.gfm, true)
+        XCTAssertEqual(result.diagnostics.first?.severity, .warning)
+        XCTAssertEqual(result.diagnostics.first?.span, MDISourceSpan(startByte: 1, endByte: 2))
+    }
+
+    func testErrorsExposeTheirMessage() {
+        XCTAssertEqual(MDIError.core("core failed").errorDescription, "core failed")
+        XCTAssertEqual(MDIError.invalidWireFormat("bad wire").errorDescription, "bad wire")
     }
 }


### PR DESCRIPTION
Adds consumer SwiftPM installation guidance and the Swift binding docs URL. Expands XCTest coverage across parsing, rendering, serialization, binary output, JSON IR Codable types, and errors. Local Building for debugging...
[0/1] Write swift-version--1AB21518FC5DEDBE.txt
Build complete! (0.08s) passes against the released 2.0.1 XCFramework; XCTest runs in the full-Xcode release prepare workflow.