### PR TITLE
Release Swift package 2.0.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
         .library(name: "MDI", targets: ["MDI"]),
     ],
     targets: [
-        .binaryTarget(name: "MDICore", url: "https://github.com/illusions-lab/MDI/releases/download/2.0.1/MDICore.xcframework.zip", checksum: "4303d21e7d0812412cd15475c6c61788601e11f65bf1f69d8ce278652eb72a05"),
+        .binaryTarget(name: "MDICore", url: "https://github.com/illusions-lab/MDI/releases/download/2.0.2/MDICore.xcframework.zip", checksum: "d1fd0fedd6cb5464edbd193efac60052589dc0a71cef380e64f15197c319fc89"),
         .target(name: "MDI", dependencies: ["MDICore"], path: "swift/Sources/MDI"),
         .testTarget(name: "MDITests", dependencies: ["MDI"], path: "swift/Tests/MDITests"),
     ]


### PR DESCRIPTION
Prepared artifact from workflow run 29760742403. The full-Xcode release gate built the XCFramework and passed all 8 XCTest cases. After merge, dispatch Publish Swift Package with action=publish, version=2.0.2, prepare_run_id=29760742403.