### PR TITLE
docs: move Illusions link into homepages

### DIFF
--- a/docs/src/components/Header.astro
+++ b/docs/src/components/Header.astro
@@ -13,7 +13,6 @@ const shouldRenderSearch =
 <div class="header">
 	<div class="title-wrapper sl-flex">
 		<SiteTitle />
-		<a class="illusions-link" href="https://www.illusions.app/">illusions</a>
 	</div>
 	<div class="sl-flex print:hidden">
 		{shouldRenderSearch && <Search />}
@@ -51,26 +50,11 @@ const shouldRenderSearch =
 			min-width: 0;
 		}
 
-		.illusions-link {
-			color: var(--sl-color-gray-2);
-			font-size: var(--sl-text-sm);
-			white-space: nowrap;
-		}
-
-		.illusions-link:hover {
-			color: var(--sl-color-white);
-		}
-
 		.social-icons::after {
 			content: '';
 			height: 2rem;
 			border-inline-end: 1px solid var(--sl-color-gray-5);
 		}
 
-		@media (max-width: 32rem) {
-			.illusions-link {
-				display: none;
-			}
-		}
 	}
 </style>

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -55,3 +55,5 @@ const html = renderHtml(source);                 // <ruby>...<span class="mdi-tc
 ```
 
 Full walkthrough, including PDF/EPUB/DOCX and export profiles, in [Getting Started](/guides/getting-started/).
+
+Built by [illusions](https://www.illusions.app/).

--- a/docs/src/content/docs/ja/index.mdx
+++ b/docs/src/content/docs/ja/index.mdx
@@ -46,3 +46,5 @@ const html = renderHtml(source);                 // <ruby>...<span class="mdi-tc
 ```
 
 PDF/EPUB/DOCX と export profile を含む手順は [Getting Started](/ja/guides/getting-started/) にあります。
+
+[illusions](https://www.illusions.app/) が制作しています。

--- a/docs/src/content/docs/zh-tw/index.mdx
+++ b/docs/src/content/docs/zh-tw/index.mdx
@@ -47,3 +47,5 @@ mdi build novel.mdi --to html
 ```
 
 完整流程（PDF、EPUB、DOCX 與 export profile）請見[快速上手](/zh-tw/guides/getting-started/)。
+
+由 [illusions](https://www.illusions.app/) 製作。


### PR DESCRIPTION
## Summary

- Remove the Illusions link from the global header.
- Retain the attribution as a subtle link at the end of each localized documentation homepage.

## Validation

- `pnpm --dir docs build`

The build completed successfully. It emitted the existing MDI syntax-highlighting fallback warning.