### PR TITLE
feat: publish paper-size labels and fix vertical blanks

### DIFF
--- a/config/publication-layouts.yaml
+++ b/config/publication-layouts.yaml
@@ -72,6 +72,78 @@ paperSizes:
   B5: { widthMm: 176, heightMm: 250 }
   B6: { widthMm: 125, heightMm: 176 }
 
+# Localized UI metadata is deliberately separate from paper geometry. Every
+# locale must cover the full paperSizes catalogue; CI verifies that contract.
+paperSizeLabels:
+  ja:
+    A0: A0判
+    A1: A1判
+    A2: A2判
+    A3: A3判
+    A4: A4判
+    A5: A5判
+    A6: A6判
+    A7: A7判
+    A8: A8判
+    A9: A9判
+    A10: A10判
+    JIS-B0: JIS B0判
+    JIS-B1: JIS B1判
+    JIS-B2: JIS B2判
+    JIS-B3: JIS B3判
+    JIS-B4: JIS B4判
+    JIS-B5: JIS B5判
+    JIS-B6: JIS B6判
+    JIS-B7: JIS B7判
+    JIS-B8: JIS B8判
+    JIS-B9: JIS B9判
+    JIS-B10: JIS B10判
+    ISO-B0: ISO B0判
+    ISO-B1: ISO B1判
+    ISO-B2: ISO B2判
+    ISO-B3: ISO B3判
+    ISO-B4: ISO B4判
+    ISO-B5: ISO B5判
+    ISO-B6: ISO B6判
+    ISO-B7: ISO B7判
+    ISO-B8: ISO B8判
+    ISO-B9: ISO B9判
+    ISO-B10: ISO B10判
+    Bunko: 文庫判
+    Shinsho: 新書判
+    Shirokuban: 四六判
+    Kikuban: 菊判
+    A5-ban: A5判
+    B6-ban: B6判
+    AB-ban: AB判
+    Ju-ban: 十六判
+    Kiku-tate: 菊判縦
+    Tankobon: 単行本判
+    Letter: レター
+    Legal: リーガル
+    Tabloid: タブロイド
+    Executive: エグゼクティブ
+    Statement: ステートメント
+    Folio: フォリオ
+    Quarto: クォート
+    10x14: 10 × 14インチ
+    Naga-3: 長形3号
+    Naga-4: 長形4号
+    Kaku-2: 角形2号
+    Kaku-3: 角形3号
+    Kaku-6: 角形6号
+    Kaku-8: 角形8号
+    You-4: 洋形4号
+    You-6: 洋形6号
+    Hagaki: はがき
+    Ofuku-Hagaki: 往復はがき
+    L-ban: L判
+    2L-ban: 2L判
+    KG: KG判
+    Cabinet: キャビネ判
+    B5: ISO B5判
+    B6: ISO B6判
+
 # These are generic renderer defaults, not contest or publisher-house presets.
 layouts:
   japanese-publisher:

--- a/mdi-core/src/lib.rs
+++ b/mdi-core/src/lib.rs
@@ -3221,7 +3221,10 @@ mod tests {
         ] {
             let rendered = render_text(source);
             assert_eq!(rendered.trim_end(), expected, "source: {source:?}");
-            assert!(parse_output(source).diagnostics.is_empty(), "source: {source:?}");
+            assert!(
+                parse_output(source).diagnostics.is_empty(),
+                "source: {source:?}"
+            );
         }
     }
 
@@ -3473,9 +3476,21 @@ mod tests {
     fn renders_every_documented_mdi_construct_in_vertical_html() {
         let vertical = "---\ntitle: 構文\nlang: ja\nwriting-mode: vertical\n---\n\n";
         for (name, source, expected) in [
-            ("front matter", "# 見出し", "<html lang=\"ja\" style=\"writing-mode: vertical-rl;\">"),
-            ("group ruby", "{東京|とうきょう}", "<ruby class=\"mdi-ruby\">東京"),
-            ("split ruby", "{東京|とう.きょう}", "<ruby class=\"mdi-ruby\""),
+            (
+                "front matter",
+                "# 見出し",
+                "<html lang=\"ja\" style=\"writing-mode: vertical-rl;\">",
+            ),
+            (
+                "group ruby",
+                "{東京|とうきょう}",
+                "<ruby class=\"mdi-ruby\">東京",
+            ),
+            (
+                "split ruby",
+                "{東京|とう.きょう}",
+                "<ruby class=\"mdi-ruby\"",
+            ),
             ("tate-chu-yoko", "^12^", "<span class=\"mdi-tcy\">12</span>"),
             ("default boten", "[[em:傍点]]", "class=\"mdi-em\""),
             ("custom boten", "[[em:※:任意]]", "--mdi-em:&quot;※&quot;"),
@@ -3484,20 +3499,43 @@ mod tests {
             ("blank backslash", "\\", "<p class=\"mdi-blank\"></p>"),
             ("blank br", "<br>", "<p class=\"mdi-blank\"></p>"),
             ("blank br slash", "<br />", "<p class=\"mdi-blank\"></p>"),
-            ("blank legacy macro", "[[blank]]", "<p class=\"mdi-blank\"></p>"),
+            (
+                "blank legacy macro",
+                "[[blank]]",
+                "<p class=\"mdi-blank\"></p>",
+            ),
             ("warichu", "[[warichu:割注]]", "class=\"mdi-warichu\""),
             ("kerning", "[[kern:-0.1em:詰め]]", "--mdi-kern:-0.1em"),
             ("indent", "[[indent:2]]\n字下げ", "class=\"mdi-indent\""),
-            ("bottom alignment", "[[bottom]]\n地付き", "class=\"mdi-bottom\""),
+            (
+                "bottom alignment",
+                "[[bottom]]\n地付き",
+                "class=\"mdi-bottom\"",
+            ),
             ("bottom shift", "[[bottom:2]]\n地付き", "--mdi-shift:2"),
             ("page break", "[[pagebreak]]", "class=\"mdi-pagebreak\""),
-            ("recto page break", "[[pagebreak:right]]", "class=\"mdi-pagebreak mdi-pagebreak-right\""),
-            ("verso page break", "[[pagebreak:left]]", "class=\"mdi-pagebreak mdi-pagebreak-left\""),
+            (
+                "recto page break",
+                "[[pagebreak:right]]",
+                "class=\"mdi-pagebreak mdi-pagebreak-right\"",
+            ),
+            (
+                "verso page break",
+                "[[pagebreak:left]]",
+                "class=\"mdi-pagebreak mdi-pagebreak-left\"",
+            ),
             ("footnote", "脚注[^n]\n\n[^n]: 注", "data-footnotes"),
-            ("escaped delimiters", "\\{ \\} \\| \\^ \\[ \\: \\《 \\》", "{ } | ^ [ : 《 》"),
+            (
+                "escaped delimiters",
+                "\\{ \\} \\| \\^ \\[ \\: \\《 \\》",
+                "{ } | ^ [ : 《 》",
+            ),
         ] {
             let html = render_html(&format!("{vertical}{source}"));
-            assert!(html.contains(expected), "missing {name}: {expected}; rendered {html}");
+            assert!(
+                html.contains(expected),
+                "missing {name}: {expected}; rendered {html}"
+            );
         }
         assert!(render_html(&format!("{vertical}\\")).contains(".mdi-blank{min-block-size:1lh}"));
     }

--- a/mdi-core/src/lib.rs
+++ b/mdi-core/src/lib.rs
@@ -818,7 +818,10 @@ fn annotate_and_lower(node: &mut serde_json::Value, source: &str, protected: boo
     }
     let span = object.get("span").cloned();
     let parsed = parse_inline_parts(rendered_value);
-    if parsed.len() == 1 && matches!(parsed.first(), Some((Inline::Text(_), _, _))) {
+    if let Some((Inline::Text(value), _, _)) = parsed.first()
+        && parsed.len() == 1
+        && value == rendered_value
+    {
         return;
     }
     let replacement: Vec<serde_json::Value> = parsed
@@ -1761,7 +1764,7 @@ fn children(node: &serde_json::Value) -> &[serde_json::Value] {
 
 /// The base stylesheet is intentionally shipped by the core alongside the
 /// semantic HTML. Hosts may add presentation CSS, but not reinterpret nodes.
-pub const MDI_STYLESHEET: &str = ".mdi-tcy{text-combine-upright:all}.mdi-nobr{white-space:nowrap}.mdi-warichu{font-size:.6em}.mdi-em{text-emphasis:var(--mdi-em,filled sesame)}.mdi-kern{letter-spacing:var(--mdi-kern)}.mdi-blank{min-height:1em}.mdi-indent{margin-inline-start:calc(var(--mdi-indent)*1em)}.mdi-bottom{text-align:end}.mdi-pagebreak{break-after:page}";
+pub const MDI_STYLESHEET: &str = ".mdi-tcy{text-combine-upright:all}.mdi-nobr{white-space:nowrap}.mdi-warichu{font-size:.6em}.mdi-em{text-emphasis:var(--mdi-em,filled sesame)}.mdi-kern{letter-spacing:var(--mdi-kern)}.mdi-blank{min-block-size:1lh}.mdi-indent{margin-inline-start:calc(var(--mdi-indent)*1em)}.mdi-bottom{text-align:end}.mdi-pagebreak{break-after:page}";
 
 /// Build a reflowable EPUB 3 archive entirely from Rust's document IR.
 /// Metadata comes from front matter; richer cover and print-profile options
@@ -2600,7 +2603,7 @@ fn boten(value: &str) -> Option<(Inline, usize)> {
     if !value.starts_with(prefix) {
         return None;
     }
-    let end = value.find("》》")?;
+    let end = close_boten_alias(value)?;
     let body = &value[prefix.len()..end];
     if body.is_empty()
         || body.contains('\n')
@@ -2616,6 +2619,24 @@ fn boten(value: &str) -> Option<(Inline, usize)> {
         },
         end + "》》".len(),
     ))
+}
+
+/// Find the closing `》》` of the supported boten alias.  As with every other
+/// MDI delimiter, an escaped `》` is content and cannot close the alias.
+fn close_boten_alias(value: &str) -> Option<usize> {
+    let mut index = "《《".len();
+    while index < value.len() {
+        let rest = &value[index..];
+        if rest.starts_with('\\') {
+            let next = rest.chars().nth(1)?;
+            index += 1 + next.len_utf8();
+        } else if rest.starts_with("》》") {
+            return Some(index);
+        } else {
+            index += rest.chars().next()?.len_utf8();
+        }
+    }
+    None
 }
 
 fn bracket_macro(value: &str) -> Option<(Inline, usize)> {
@@ -3182,6 +3203,49 @@ mod tests {
     }
 
     #[test]
+    fn recovers_from_malformed_inline_syntax_at_delimiter_boundaries() {
+        // A malformed construct must stay literal without preventing a later,
+        // adjacent construct from being recognized.  These cases cover every
+        // inline delimiter family, including a delimiter at end of input.
+        for (source, expected) in [
+            ("{東京|とうきょう", "{東京|とうきょう"),
+            ("{東京|とうきょう ^12^", "{東京|とうきょう 12"),
+            ("^1234567^ ^12^", "^1234567^ 12"),
+            ("[[no-break:]][[em:強調]]", "[[no-break:]]強調"),
+            ("[[kern:wide:字]][[warichu:注]]", "[[kern:wide:字]]注"),
+            ("[[em:未閉", "[[em:未閉"),
+            ("《《未閉", "《《未閉"),
+            ("{", "{"),
+            ("^", "^"),
+            ("[[", "[["),
+        ] {
+            let rendered = render_text(source);
+            assert_eq!(rendered.trim_end(), expected, "source: {source:?}");
+            assert!(parse_output(source).diagnostics.is_empty(), "source: {source:?}");
+        }
+    }
+
+    #[test]
+    fn honors_escaped_alias_delimiters_without_consuming_them_as_closers() {
+        // Escaped delimiters never participate in matching.  In particular,
+        // the first `》` below is content; the following pair closes the alias.
+        assert_eq!(
+            parse_inlines("《《a\\》》》"),
+            vec![Inline::Em {
+                mark: "﹅".into(),
+                children: vec![Inline::Text("a》".into())],
+            }]
+        );
+
+        // Without a non-escaped closing pair, the complete alias remains
+        // literal instead of partially consuming its escaped content.
+        assert_eq!(
+            parse_inlines("《《a\\》》"),
+            vec![Inline::Text("《《a》》".into())]
+        );
+    }
+
+    #[test]
     fn applies_mdi_escapes_once_before_recognition() {
         assert_eq!(
             parse_inlines(r"\{東京\|とうきょう\} \^12\^ \[\[br\]\] \《《文字\》》"),
@@ -3403,6 +3467,39 @@ mod tests {
         assert!(html.contains("<h1>題</h1>"));
         assert!(html.contains("<ruby class=\"mdi-ruby\">東京<rp>（</rp><rt>とうきょう</rt>"));
         assert!(html.contains("<span class=\"mdi-tcy\">12</span>"));
+    }
+
+    #[test]
+    fn renders_every_documented_mdi_construct_in_vertical_html() {
+        let vertical = "---\ntitle: 構文\nlang: ja\nwriting-mode: vertical\n---\n\n";
+        for (name, source, expected) in [
+            ("front matter", "# 見出し", "<html lang=\"ja\" style=\"writing-mode: vertical-rl;\">"),
+            ("group ruby", "{東京|とうきょう}", "<ruby class=\"mdi-ruby\">東京"),
+            ("split ruby", "{東京|とう.きょう}", "<ruby class=\"mdi-ruby\""),
+            ("tate-chu-yoko", "^12^", "<span class=\"mdi-tcy\">12</span>"),
+            ("default boten", "[[em:傍点]]", "class=\"mdi-em\""),
+            ("custom boten", "[[em:※:任意]]", "--mdi-em:&quot;※&quot;"),
+            ("no-break", "[[no-break:改行禁止]]", "class=\"mdi-nobr\""),
+            ("explicit line break", "前[[br]]次", "<br>"),
+            ("blank backslash", "\\", "<p class=\"mdi-blank\"></p>"),
+            ("blank br", "<br>", "<p class=\"mdi-blank\"></p>"),
+            ("blank br slash", "<br />", "<p class=\"mdi-blank\"></p>"),
+            ("blank legacy macro", "[[blank]]", "<p class=\"mdi-blank\"></p>"),
+            ("warichu", "[[warichu:割注]]", "class=\"mdi-warichu\""),
+            ("kerning", "[[kern:-0.1em:詰め]]", "--mdi-kern:-0.1em"),
+            ("indent", "[[indent:2]]\n字下げ", "class=\"mdi-indent\""),
+            ("bottom alignment", "[[bottom]]\n地付き", "class=\"mdi-bottom\""),
+            ("bottom shift", "[[bottom:2]]\n地付き", "--mdi-shift:2"),
+            ("page break", "[[pagebreak]]", "class=\"mdi-pagebreak\""),
+            ("recto page break", "[[pagebreak:right]]", "class=\"mdi-pagebreak mdi-pagebreak-right\""),
+            ("verso page break", "[[pagebreak:left]]", "class=\"mdi-pagebreak mdi-pagebreak-left\""),
+            ("footnote", "脚注[^n]\n\n[^n]: 注", "data-footnotes"),
+            ("escaped delimiters", "\\{ \\} \\| \\^ \\[ \\: \\《 \\》", "{ } | ^ [ : 《 》"),
+        ] {
+            let html = render_html(&format!("{vertical}{source}"));
+            assert!(html.contains(expected), "missing {name}: {expected}; rendered {html}");
+        }
+        assert!(render_html(&format!("{vertical}\\")).contains(".mdi-blank{min-block-size:1lh}"));
     }
 
     #[test]

--- a/nodejs/packages/export-profile/README.md
+++ b/nodejs/packages/export-profile/README.md
@@ -33,6 +33,24 @@ const fromFile = parseExportProfileJson(
 );
 ```
 
+## Paper-size UI metadata
+
+Japanese labels are part of the public catalogue, alongside stable keys and
+physical dimensions. `listPageSizes()` is suitable for a select menu.
+
+```ts
+import {
+  getPageSizeLabel,
+  listPageSizes,
+  PAGE_SIZE_LABELS,
+} from "@illusions-lab/mdi-export-profile";
+
+getPageSizeLabel("Bunko"); // "文庫判"
+PAGE_SIZE_LABELS.ja["JIS-B5"]; // "JIS B5判"
+listPageSizes({ locale: "ja" });
+// [{ key: "A4", label: "A4判", widthMm: 210, heightMm: 297 }, ...]
+```
+
 Use the resolved profile with the JavaScript PDF/mdast adapters or pass a JSON
 profile to `mdi build --config export.json`. Rust remains responsible for MDI
 syntax and document semantics.

--- a/nodejs/packages/export-profile/src/index.test.ts
+++ b/nodejs/packages/export-profile/src/index.test.ts
@@ -1,13 +1,45 @@
 import { describe, expect, it } from "vitest";
 import {
   PAGE_DIMENSIONS,
+  PAGE_SIZE_LABELS,
   PAGE_SIZES,
+  getPageSizeLabel,
+  listPageSizes,
   parseExportProfileJson,
   resolveExportProfile,
   resolvePrintProfile,
 } from "./index.js";
 
 describe("export profiles", () => {
+  it("publishes complete Japanese labels and UI metadata for every paper size", () => {
+    const sizes = listPageSizes();
+    expect(sizes).toHaveLength(PAGE_SIZES.length);
+    expect(Object.keys(PAGE_SIZE_LABELS.ja)).toHaveLength(PAGE_SIZES.length);
+
+    for (const pageSize of PAGE_SIZES) {
+      expect(PAGE_SIZE_LABELS.ja[pageSize]).toEqual(expect.any(String));
+      expect(getPageSizeLabel(pageSize, "ja")).toBe(PAGE_SIZE_LABELS.ja[pageSize]);
+      expect(sizes.find((size) => size.key === pageSize)).toEqual({
+        key: pageSize,
+        label: PAGE_SIZE_LABELS.ja[pageSize],
+        widthMm: PAGE_DIMENSIONS[pageSize].width,
+        heightMm: PAGE_DIMENSIONS[pageSize].height,
+      });
+    }
+  });
+  it("preserves distinct Japanese labels for A, JIS B, and ISO B families", () => {
+    expect(getPageSizeLabel("A4")).toBe("A4判");
+    expect(getPageSizeLabel("JIS-B5")).toBe("JIS B5判");
+    expect(getPageSizeLabel("ISO-B5")).toBe("ISO B5判");
+    expect(getPageSizeLabel("B5")).toBe("ISO B5判");
+    expect(getPageSizeLabel("Bunko")).toBe("文庫判");
+    expect(getPageSizeLabel("Ofuku-Hagaki")).toBe("往復はがき");
+  });
+  it("rejects unsupported runtime paper-size keys and locales", () => {
+    expect(() => getPageSizeLabel("A11" as never)).toThrow("Unsupported page size or locale");
+    expect(() => getPageSizeLabel("A4", "en" as never)).toThrow("Unsupported page size or locale");
+    expect(() => listPageSizes({ locale: "en" as never })).toThrow("Unsupported page size or locale");
+  });
   it("resolves a physically valid publisher default for every supported paper size and writing direction", () => {
     for (const pageSize of PAGE_SIZES) {
       expect(

--- a/nodejs/packages/export-profile/src/index.ts
+++ b/nodejs/packages/export-profile/src/index.ts
@@ -203,6 +203,66 @@ export const PAGE_DIMENSIONS = {
 export type PageSize = keyof typeof PAGE_DIMENSIONS;
 export const PAGE_SIZES = Object.keys(PAGE_DIMENSIONS) as PageSize[];
 
+/** Localized display names for the shared paper-size catalogue. */
+export const PAGE_SIZE_LABELS = {
+  ja: {
+    A0: "A0判", A1: "A1判", A2: "A2判", A3: "A3判", A4: "A4判",
+    A5: "A5判", A6: "A6判", A7: "A7判", A8: "A8判", A9: "A9判", A10: "A10判",
+    "JIS-B0": "JIS B0判", "JIS-B1": "JIS B1判", "JIS-B2": "JIS B2判",
+    "JIS-B3": "JIS B3判", "JIS-B4": "JIS B4判", "JIS-B5": "JIS B5判",
+    "JIS-B6": "JIS B6判", "JIS-B7": "JIS B7判", "JIS-B8": "JIS B8判",
+    "JIS-B9": "JIS B9判", "JIS-B10": "JIS B10判",
+    "ISO-B0": "ISO B0判", "ISO-B1": "ISO B1判", "ISO-B2": "ISO B2判",
+    "ISO-B3": "ISO B3判", "ISO-B4": "ISO B4判", "ISO-B5": "ISO B5判",
+    "ISO-B6": "ISO B6判", "ISO-B7": "ISO B7判", "ISO-B8": "ISO B8判",
+    "ISO-B9": "ISO B9判", "ISO-B10": "ISO B10判",
+    Bunko: "文庫判", Shinsho: "新書判", Shirokuban: "四六判", Kikuban: "菊判",
+    "A5-ban": "A5判", "B6-ban": "B6判", "AB-ban": "AB判", "Ju-ban": "十六判",
+    "Kiku-tate": "菊判縦", Tankobon: "単行本判",
+    Letter: "レター", Legal: "リーガル", Tabloid: "タブロイド", Executive: "エグゼクティブ",
+    Statement: "ステートメント", Folio: "フォリオ", Quarto: "クォート", "10x14": "10 × 14インチ",
+    "Naga-3": "長形3号", "Naga-4": "長形4号", "Kaku-2": "角形2号", "Kaku-3": "角形3号",
+    "Kaku-6": "角形6号", "Kaku-8": "角形8号", "You-4": "洋形4号", "You-6": "洋形6号",
+    Hagaki: "はがき", "Ofuku-Hagaki": "往復はがき", "L-ban": "L判", "2L-ban": "2L判",
+    KG: "KG判", Cabinet: "キャビネ判", B5: "ISO B5判", B6: "ISO B6判",
+  },
+} as const satisfies { ja: Record<PageSize, string> };
+
+export type PageSizeLocale = keyof typeof PAGE_SIZE_LABELS;
+
+/** UI-ready metadata for one paper size in a requested locale. */
+export interface PageSizeMetadata {
+  key: PageSize;
+  label: string;
+  widthMm: number;
+  heightMm: number;
+}
+
+/** Return the localized UI label for a supported paper-size key. */
+export function getPageSizeLabel(
+  pageSize: PageSize,
+  locale: PageSizeLocale = "ja",
+): string {
+  const labels = PAGE_SIZE_LABELS[locale];
+  const label = labels?.[pageSize];
+  if (typeof label !== "string")
+    throw new Error(`Unsupported page size or locale: ${String(pageSize)}, ${String(locale)}`);
+  return label;
+}
+
+/** List every paper size with a localized label and physical millimetre dimensions. */
+export function listPageSizes(
+  options: { locale?: PageSizeLocale } = {},
+): PageSizeMetadata[] {
+  const locale = options.locale ?? "ja";
+  return PAGE_SIZES.map((key) => ({
+    key,
+    label: getPageSizeLabel(key, locale),
+    widthMm: PAGE_DIMENSIONS[key].width,
+    heightMm: PAGE_DIMENSIONS[key].height,
+  }));
+}
+
 export const DEFAULT_EXPORT_PROFILE: ResolvedExportProfile = {
   layout: {
     system: "japanese-publisher",

--- a/nodejs/packages/to-pdf/CHANGELOG.md
+++ b/nodejs/packages/to-pdf/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Add the browser-safe `@illusions-lab/mdi-to-pdf/profile` entry for applying
   Chromium print profiles without importing Playwright or launching Chromium.
+- Make all blank-paragraph spellings reserve one logical strict-grid column in
+  vertical Chromium layout.
 
 ## 2.0.18
 

--- a/nodejs/packages/to-pdf/package.json
+++ b/nodejs/packages/to-pdf/package.json
@@ -38,6 +38,7 @@
     "@types/mdast": "^4.0.0"
   },
   "devDependencies": {
+    "@illusions-lab/mdi": "workspace:*",
     "@illusions-lab/mdi-remark": "workspace:*",
     "remark-parse": "^11.0.0",
     "unified": "^11.0.0",

--- a/nodejs/packages/to-pdf/src/index.test.ts
+++ b/nodejs/packages/to-pdf/src/index.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from "vitest";
+import { chromium } from "playwright";
+import { renderHtml } from "@illusions-lab/mdi";
 import { unified } from "unified";
 import remarkParse from "remark-parse";
 import remarkMdi from "@illusions-lab/mdi-remark";
@@ -119,6 +121,53 @@ describe("browser-safe Chromium print profile", () => {
     expect(prepared.pageNumbers.headerTemplate).toBeUndefined();
     expect(prepared.pageNumbers.footerTemplate).toBeUndefined();
   });
+});
+
+describe("vertical Chromium syntax layout", () => {
+  it("keeps documented blank syntax as one strict-grid column", async () => {
+    const html = renderHtml(`---
+writing-mode: vertical
+---
+
+前の段落です。
+
+\\
+
+<br>
+
+<br />
+
+[[blank]]
+
+後の段落です。`);
+    const prepared = prepareChromiumPrintProfile(html, {
+      layout: { system: "japanese-publisher" },
+      typesetting: { writingMode: "vertical" },
+    }, "vertical");
+    const browser = await chromium.launch({ headless: true });
+    try {
+      const page = await browser.newPage();
+      await page.setContent(prepared.html);
+      const blankColumns = await page.locator(".mdi-blank").evaluateAll((blanks) =>
+        blanks.map((blank) => {
+          const style = blank.ownerDocument.defaultView!.getComputedStyle(blank);
+          return {
+            blockSize: blank.getBoundingClientRect().width,
+            minimumBlockSize: Number.parseFloat(style.minBlockSize),
+            lineHeight: Number.parseFloat(style.lineHeight),
+          };
+        }),
+      );
+      expect(blankColumns).toHaveLength(4);
+      for (const column of blankColumns) {
+        expect(column.minimumBlockSize).toBeGreaterThan(0);
+        expect(column.blockSize).toBeCloseTo(column.lineHeight, 2);
+        expect(column.blockSize).toBeCloseTo(column.minimumBlockSize, 2);
+      }
+    } finally {
+      await browser.close();
+    }
+  }, 30_000);
 });
 
 describe("PDF export profile", () => {

--- a/nodejs/scripts/pack-publishable-package.test.mjs
+++ b/nodejs/scripts/pack-publishable-package.test.mjs
@@ -119,11 +119,14 @@ test("npm artifacts replace workspace dependencies and MDI installs for consumer
         "--input-type=module",
         "--eval",
         `import { prepareChromiumPrintProfile } from "@illusions-lab/mdi-to-pdf/profile";
+         import { getPageSizeLabel, listPageSizes } from "@illusions-lab/mdi-export-profile";
          const print = prepareChromiumPrintProfile("<p>本文</p>", undefined, "vertical");
          console.log(JSON.stringify({
            hasCss: print.html.includes("mdi-export-profile"),
            widthMm: print.page.widthMm,
            heightMm: print.page.heightMm,
+           bunkoLabel: getPageSizeLabel("Bunko"),
+           jisB5Label: listPageSizes().find((size) => size.key === "JIS-B5")?.label,
          }));`,
       ],
       { cwd: consumerDirectory, encoding: "utf8" }
@@ -132,6 +135,8 @@ test("npm artifacts replace workspace dependencies and MDI installs for consumer
       hasCss: true,
       widthMm: 297,
       heightMm: 210,
+      bunkoLabel: "文庫判",
+      jisB5Label: "JIS B5判",
     });
 
     const source = join(consumerDirectory, "book.mdi");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -358,6 +358,9 @@ importers:
         specifier: ^1.48.0
         version: 1.61.1
     devDependencies:
+      '@illusions-lab/mdi':
+        specifier: workspace:*
+        version: link:../mdi
       '@illusions-lab/mdi-remark':
         specifier: workspace:*
         version: link:../remark

--- a/scripts/verify-publication-layouts.mjs
+++ b/scripts/verify-publication-layouts.mjs
@@ -14,8 +14,8 @@ const [yamlSource, typescriptSource] = await Promise.all([
   readFile(new URL("../nodejs/packages/export-profile/src/index.ts", import.meta.url), "utf8"),
 ]);
 const config = parse(yamlSource);
-if (config?.version !== 1 || config?.units !== "mm" || !config.paperSizes)
-  throw new Error("publication-layouts.yaml must declare version 1, mm units, and paperSizes");
+if (config?.version !== 1 || config?.units !== "mm" || !config.paperSizes || !config.paperSizeLabels?.ja)
+  throw new Error("publication-layouts.yaml must declare version 1, mm units, paperSizes, and Japanese labels");
 
 const staticSizes = new Map(
   [...typescriptSource.matchAll(/^\s*(?:"([^"]+)"|(\w+)):\s*\{ width: (\d+), height: (\d+) \},$/gm)]
@@ -28,6 +28,24 @@ for (const [name, size] of Object.entries(config.paperSizes)) {
 }
 if (staticSizes.size !== Object.keys(config.paperSizes).length)
   throw new Error("publication-layouts.yaml must list every PAGE_DIMENSIONS entry");
+
+const labelBlock = typescriptSource.match(
+  /export const PAGE_SIZE_LABELS = \{\n  ja: \{([\s\S]*?)\n  \},\n\} as const/,
+)?.[1];
+if (!labelBlock) throw new Error("PAGE_SIZE_LABELS.ja must be exported");
+const staticLabels = new Map(
+  [...labelBlock.matchAll(/(?:"([^"]+)"|(\w+)):\s*"([^"]+)"/g)]
+    .map((match) => [match[1] ?? match[2], match[3]]),
+);
+for (const name of Object.keys(config.paperSizes)) {
+  if (typeof config.paperSizeLabels.ja[name] !== "string" || !staticLabels.get(name))
+    throw new Error(`Japanese paper-size label missing for ${name}`);
+  if (staticLabels.get(name) !== config.paperSizeLabels.ja[name])
+    throw new Error(`Japanese paper-size label mismatch for ${name}`);
+}
+if (staticLabels.size !== Object.keys(config.paperSizes).length ||
+  Object.keys(config.paperSizeLabels.ja).length !== Object.keys(config.paperSizes).length)
+  throw new Error("Japanese paper-size labels must cover every PAGE_DIMENSIONS entry");
 
 const vertical = config.layouts?.["japanese-publisher"]?.vertical;
 const horizontal = config.layouts?.word?.horizontal;


### PR DESCRIPTION
## Summary
- publish complete Japanese paper-size labels and UI metadata from `@illusions-lab/mdi-export-profile`
- validate labels against the shared publication catalogue in CI
- fix vertical Chromium blank paragraphs to reserve one logical strict-grid column
- test every documented MDI construct independently through the Rust HTML renderer

## Validation
- `cargo test` (40 tests)
- export-profile, mdi, and to-pdf typecheck/tests
- 90% coverage gate: export-profile 95.23% branches; to-pdf 100%
- full workspace build and packed npm consumer test

Closes #51
Closes #52