### PR TITLE
docs: restore API reference entry route

### DIFF
--- a/docs/src/pages/api/index.astro
+++ b/docs/src/pages/api/index.astro
@@ -1,0 +1,3 @@
+---
+return Astro.redirect('/api/mdi/readme/', 302);
+---


### PR DESCRIPTION
Restores the API entry route and redirects it to the generated JavaScript API reference. Verified with the docs build.