### PR TITLE
docs: generate primary JavaScript API reference

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -14,6 +14,7 @@ import { mdiHandlers } from '@illusions-lab/mdi-to-hast';
  */
 
 const packages = [
+	'mdi',
 	'mdast-util-mdi',
 	'remark',
 	'to-hast',


### PR DESCRIPTION
Adds the primary mdi package to generated TypeDoc pages so the API entry route points to a real reference.