### PR TITLE
Make Swift release preparation resumable

### DIFF
--- a/.github/workflows/swift-release.yml
+++ b/.github/workflows/swift-release.yml
@@ -132,13 +132,18 @@ jobs:
           VERSION: ${{ inputs.version }}
         run: |
           BRANCH="swift-release/$VERSION"
-          git switch -c "$BRANCH"
+          git fetch origin "$BRANCH:refs/remotes/origin/$BRANCH" || true
+          git switch -C "$BRANCH"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add Package.swift
           git commit -m "Release Swift package $VERSION"
-          git push origin "$BRANCH"
-          gh pr create --base main --head "$BRANCH" --title "Release Swift package $VERSION" --body "Prepared by workflow run $GITHUB_RUN_ID. Merge after the required checks pass, then dispatch **Publish Swift Package** with action **publish** and prepare run ID $GITHUB_RUN_ID."
+          git push --force-with-lease origin "$BRANCH"
+          if gh pr view "$BRANCH" --json number >/dev/null 2>&1; then
+            echo "Updated the existing release manifest pull request."
+          elif ! gh pr create --base main --head "$BRANCH" --title "Release Swift package $VERSION" --body "Prepared by workflow run $GITHUB_RUN_ID. Merge after the required checks pass, then dispatch **Publish Swift Package** with action **publish** and prepare run ID $GITHUB_RUN_ID."; then
+            echo "::notice::The release branch is ready, but GitHub Actions cannot create pull requests in this repository. Create the pull request manually, then merge it after the required checks pass."
+          fi
 
   publish:
     if: inputs.action == 'publish'


### PR DESCRIPTION
Allow the Swift prepare workflow to refresh an existing release branch and reuse an already-open manifest PR. If repository policy blocks github-actions[bot] from creating PRs, leave a successful prepared branch plus an explicit notice so an authenticated maintainer can create it manually.

Validated with actionlint and the live existing PR lookup.