### PR TITLE
Document Swift binding and enforce coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,36 @@ jobs:
           name: rust
           fail_ci_if_error: true
 
+  swift:
+    name: Swift
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-darwin,x86_64-apple-darwin,aarch64-apple-ios,aarch64-apple-ios-sim,x86_64-apple-ios
+
+      - name: Build the Apple XCFramework
+        run: scripts/package-swift-xcframework.sh "$RUNNER_TEMP/mdi-swift"
+
+      - name: Test Swift binding with coverage
+        run: |
+          mkdir -p swift/Artifacts
+          ditto "$RUNNER_TEMP/mdi-swift/MDICore.xcframework" swift/Artifacts/MDICore.xcframework
+          scripts/write-swift-package-manifest.sh local "swift/Artifacts/MDICore.xcframework"
+          swift test --enable-code-coverage
+          scripts/export-swift-coverage.sh swift/coverage.lcov
+
+      - name: Upload Swift coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./swift/coverage.lcov
+          flags: swift
+          name: swift
+          fail_ci_if_error: true
+
   python:
     name: Python binding
     runs-on: ubuntu-latest

--- a/codecov.yml
+++ b/codecov.yml
@@ -16,9 +16,11 @@ flags:
   rust:
     paths:
       - mdi-core/
+  swift:
+    paths:
+      - swift/
 
 ignore:
   - nodejs/**/dist/
   - nodejs/docs/
   - python/
-  - swift/

--- a/nodejs/docs/src/content/docs/bindings/swift.md
+++ b/nodejs/docs/src/content/docs/bindings/swift.md
@@ -1,26 +1,90 @@
 ---
 title: Swift
-description: Status and expected contract for the Swift binding.
+description: Install and use MDI from Swift with Swift Package Manager.
 ---
 
-The Swift binding is a Swift Package Manager package named `IllusionMarkdown`.
-It forwards all parsing and rendering to `mdi-core` through its small C ABI;
-Swift never contains grammar or rendering decisions.
+`IllusionMarkdown` is MDI's Swift Package Manager distribution. Its product and
+import module are both named `MDI`:
 
-During repository development, `swift/Package.swift` provides the local
-binding layout. The `Publish Swift Package` workflow builds and tests the
-native Rust library as an XCFramework, writes the root `Package.swift`, tags
-the release, and uploads the artifact using GitHub Actions' built-in token.
+```swift
+import MDI
+```
 
-## Expected contract
+Swift forwards parsing and rendering to the Rust `mdi-core` through a compact C
+ABI. It does not reimplement the grammar, so all bindings share the same
+syntax, document IR, diagnostics, and renderers.
 
-The binding exposes the same syntax/IR versions, diagnostics, UTF-8 byte spans,
-and complete document tree as the other bindings. `MDIParseResult.document` is
-represented by the lossless `MDIJSONValue` tagged JSON value, while source spans
-and diagnostics use Swift-native value types. It must not own grammar or
-renderer semantics.
+## Installation
 
-The current module is `MDI` (published in the `IllusionMarkdown` SwiftPM
-package). The public entry points are
-`parse`, `renderHTML`, `serialize`, `renderText`, `renderEPUB`, and
-`renderDOCX`; native-library and core failures are surfaced as `MDIError`.
+Add MDI to your package dependencies, then add the `MDI` product to the target
+that uses it:
+
+```swift
+dependencies: [
+    .package(url: "https://github.com/illusions-lab/MDI.git", from: "2.0.2"),
+]
+
+// In a target:
+.product(name: "MDI", package: "MDI")
+```
+
+The binary package supports macOS 13+ and iOS 15+ on Apple Silicon and Intel
+simulators where applicable.
+
+## Parsing
+
+`MDI.parse(_:)` returns the versioned, Rust-owned document IR:
+
+```swift
+let result = try MDI.parse("# 見出し\n\n{東京|とうきょう}で第^12^話")
+
+print(result.irVersion)          // "1.0"
+print(result.capabilities.mdi)   // true
+print(result.diagnostics)
+```
+
+`result.document` is a lossless `MDIJSONValue` tree. Use pattern matching on
+`.object`, `.array`, `.string`, `.number`, `.bool`, and `.null` when consuming
+nodes. Source positions are UTF-8 byte offsets in `MDISourceSpan`.
+
+## Rendering and serialization
+
+All renderers take MDI source text:
+
+```swift
+let html = try MDI.renderHTML("{東京|とうきょう} ^12^")
+let mdi = try MDI.serialize("{東京|とうきょう} ^12^")
+let text = try MDI.renderText("# Title")
+
+let epub: Data = try MDI.renderEPUB("# Chapter")
+let docx: Data = try MDI.renderDOCX("# Chapter")
+```
+
+`renderEPUB` and `renderDOCX` return ZIP-based `Data`; write the data to a
+file with the appropriate extension.
+
+## Errors
+
+Every public operation throws `MDIError`:
+
+- `MDIError.core` reports a failure returned by the Rust core.
+- `MDIError.invalidWireFormat` indicates an invalid or unsupported native
+  response.
+
+```swift
+do {
+    let html = try MDI.renderHTML(source)
+    print(html)
+} catch let error as MDIError {
+    print(error.localizedDescription)
+}
+```
+
+## Development and releases
+
+The repository's `swift/Package.swift` is the local development package. CI
+builds an XCFramework, runs XCTest with a 90% line-coverage gate for
+`swift/Sources/MDI`, and uploads the report to Codecov. The release workflow
+creates a manifest pull request and publishes the approved artifact after that
+PR is merged. It uses GitHub Actions' built-in token; no PAT or second
+repository is required.

--- a/nodejs/docs/src/content/docs/ja/bindings/swift.md
+++ b/nodejs/docs/src/content/docs/ja/bindings/swift.md
@@ -1,10 +1,53 @@
 ---
 title: Swift
-description: Swift binding の状態と予定契約。
+description: Swift Package Manager で MDI をインストールして使用する。
 ---
 
-Swift バインディングは `IllusionMarkdown` という Swift Package Manager パッケージです。小さな C ABI を通じて解析とレンダリングをすべて `mdi-core` に委譲し、Swift 側は文法やレンダリングの判断を持ちません。
+`IllusionMarkdown` は MDI の Swift Package Manager 配布名です。product と import module はどちらも `MDI` です。
 
-リポジトリ開発時は `swift/Package.swift` がローカルのバインディング構成を提供します。`Publish Swift Package` workflow はネイティブ Rust ライブラリを XCFramework としてビルド・テストし、root の `Package.swift` を生成して tag を作成し、GitHub Actions の組み込み token で artifact をアップロードします。
+```swift
+import MDI
+```
 
-同じ構文／IR バージョン、診断、UTF-8 バイトスパン、完全な文書ツリーを公開します。`MDIParseResult.document` は可逆な `MDIJSONValue` で表し、SwiftPM の配布パッケージは `IllusionMarkdown`、import module は `MDI` です。公開 API は `parse`、`renderHTML`、`serialize`、`renderText`、`renderEPUB`、`renderDOCX` です。
+Swift は小さな C ABI を通じて Rust の `mdi-core` に解析とレンダリングを委譲します。文法を再実装しないため、全バインディングで同じ構文、document IR、diagnostics、renderer を共有します。
+
+## インストール
+
+`Package.swift` に依存関係を追加し、使用する target に `MDI` product を追加します。
+
+```swift
+dependencies: [
+    .package(url: "https://github.com/illusions-lab/MDI.git", from: "2.0.2"),
+]
+
+// target の dependencies:
+.product(name: "MDI", package: "MDI")
+```
+
+バイナリパッケージは macOS 13+、iOS 15+、Apple Silicon、および該当する Intel simulator をサポートします。
+
+## 解析と IR
+
+```swift
+let result = try MDI.parse("# 見出し\n\n{東京|とうきょう}で第^12^話")
+print(result.irVersion)          // "1.0"
+print(result.diagnostics)
+```
+
+`result.document` は可逆な `MDIJSONValue` ツリーです。`.object`、`.array`、`.string`、`.number`、`.bool`、`.null` の pattern matching で node を扱えます。`MDISourceSpan` は UTF-8 byte offset です。
+
+## レンダリング
+
+```swift
+let html = try MDI.renderHTML("{東京|とうきょう} ^12^")
+let mdi = try MDI.serialize("{東京|とうきょう} ^12^")
+let text = try MDI.renderText("# Title")
+let epub: Data = try MDI.renderEPUB("# Chapter")
+let docx: Data = try MDI.renderDOCX("# Chapter")
+```
+
+EPUB と DOCX は ZIP ベースの `Data` を返すため、対応する拡張子でファイルへ書き出してください。
+
+## エラーとリリース
+
+すべての API は `MDIError` を throw します。`core` は Rust core の失敗、`invalidWireFormat` は無効または未対応の native response を表します。CI は XCFramework をビルドし、XCTest を実行して `swift/Sources/MDI` に 90% の line coverage を要求し、Codecov へ送信します。PAT や別リポジトリは必要ありません。

--- a/nodejs/docs/src/content/docs/zh-tw/bindings/swift.md
+++ b/nodejs/docs/src/content/docs/zh-tw/bindings/swift.md
@@ -1,10 +1,53 @@
 ---
 title: Swift
-description: Swift binding 的狀態與預期契約。
+description: 使用 Swift Package Manager 安裝與使用 MDI。
 ---
 
-Swift 綁定是名為 `IllusionMarkdown` 的 Swift Package Manager 套件。它透過小型 C ABI 將所有解析與轉譯交給 `mdi-core`；Swift 不會包含語法或轉譯判斷。
+`IllusionMarkdown` 是 MDI 的 Swift Package Manager 發行套件；產品與 import module 都叫作 `MDI`：
 
-在此 repository 開發時，`swift/Package.swift` 提供本地綁定配置。`Publish Swift Package` workflow 會把原生 Rust 函式庫建置並測試為 XCFramework、寫入 root `Package.swift`、建立 tag，並用 GitHub Actions 的內建 token 上傳 artifact。
+```swift
+import MDI
+```
 
-它公開與其他語言相同的語法／IR 版本、診斷、UTF-8 位元組跨度與完整文件樹。`MDIParseResult.document` 使用無損的 `MDIJSONValue` 標記 JSON 值；跨度與診斷則使用 Swift 原生值型別。SwiftPM 發行套件是 `IllusionMarkdown`，import module 是 `MDI`。公開入口為 `parse`、`renderHTML`、`serialize`、`renderText`、`renderEPUB` 與 `renderDOCX`。
+Swift 會透過精簡的 C ABI 將解析和轉譯交給 Rust 的 `mdi-core`，不會重作語法，因此所有綁定共用同一份語法、文件 IR、診斷與 renderer。
+
+## 安裝
+
+在 `Package.swift` 加入相依套件，並讓使用它的 target 相依於 `MDI` 產品：
+
+```swift
+dependencies: [
+    .package(url: "https://github.com/illusions-lab/MDI.git", from: "2.0.2"),
+]
+
+// target 的 dependencies：
+.product(name: "MDI", package: "MDI")
+```
+
+二進位套件支援 macOS 13+ 與 iOS 15+，包含 Apple Silicon 與適用的 Intel simulator。
+
+## 解析與 IR
+
+```swift
+let result = try MDI.parse("# 見出し\n\n{東京|とうきょう}で第^12^話")
+print(result.irVersion)          // "1.0"
+print(result.diagnostics)
+```
+
+`result.document` 是無損的 `MDIJSONValue` 樹；可用 `.object`、`.array`、`.string`、`.number`、`.bool`、`.null` pattern matching 取用節點。`MDISourceSpan` 使用 UTF-8 byte offset。
+
+## 轉譯
+
+```swift
+let html = try MDI.renderHTML("{東京|とうきょう} ^12^")
+let mdi = try MDI.serialize("{東京|とうきょう} ^12^")
+let text = try MDI.renderText("# Title")
+let epub: Data = try MDI.renderEPUB("# Chapter")
+let docx: Data = try MDI.renderDOCX("# Chapter")
+```
+
+EPUB 與 DOCX 回傳 ZIP 格式的 `Data`，請以對應副檔名寫入檔案。
+
+## 錯誤與發布
+
+所有 API 都會拋出 `MDIError`：`core` 表示 Rust core 的失敗，`invalidWireFormat` 表示無效或不支援的 native 回應。CI 會建置 XCFramework、跑 XCTest，並對 `swift/Sources/MDI` 強制 90% line coverage、上傳 Codecov；發版只使用 GitHub Actions 內建 token，不需要 PAT 或獨立倉庫。

--- a/scripts/export-swift-coverage.sh
+++ b/scripts/export-swift-coverage.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 <lcov-output>" >&2
+  exit 64
+fi
+
+coverage_json="$(swift test --show-codecov-path)"
+test_binary="$(find .build -type f -path '*IllusionMarkdownPackageTests.xctest/Contents/MacOS/IllusionMarkdownPackageTests' -print -quit)"
+profile_data="$(dirname "$coverage_json")/default.profdata"
+
+[[ -f "$coverage_json" ]]
+[[ -n "$test_binary" && -f "$test_binary" ]]
+[[ -f "$profile_data" ]]
+
+coverage_percent="$(jq -r '
+  [ .data[].files[]
+    | select(.filename | endswith("/swift/Sources/MDI/MDI.swift"))
+    | .summary.lines
+    | (.covered / .count * 100)
+  ] | if length == 1 then .[0] else error("expected exactly one MDI source coverage record") end
+' "$coverage_json")"
+
+awk -v coverage="$coverage_percent" 'BEGIN {
+  printf "Swift MDI line coverage: %.2f%%\\n", coverage
+  exit !(coverage >= 90)
+}'
+
+xcrun llvm-cov export "$test_binary" \
+  -instr-profile="$profile_data" \
+  -format=lcov > "$1"


### PR DESCRIPTION
Completes the three Swift binding documentation pages with installation, parsing, rendering, binary output, and error guidance. Adds a macOS Swift CI job that builds the XCFramework, runs XCTest with coverage, requires at least 90% line coverage for swift/Sources/MDI, and uploads LCOV to Codecov.