### PR TITLE
fix(release): authenticate cargo with crates.io OIDC

### DIFF
--- a/.github/workflows/release-rust.yml
+++ b/.github/workflows/release-rust.yml
@@ -31,11 +31,17 @@ jobs:
         run: cargo package --locked
 
       # crates.io must have this repository configured as a trusted publisher.
-      # Cargo exchanges GitHub's OIDC token; no long-lived registry token is
-      # stored in this workflow.
+      # Exchange GitHub's OIDC token for a short-lived registry token; no
+      # long-lived registry token is stored in this workflow.
+      - name: Authenticate with crates.io
+        id: auth
+        uses: rust-lang/crates-io-auth-action@v1
+
       - name: Publish the manifest version when it is new
         id: publish
         shell: bash
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
         run: |
           version=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')
           status=$(


### PR DESCRIPTION
## Summary
- add the official `rust-lang/crates-io-auth-action@v1` OIDC exchange
- pass its short-lived token to `cargo publish` through `CARGO_REGISTRY_TOKEN`
- keep the registry existence check introduced in #55

## Root cause
`id-token: write` only allows GitHub to mint an OIDC identity token. Cargo does not exchange it itself, so the previous publish attempt correctly reached `cargo publish` but failed with `no token found`.

## Verification
- implementation follows the official crates.io Trusted Publishing workflow
- workflow diff passes `git diff --check`