### PR TITLE
Fix absent Python release tag check

### DIFF
--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -108,11 +108,10 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          tag_sha=$(
+          if tag_sha=$(
             gh api "repos/$GITHUB_REPOSITORY/commits/$RELEASE_TAG" \
-              --jq '.sha' 2>/dev/null || true
-          )
-          if [[ -n "$tag_sha" ]]; then
+              --jq '.sha' 2>/dev/null
+          ); then
             test "$tag_sha" = "$RELEASE_SHA"
           fi
 


### PR DESCRIPTION
Fix the PyPI release preflight so an absent tag is treated as absent instead of interpreting GitHub's 422 response body as a commit SHA.

Validated with actionlint and live GitHub API checks for both absent and existing tags.