### PR TITLE
docs: restore Codecov badge and update homepage attribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ The language toolkits below call this same parser instead of reimplementing the 
 
 [![CI](https://img.shields.io/github/actions/workflow/status/illusions-lab/MDI/ci.yml/CI?branch=main&style=for-the-badge&logo=githubactions&logoColor=white&label=CI)](https://github.com/illusions-lab/MDI/actions/workflows/ci.yml)
 [![Docs](https://img.shields.io/github/actions/workflow/status/illusions-lab/MDI/docs.yml/Docs?branch=main&style=for-the-badge&logo=readthedocs&logoColor=white&label=Docs)](https://github.com/illusions-lab/MDI/actions/workflows/docs.yml)
+[![codecov](https://codecov.io/gh/illusions-lab/MDI/graph/badge.svg?token=J6GJZW744R)](https://codecov.io/gh/illusions-lab/MDI)
 [![npm version](https://img.shields.io/npm/v/%40illusions-lab%2Fmdi?style=for-the-badge&logo=npm&logoColor=white&label=npm)](https://www.npmjs.com/package/@illusions-lab/mdi)
 [![License](https://img.shields.io/github/license/illusions-lab/MDI?style=for-the-badge&logo=opensourceinitiative&logoColor=white)](./LICENSE)
 

--- a/docs/src/components/Header.astro
+++ b/docs/src/components/Header.astro
@@ -13,7 +13,6 @@ const shouldRenderSearch =
 <div class="header">
 	<div class="title-wrapper sl-flex">
 		<SiteTitle />
-		<a class="illusions-link" href="https://www.illusions.app/">illusions</a>
 	</div>
 	<div class="sl-flex print:hidden">
 		{shouldRenderSearch && <Search />}
@@ -51,26 +50,11 @@ const shouldRenderSearch =
 			min-width: 0;
 		}
 
-		.illusions-link {
-			color: var(--sl-color-gray-2);
-			font-size: var(--sl-text-sm);
-			white-space: nowrap;
-		}
-
-		.illusions-link:hover {
-			color: var(--sl-color-white);
-		}
-
 		.social-icons::after {
 			content: '';
 			height: 2rem;
 			border-inline-end: 1px solid var(--sl-color-gray-5);
 		}
 
-		@media (max-width: 32rem) {
-			.illusions-link {
-				display: none;
-			}
-		}
 	}
 </style>

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -55,3 +55,5 @@ const html = renderHtml(source);                 // <ruby>...<span class="mdi-tc
 ```
 
 Full walkthrough, including PDF/EPUB/DOCX and export profiles, in [Getting Started](/guides/getting-started/).
+
+Built by [illusions](https://www.illusions.app/).

--- a/docs/src/content/docs/ja/index.mdx
+++ b/docs/src/content/docs/ja/index.mdx
@@ -46,3 +46,5 @@ const html = renderHtml(source);                 // <ruby>...<span class="mdi-tc
 ```
 
 PDF/EPUB/DOCX と export profile を含む手順は [Getting Started](/ja/guides/getting-started/) にあります。
+
+[illusions](https://www.illusions.app/) が制作しています。

--- a/docs/src/content/docs/zh-tw/index.mdx
+++ b/docs/src/content/docs/zh-tw/index.mdx
@@ -47,3 +47,5 @@ mdi build novel.mdi --to html
 ```
 
 完整流程（PDF、EPUB、DOCX 與 export profile）請見[快速上手](/zh-tw/guides/getting-started/)。
+
+由 [illusions](https://www.illusions.app/) 製作。


### PR DESCRIPTION
## Summary

- Restore the Codecov badge in the root README.
- Move the Illusions attribution from the global header to the localized documentation homepages.

## Why

The Codecov badge was removed accidentally, while the Illusions link should remain discoverable without occupying header navigation space.

## Validation

- `pnpm --dir docs build`
- `git diff --check`