### PR TITLE
Cover Swift native response error paths

### DIFF
--- a/scripts/write-swift-package-manifest.sh
+++ b/scripts/write-swift-package-manifest.sh
@@ -43,7 +43,7 @@ let package = Package(
     targets: [
         $binary_target,
         .target(name: "MDI", dependencies: ["MDICore"], path: "swift/Sources/MDI"),
-        .testTarget(name: "MDITests", dependencies: ["MDI"], path: "swift/Tests/MDITests"),
+        .testTarget(name: "MDITests", dependencies: ["MDI", "MDICore"], path: "swift/Tests/MDITests"),
     ]
 )
 EOF

--- a/swift/Package.swift
+++ b/swift/Package.swift
@@ -10,6 +10,6 @@ let package = Package(
 	targets: [
 		.systemLibrary(name: "MDICore", path: "Sources/MDICore"),
 		.target(name: "MDI", dependencies: ["MDICore"]),
-		.testTarget(name: "MDITests", dependencies: ["MDI"]),
+		.testTarget(name: "MDITests", dependencies: ["MDI", "MDICore"]),
 	]
 )

--- a/swift/Sources/MDI/MDI.swift
+++ b/swift/Sources/MDI/MDI.swift
@@ -84,7 +84,10 @@ public struct MDIParseResult: Codable, Equatable, Sendable {
 /// Swift interface to the Rust-owned MDI parser and renderers.
 public enum MDI {
     public static func parse(_ source: String) throws -> MDIParseResult {
-        let data = try call(source, operation: mdi_parse_json)
+        try parseResult(from: call(source, operation: mdi_parse_json))
+    }
+
+    static func parseResult(from data: Data) throws -> MDIParseResult {
         let result: MDIParseResult
         do { result = try JSONDecoder().decode(MDIParseResult.self, from: data) }
         catch { throw MDIError.invalidWireFormat("MDI core returned invalid parse JSON: \(error.localizedDescription)") }
@@ -100,17 +103,27 @@ public enum MDI {
     public static func renderEPUB(_ source: String) throws -> Data { try call(source, operation: mdi_render_epub) }
     public static func renderDOCX(_ source: String) throws -> Data { try call(source, operation: mdi_render_docx) }
 
-    private static func stringCall(_ source: String, operation: MDIFFIOperation) throws -> String {
-        let data = try call(source, operation: operation)
+    static func string(from data: Data) throws -> String {
         guard let value = String(data: data, encoding: .utf8) else {
             throw MDIError.invalidWireFormat("MDI core returned non-UTF-8 string data")
         }
         return value
     }
 
-    private static func call(_ source: String, operation: MDIFFIOperation) throws -> Data {
-        let bytes = Array(source.utf8)
+    private static func stringCall(_ source: String, operation: MDIFFIOperation) throws -> String {
+        try string(from: call(source, operation: operation))
+    }
+
+    static func call(_ source: String, operation: MDIFFIOperation) throws -> Data {
+        try call(bytes: Array(source.utf8), operation: operation)
+    }
+
+    static func call(bytes: [UInt8], operation: MDIFFIOperation) throws -> Data {
         let result = bytes.withUnsafeBufferPointer { operation($0.baseAddress, $0.count) }
+        return try data(from: result)
+    }
+
+    static func data(from result: mdi_ffi_result) throws -> Data {
         defer { mdi_free_buffer(result.value); mdi_free_buffer(result.error) }
         if result.error.len > 0 {
             let message = String(data: Data(bytes: result.error.data!, count: result.error.len), encoding: .utf8) ?? "Unknown MDI core error"
@@ -123,4 +136,4 @@ public enum MDI {
     }
 }
 
-private typealias MDIFFIOperation = @convention(c) (UnsafePointer<UInt8>?, Int) -> mdi_ffi_result
+typealias MDIFFIOperation = @convention(c) (UnsafePointer<UInt8>?, Int) -> mdi_ffi_result

--- a/swift/Tests/MDITests/MDITests.swift
+++ b/swift/Tests/MDITests/MDITests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import XCTest
+import MDICore
 @testable import MDI
 
 final class MDITests: XCTestCase {
@@ -84,5 +85,44 @@ final class MDITests: XCTestCase {
     func testErrorsExposeTheirMessage() {
         XCTAssertEqual(MDIError.core("core failed").errorDescription, "core failed")
         XCTAssertEqual(MDIError.invalidWireFormat("bad wire").errorDescription, "bad wire")
+    }
+
+    func testRejectsMalformedNativeParsePayloads() {
+        XCTAssertThrowsError(try MDI.parseResult(from: Data("not JSON".utf8))) { error in
+            guard case let .invalidWireFormat(message) = error as? MDIError else {
+                return XCTFail("expected an invalid wire-format error")
+            }
+            XCTAssertTrue(message.contains("invalid parse JSON"))
+        }
+
+        let unsupported = """
+        {"irVersion":"999.0","syntaxVersion":"2.0","capabilities":{"mdi":true,"commonMark":true,"gfm":true,"frontMatter":true,"sourceSpans":false},"document":{},"diagnostics":[]}
+        """
+        XCTAssertThrowsError(try MDI.parseResult(from: Data(unsupported.utf8))) { error in
+            XCTAssertEqual(error as? MDIError, .invalidWireFormat("Unsupported MDI IR version: 999.0"))
+        }
+    }
+
+    func testRejectsMalformedNativeStringAndBufferPayloads() {
+        XCTAssertThrowsError(try MDI.string(from: Data([0xff]))) { error in
+            XCTAssertEqual(error as? MDIError, .invalidWireFormat("MDI core returned non-UTF-8 string data"))
+        }
+
+        let invalid = mdi_ffi_result(
+            value: mdi_ffi_buffer(data: nil, len: 1),
+            error: mdi_ffi_buffer(data: nil, len: 0)
+        )
+        XCTAssertThrowsError(try MDI.data(from: invalid)) { error in
+            XCTAssertEqual(error as? MDIError, .invalidWireFormat("MDI core returned an invalid buffer"))
+        }
+    }
+
+    func testForwardsRustCoreErrors() {
+        XCTAssertThrowsError(try MDI.call(bytes: [0xff], operation: mdi_parse_json)) { error in
+            guard case let .core(message) = error as? MDIError else {
+                return XCTFail("expected a core error")
+            }
+            XCTAssertFalse(message.isEmpty)
+        }
     }
 }


### PR DESCRIPTION
Adds tests for malformed native parse JSON, incompatible IR versions, non-UTF-8 string output, invalid FFI buffers, and Rust core errors. The added internal decoding seams preserve the public API while exercising the previously untestable wire-format branches, targeting meaningful coverage headroom above 90%.