### PR TITLE
fix(release): dispatch crates publishing after CI

### DIFF
--- a/.github/workflows/release-rust.yml
+++ b/.github/workflows/release-rust.yml
@@ -6,22 +6,46 @@ on:
     types: [completed]
     branches: [main]
   workflow_dispatch:
+    inputs:
+      release_sha:
+        description: Commit on main whose complete CI run succeeded
+        required: true
+        type: string
 
 # Publishing here is deliberately limited to the canonical crate. The JNI
 # crate is an Android implementation detail (`publish = false`); the other
 # ecosystems have their own release workflows.
-concurrency: release-rust-${{ github.event.workflow_run.head_sha || github.sha }}
+concurrency: release-rust-${{ github.event.workflow_run.head_sha || inputs.release_sha || github.sha }}
 
 jobs:
+  dispatch:
+    if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      # crates.io deliberately rejects OIDC tokens from workflow_run events.
+      # Redispatch the already-gated commit as the supported workflow_dispatch
+      # event; the publishing job independently verifies the completed CI run.
+      - name: Dispatch the trusted-publishing workflow
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: >-
+          gh workflow run release-rust.yml
+          --repo "$GITHUB_REPOSITORY"
+          --ref main
+          --field release_sha="$RELEASE_SHA"
+
   crates-io:
-    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       actions: read
       contents: write
       id-token: write
     env:
-      RELEASE_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
+      RELEASE_SHA: ${{ inputs.release_sha }}
     defaults:
       run:
         working-directory: mdi-core
@@ -30,11 +54,12 @@ jobs:
         with:
           ref: ${{ env.RELEASE_SHA }}
 
-      - name: Verify the manual release commit passed the complete CI gate
-        if: github.event_name == 'workflow_dispatch'
+      - name: Verify the release commit is current and passed the complete CI gate
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          main_sha=$(gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/main" --jq '.object.sha')
+          test "$RELEASE_SHA" = "$main_sha"
           count=$(
             gh api --method GET \
               "repos/$GITHUB_REPOSITORY/actions/workflows/ci.yml/runs" \


### PR DESCRIPTION
## What changed

- split the Rust release workflow into a CI-gated dispatcher and a `workflow_dispatch` publishing job
- pass the successful main commit SHA into the publishing job
- independently verify that the SHA is the current main head and has a successful completed CI run before publishing

## Root cause

crates.io Trusted Publishing rejects OIDC token exchange when the GitHub workflow was triggered by `workflow_run`. The complete-CI release gate therefore worked, but the registry authentication step returned HTTP 400.

## Impact

Rust publishing remains gated behind every platform unit/coverage job and the publication contracts, while the actual crates.io authentication now runs under the supported `workflow_dispatch` event.

## Validation

- `actionlint .github/workflows/release-rust.yml`
- `git diff --check`
- executed the workflow main-head and successful-CI API checks against merge commit `53e66f52a0f01079a18fb09ac911b4472c7ad319`