### PR TITLE
feat(pdf): add browser-safe print profile adapter

### DIFF
--- a/nodejs/packages/to-pdf/CHANGELOG.md
+++ b/nodejs/packages/to-pdf/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @illusions-lab/mdi-to-pdf
 
+## Unreleased
+
+### Patch Changes
+
+- Add the browser-safe `@illusions-lab/mdi-to-pdf/profile` entry for applying
+  Chromium print profiles without importing Playwright or launching Chromium.
+
 ## 2.0.18
 
 ### Patch Changes

--- a/nodejs/packages/to-pdf/README.md
+++ b/nodejs/packages/to-pdf/README.md
@@ -24,6 +24,24 @@ const pdf = await renderHtmlToPdf(renderHtml("# A Rust-owned document"));
 `mdiToPdf(mdast, profile)` remains available for existing unified consumers,
 but new applications should use the Rust-HTML route above.
 
+## Electron and Web Chromium hosts
+
+Use the browser-safe profile entry when the application already owns Chromium.
+It does not import Playwright, Node built-ins, or launch a browser.
+
+```ts
+import { prepareChromiumPrintProfile } from "@illusions-lab/mdi-to-pdf/profile";
+
+const print = prepareChromiumPrintProfile(html, profile, sourceWritingMode);
+// Load print.html into an Electron BrowserWindow or an iframe and print it.
+// print.page has physical millimetre dimensions and margins.
+// print.pageNumbers contains optional Chromium header/footer templates.
+```
+
+`applyPdfProfile(html, resolvedProfile)` is also exported from this entry for
+hosts that already resolve their profile. Browser hosts should use `print.html`
+for the shared CSS layout; page-number headers and footers remain host-specific.
+
 ## What this package owns
 
 ```text

--- a/nodejs/packages/to-pdf/package.json
+++ b/nodejs/packages/to-pdf/package.json
@@ -17,13 +17,17 @@
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
+    },
+    "./profile": {
+      "types": "./dist/profile.d.ts",
+      "default": "./dist/profile.js"
     }
   },
   "files": [
     "dist"
   ],
   "scripts": {
-    "build": "tsup src/index.ts --format esm,cjs --dts",
+    "build": "tsup --entry src/index.ts --entry src/profile.ts --format esm,cjs --dts",
     "test": "vitest run --passWithNoTests",
     "typecheck": "tsc --noEmit"
   },

--- a/nodejs/packages/to-pdf/src/index.test.ts
+++ b/nodejs/packages/to-pdf/src/index.test.ts
@@ -5,6 +5,7 @@ import remarkMdi from "@illusions-lab/mdi-remark";
 import { resolveExportProfile } from "@illusions-lab/mdi-export-profile";
 import type { Root } from "mdast";
 import { applyPdfProfile, mdiToPdf, renderHtmlToPdf } from "./index.js";
+import { prepareChromiumPrintProfile } from "./profile.js";
 
 describe("mdiToPdf", () =>
   it("generates a browser-rendered PDF", async () => {
@@ -71,6 +72,53 @@ describe("PDF page-number layout", () => {
     );
     expect(pdf.subarray(0, 5).toString()).toBe("%PDF-");
   }, 30_000);
+});
+
+describe("browser-safe Chromium print profile", () => {
+  it("keeps the Playwright adapter and browser hosts on identical CSS", () => {
+    const html = "<html><head></head><body><p>本文</p></body></html>";
+    const profile = {
+      layout: { system: "japanese-publisher" as const },
+      typesetting: { writingMode: "vertical" as const },
+      pagination: {
+        pageSize: "A4" as const,
+        landscape: true,
+        pageNumbers: { enabled: true, format: "fraction" as const, position: "top-right" as const },
+      },
+    };
+    const prepared = prepareChromiumPrintProfile(html, profile);
+
+    expect(prepared.html).toBe(applyPdfProfile(html, prepared.profile));
+    expect(prepared.page).toMatchObject({ widthMm: 297, heightMm: 210, landscape: true });
+    expect(prepared.pageNumbers.headerTemplate).toContain('text-align:right');
+    expect(prepared.pageNumbers.headerTemplate).toContain('class="totalPages"');
+    expect(prepared.pageNumbers.footerTemplate).toBeUndefined();
+  });
+
+  it("uses source writing mode and exposes footer metadata without launching Chromium", () => {
+    const prepared = prepareChromiumPrintProfile("<p>縦書き</p>", undefined, "vertical");
+
+    expect(prepared.html).toContain('<style id="mdi-export-profile">');
+    expect(prepared.html).toContain("writing-mode:vertical-rl");
+    expect(prepared.page).toMatchObject({ widthMm: 297, heightMm: 210, landscape: true });
+    expect(prepared.pageNumbers).toMatchObject({ enabled: true, position: "bottom-center" });
+    expect(prepared.pageNumbers.headerTemplate).toBeUndefined();
+    expect(prepared.pageNumbers.footerTemplate).toContain('class="pageNumber"');
+  });
+
+  it("keeps browser-safe input validation and creates no header/footer for disabled numbering", () => {
+    expect(() => prepareChromiumPrintProfile(null as never)).toThrow("html must be a string");
+    const prepared = prepareChromiumPrintProfile(
+      "<html><body><p>本文</p></body></html>",
+      {
+        layout: { system: "word" },
+        pagination: { pageNumbers: { enabled: false } },
+      },
+    );
+    expect(prepared.html).toContain("<head><style id=\"mdi-export-profile\">");
+    expect(prepared.pageNumbers.headerTemplate).toBeUndefined();
+    expect(prepared.pageNumbers.footerTemplate).toBeUndefined();
+  });
 });
 
 describe("PDF export profile", () => {

--- a/nodejs/packages/to-pdf/src/index.ts
+++ b/nodejs/packages/to-pdf/src/index.ts
@@ -1,12 +1,11 @@
 import { chromium } from "playwright";
 import type { Root } from "mdast";
 import { mdiToHtml } from "@illusions-lab/mdi-to-html";
-import {
-  PAGE_DIMENSIONS,
-  resolvePrintProfile,
-  type ExportProfile,
-  type ResolvedExportProfile,
-} from "@illusions-lab/mdi-export-profile";
+import type { ExportProfile } from "@illusions-lab/mdi-export-profile";
+import { prepareChromiumPrintProfile } from "./profile.js";
+
+export { applyPdfProfile, prepareChromiumPrintProfile } from "./profile.js";
+export type { ChromiumPrintPageNumber, ChromiumPrintProfile } from "./profile.js";
 
 export const MDI_SPEC_VERSION = "2.0";
 
@@ -21,26 +20,19 @@ export async function renderHtmlToPdf(
   profile?: ExportProfile,
   sourceWritingMode?: unknown
 ): Promise<Buffer> {
-  const resolved = resolvePrintProfile(profile, sourceWritingMode);
+  const prepared = prepareChromiumPrintProfile(html, profile, sourceWritingMode);
   const browser = await chromium.launch({ headless: true });
   try {
     const page = await browser.newPage();
-    await page.setContent(applyPdfProfile(html, resolved));
-    const pageNumber = resolved.pagination.pageNumbers;
+    await page.setContent(prepared.html);
     return Buffer.from(
       await page.pdf({
         preferCSSPageSize: true,
         printBackground: true,
         margin: { top: "0mm", right: "0mm", bottom: "0mm", left: "0mm" },
-        displayHeaderFooter: pageNumber.enabled,
-        headerTemplate:
-          pageNumber.enabled && pageNumber.position.startsWith("top-")
-            ? pageNumberTemplate(pageNumber.format, pageNumber.position)
-            : "<span></span>",
-        footerTemplate:
-          pageNumber.enabled && pageNumber.position.startsWith("bottom-")
-            ? pageNumberTemplate(pageNumber.format, pageNumber.position)
-            : "<span></span>",
+        displayHeaderFooter: prepared.pageNumbers.enabled,
+        headerTemplate: prepared.pageNumbers.headerTemplate ?? "<span></span>",
+        footerTemplate: prepared.pageNumbers.footerTemplate ?? "<span></span>",
       })
     );
   } finally {
@@ -57,101 +49,4 @@ export async function mdiToPdf(
     tree.data as { frontmatter?: { writingMode?: unknown } } | undefined
   )?.frontmatter?.writingMode;
   return renderHtmlToPdf(mdiToHtml(tree), profile, sourceWritingMode);
-}
-
-/** Converts page geometry and Japanese composition settings into isolated print CSS. */
-export function applyPdfProfile(
-  html: string,
-  profile: ResolvedExportProfile
-): string {
-  const { pagination, typesetting } = profile;
-  const dimensions = PAGE_DIMENSIONS[pagination.pageSize];
-  const width = pagination.landscape ? dimensions.height : dimensions.width;
-  const height = pagination.landscape ? dimensions.width : dimensions.height;
-  const cross =
-    typesetting.writingMode === "vertical"
-      ? width - pagination.margins.left - pagination.margins.right
-      : height - pagination.margins.top - pagination.margins.bottom;
-  // The profile resolver always provides a physical point size. PDF layout
-  // must use that same value as DOCX/EPUB rather than retain a dead fallback.
-  const fontSize = (typesetting.fontSize! / 72) * 25.4;
-  const strictGrid = pagination.gridMode === "strict";
-  const inline =
-    typesetting.writingMode === "vertical"
-      ? height - pagination.margins.top - pagination.margins.bottom
-      : width - pagination.margins.left - pagination.margins.right;
-  const characterPitch = inline / pagination.charactersPerLine;
-  // CSS character spacing is placed between glyphs, so use N - 1 intervals.
-  // This makes ordinary full-width CJK body text occupy the resolved manuscript
-  // inline extent without changing the requested body type size.
-  const rawCharacterSpacing = strictGrid
-    ? (inline - fontSize * pagination.charactersPerLine) /
-      Math.max(1, pagination.charactersPerLine - 1)
-    : 0;
-  const characterSpacing = Math.abs(rawCharacterSpacing) < 1e-9
-    ? 0
-    : rawCharacterSpacing;
-  const linePitch = cross / pagination.linesPerPage;
-  // A physical length, rather than a multiplier, prevents browser font-metric
-  // differences from changing the number of manuscript lines in strict mode.
-  const lineHeight = strictGrid
-    ? `${linePitch}mm`
-    : typesetting.lineSpacing === undefined
-    ? cross / pagination.linesPerPage / fontSize
-    : typesetting.lineSpacing;
-  const fullwidth = typesetting.fullwidthSpaceIndent
-    ? "　".repeat(Math.round(typesetting.textIndentEm))
-    : "";
-  const writingMode =
-    typesetting.writingMode === "vertical" ? "vertical-rl" : "horizontal-tb";
-  const strictBlockCss = strictGrid
-    ? `p{margin:0;text-indent:${typesetting.fullwidthSpaceIndent ? "0" : `${typesetting.textIndentEm}em`}}h1,h2,h3,h4,h5,h6{font-size:1em;line-height:inherit;color:#000;break-after:avoid;margin:0;font-weight:bold}`
-    : `p{margin:0 0 .75em;text-indent:${typesetting.fullwidthSpaceIndent ? "0" : `${typesetting.textIndentEm}em`}}h1,h2,h3,h4,h5,h6{color:#000;break-after:avoid;margin:0 0 .75em;line-height:1.25}p+h1,p+h2,p+h3,p+h4,p+h5,p+h6{padding-top:.75em}h1{font-size:1.6em}h2{font-size:1.35em}h3{font-size:1.15em}`;
-  const css = `<style id="mdi-export-profile">${pageRules(width, height, profile)}html{writing-mode:${writingMode}!important;background:#fff;color:#000;--mdi-grid-mode:${pagination.gridMode};--mdi-character-pitch:${characterPitch}mm;--mdi-character-spacing:${characterSpacing}mm;--mdi-line-pitch:${linePitch}mm;--mdi-characters-per-line:${pagination.charactersPerLine};--mdi-lines-per-page:${pagination.linesPerPage}}html,body{margin:0;box-sizing:border-box}body{font-family:${cssValue(
-    typesetting.fontFamily
-  )};font-size:${fontSize}mm;line-height:${lineHeight};letter-spacing:${characterSpacing}mm;writing-mode:${writingMode};text-orientation:mixed;color:#000}${strictBlockCss}a{color:inherit;text-decoration:none}.mdi-pagebreak,.mdi-pagebreak-right,.mdi-pagebreak-left{background:transparent}</style>`;
-  return html
-    .replace("</head>", `${css}</head>`)
-    .replace(/(<p(?:\s[^>]*)?>)(?!\s*<\/p>)/g, `$1${fullwidth}`);
-}
-
-/** Emit physical mirror margins for book spreads; `bindingSide` describes odd pages. */
-function pageRules(
-  width: number,
-  height: number,
-  profile: ResolvedExportProfile,
-): string {
-  const { top, right, bottom, left } = profile.pagination.margins;
-  const base = `@page{size:${width}mm ${height}mm;margin:${top}mm ${right}mm ${bottom}mm ${left}mm}`;
-  if (profile.layout.marginMode !== "mirror") return base;
-  const odd = profile.layout.bindingSide === "right"
-    ? `${top}mm ${right}mm ${bottom}mm ${left}mm`
-    : `${top}mm ${left}mm ${bottom}mm ${right}mm`;
-  const even = profile.layout.bindingSide === "right"
-    ? `${top}mm ${left}mm ${bottom}mm ${right}mm`
-    : `${top}mm ${right}mm ${bottom}mm ${left}mm`;
-  return `${base}@page :right{margin:${odd}}@page :left{margin:${even}}`;
-}
-
-function pageNumberTemplate(
-  format: ResolvedExportProfile["pagination"]["pageNumbers"]["format"],
-  position: ResolvedExportProfile["pagination"]["pageNumbers"]["position"]
-): string {
-  const align = position.endsWith("left")
-    ? "left"
-    : position.endsWith("right")
-    ? "right"
-    : "center";
-  const page = '<span class="pageNumber"></span>';
-  const value =
-    format === "dash"
-      ? `— ${page} —`
-      : format === "fraction"
-      ? `${page} / <span class="totalPages"></span>`
-      : page;
-  return `<div style="width:100%;font-size:8pt;text-align:${align};padding:0 8mm">${value}</div>`;
-}
-
-function cssValue(value: string): string {
-  return value.replace(/[{}<>;]/g, "");
 }

--- a/nodejs/packages/to-pdf/src/profile.ts
+++ b/nodejs/packages/to-pdf/src/profile.ts
@@ -1,0 +1,171 @@
+import {
+  PAGE_DIMENSIONS,
+  resolvePrintProfile,
+  type ExportProfile,
+  type ResolvedExportProfile,
+} from "@illusions-lab/mdi-export-profile";
+
+export interface ChromiumPrintPageNumber {
+  enabled: boolean;
+  format: ResolvedExportProfile["pagination"]["pageNumbers"]["format"];
+  position: ResolvedExportProfile["pagination"]["pageNumbers"]["position"];
+  /** HTML for Chromium's header or footer print slot, when one is needed. */
+  headerTemplate?: string;
+  /** HTML for Chromium's header or footer print slot, when one is needed. */
+  footerTemplate?: string;
+}
+
+/**
+ * Browser-safe data needed to print Rust-rendered HTML with Chromium.
+ *
+ * `html` already contains all layout CSS, so it can be used directly with an
+ * Electron BrowserWindow or a document opened for `window.print()`. The
+ * remaining values are physical print metadata for hosts such as
+ * `webContents.printToPDF()`. No browser is launched by this module.
+ */
+export interface ChromiumPrintProfile {
+  html: string;
+  profile: ResolvedExportProfile;
+  page: {
+    widthMm: number;
+    heightMm: number;
+    marginsMm: ResolvedExportProfile["pagination"]["margins"];
+    landscape: boolean;
+  };
+  pageNumbers: ChromiumPrintPageNumber;
+}
+
+/**
+ * Apply an export profile and expose the Chromium print metadata without
+ * importing Playwright, Node built-ins, or any Chromium launcher.
+ */
+export function prepareChromiumPrintProfile(
+  html: string,
+  profile?: ExportProfile,
+  sourceWritingMode?: unknown,
+): ChromiumPrintProfile {
+  if (typeof html !== "string") throw new TypeError("html must be a string");
+  const resolved = resolvePrintProfile(profile, sourceWritingMode);
+  const dimensions = PAGE_DIMENSIONS[resolved.pagination.pageSize];
+  const widthMm = resolved.pagination.landscape ? dimensions.height : dimensions.width;
+  const heightMm = resolved.pagination.landscape ? dimensions.width : dimensions.height;
+  const pageNumbers = resolved.pagination.pageNumbers;
+  const template = pageNumbers.enabled
+    ? pageNumberTemplate(pageNumbers.format, pageNumbers.position)
+    : undefined;
+
+  return {
+    html: applyPdfProfile(html, resolved),
+    profile: resolved,
+    page: {
+      widthMm,
+      heightMm,
+      marginsMm: resolved.pagination.margins,
+      landscape: resolved.pagination.landscape,
+    },
+    pageNumbers: {
+      ...pageNumbers,
+      ...(template && pageNumbers.position.startsWith("top-")
+        ? { headerTemplate: template }
+        : template
+          ? { footerTemplate: template }
+          : {}),
+    },
+  };
+}
+
+/** Converts page geometry and Japanese composition settings into isolated print CSS. */
+export function applyPdfProfile(
+  html: string,
+  profile: ResolvedExportProfile,
+): string {
+  const { pagination, typesetting } = profile;
+  const dimensions = PAGE_DIMENSIONS[pagination.pageSize];
+  const width = pagination.landscape ? dimensions.height : dimensions.width;
+  const height = pagination.landscape ? dimensions.width : dimensions.height;
+  const cross =
+    typesetting.writingMode === "vertical"
+      ? width - pagination.margins.left - pagination.margins.right
+      : height - pagination.margins.top - pagination.margins.bottom;
+  const fontSize = (typesetting.fontSize! / 72) * 25.4;
+  const strictGrid = pagination.gridMode === "strict";
+  const inline =
+    typesetting.writingMode === "vertical"
+      ? height - pagination.margins.top - pagination.margins.bottom
+      : width - pagination.margins.left - pagination.margins.right;
+  const characterPitch = inline / pagination.charactersPerLine;
+  const rawCharacterSpacing = strictGrid
+    ? (inline - fontSize * pagination.charactersPerLine) /
+      Math.max(1, pagination.charactersPerLine - 1)
+    : 0;
+  const characterSpacing = Math.abs(rawCharacterSpacing) < 1e-9
+    ? 0
+    : rawCharacterSpacing;
+  const linePitch = cross / pagination.linesPerPage;
+  const lineHeight = strictGrid
+    ? `${linePitch}mm`
+    : typesetting.lineSpacing === undefined
+      ? cross / pagination.linesPerPage / fontSize
+      : typesetting.lineSpacing;
+  const fullwidth = typesetting.fullwidthSpaceIndent
+    ? "　".repeat(Math.round(typesetting.textIndentEm))
+    : "";
+  const writingMode =
+    typesetting.writingMode === "vertical" ? "vertical-rl" : "horizontal-tb";
+  const strictBlockCss = strictGrid
+    ? `p{margin:0;text-indent:${typesetting.fullwidthSpaceIndent ? "0" : `${typesetting.textIndentEm}em`}}h1,h2,h3,h4,h5,h6{font-size:1em;line-height:inherit;color:#000;break-after:avoid;margin:0;font-weight:bold}`
+    : `p{margin:0 0 .75em;text-indent:${typesetting.fullwidthSpaceIndent ? "0" : `${typesetting.textIndentEm}em`}}h1,h2,h3,h4,h5,h6{color:#000;break-after:avoid;margin:0 0 .75em;line-height:1.25}p+h1,p+h2,p+h3,p+h4,p+h5,p+h6{padding-top:.75em}h1{font-size:1.6em}h2{font-size:1.35em}h3{font-size:1.15em}`;
+  const css = `<style id="mdi-export-profile">${pageRules(width, height, profile)}html{writing-mode:${writingMode}!important;background:#fff;color:#000;--mdi-grid-mode:${pagination.gridMode};--mdi-character-pitch:${characterPitch}mm;--mdi-character-spacing:${characterSpacing}mm;--mdi-line-pitch:${linePitch}mm;--mdi-characters-per-line:${pagination.charactersPerLine};--mdi-lines-per-page:${pagination.linesPerPage}}html,body{margin:0;box-sizing:border-box}body{font-family:${cssValue(
+    typesetting.fontFamily
+  )};font-size:${fontSize}mm;line-height:${lineHeight};letter-spacing:${characterSpacing}mm;writing-mode:${writingMode};text-orientation:mixed;color:#000}${strictBlockCss}a{color:inherit;text-decoration:none}.mdi-pagebreak,.mdi-pagebreak-right,.mdi-pagebreak-left{background:transparent}</style>`;
+  return injectProfileStyle(html, css)
+    .replace(/(<p(?:\s[^>]*)?>)(?!\s*<\/p>)/g, `$1${fullwidth}`);
+}
+
+function injectProfileStyle(html: string, css: string): string {
+  if (/<\/head\s*>/i.test(html))
+    return html.replace(/<\/head\s*>/i, `${css}</head>`);
+  if (/<html(?:\s[^>]*)?>/i.test(html))
+    return html.replace(/<html(?:\s[^>]*)?>/i, `$&<head>${css}</head>`);
+  return `${css}${html}`;
+}
+
+function pageRules(
+  width: number,
+  height: number,
+  profile: ResolvedExportProfile,
+): string {
+  const { top, right, bottom, left } = profile.pagination.margins;
+  const base = `@page{size:${width}mm ${height}mm;margin:${top}mm ${right}mm ${bottom}mm ${left}mm}`;
+  if (profile.layout.marginMode !== "mirror") return base;
+  const odd = profile.layout.bindingSide === "right"
+    ? `${top}mm ${right}mm ${bottom}mm ${left}mm`
+    : `${top}mm ${left}mm ${bottom}mm ${right}mm`;
+  const even = profile.layout.bindingSide === "right"
+    ? `${top}mm ${left}mm ${bottom}mm ${right}mm`
+    : `${top}mm ${right}mm ${bottom}mm ${left}mm`;
+  return `${base}@page :right{margin:${odd}}@page :left{margin:${even}}`;
+}
+
+function pageNumberTemplate(
+  format: ResolvedExportProfile["pagination"]["pageNumbers"]["format"],
+  position: ResolvedExportProfile["pagination"]["pageNumbers"]["position"],
+): string {
+  const align = position.endsWith("left")
+    ? "left"
+    : position.endsWith("right")
+      ? "right"
+      : "center";
+  const page = '<span class="pageNumber"></span>';
+  const value =
+    format === "dash"
+      ? `— ${page} —`
+      : format === "fraction"
+        ? `${page} / <span class="totalPages"></span>`
+        : page;
+  return `<div style="width:100%;font-size:8pt;text-align:${align};padding:0 8mm">${value}</div>`;
+}
+
+function cssValue(value: string): string {
+  return value.replace(/[{}<>;]/g, "");
+}

--- a/nodejs/scripts/pack-publishable-package.test.mjs
+++ b/nodejs/scripts/pack-publishable-package.test.mjs
@@ -113,6 +113,27 @@ test("npm artifacts replace workspace dependencies and MDI installs for consumer
     );
     assert.doesNotMatch(JSON.stringify(installed), /workspace:/);
 
+    const profileOutput = execFileSync(
+      process.execPath,
+      [
+        "--input-type=module",
+        "--eval",
+        `import { prepareChromiumPrintProfile } from "@illusions-lab/mdi-to-pdf/profile";
+         const print = prepareChromiumPrintProfile("<p>本文</p>", undefined, "vertical");
+         console.log(JSON.stringify({
+           hasCss: print.html.includes("mdi-export-profile"),
+           widthMm: print.page.widthMm,
+           heightMm: print.page.heightMm,
+         }));`,
+      ],
+      { cwd: consumerDirectory, encoding: "utf8" }
+    );
+    assert.deepEqual(JSON.parse(profileOutput), {
+      hasCss: true,
+      widthMm: 297,
+      heightMm: 210,
+    });
+
     const source = join(consumerDirectory, "book.mdi");
     writeFileSync(
       source,


### PR DESCRIPTION
## Summary
- add a Playwright-free `@illusions-lab/mdi-to-pdf/profile` export
- share profile-to-CSS layout rules with the existing Playwright adapter
- expose physical page and Chromium header/footer metadata for Electron and web hosts

## Validation
- Chromium PDF integration tests
- 100% to-pdf coverage across lines, branches, functions, and statements
- packed npm consumer import and CLI smoke test

Closes #49