### PR TITLE
fix(exports): improve vertical document navigation

### DIFF
--- a/mdi-core/src/docx.rs
+++ b/mdi-core/src/docx.rs
@@ -541,6 +541,7 @@ fn ruby_xml(node: &Value, base_size: i64) -> String {
 }
 
 fn table_xml(node: &Value, profile: &ResolvedExportProfile, context: &mut Context) -> String {
+    let vertical = profile.typesetting.writing_mode == "vertical";
     let rows = children(node);
     let columns = rows
         .iter()
@@ -558,6 +559,13 @@ fn table_xml(node: &Value, profile: &ResolvedExportProfile, context: &mut Contex
     let usable =
         mm_to_twips(width - profile.pagination.margins.left - profile.pagination.margins.right);
     let column_width = usable / columns as i64;
+    let borders = "<w:tblBorders><w:top w:val=\"single\" w:sz=\"4\" w:color=\"000000\"/><w:left w:val=\"single\" w:sz=\"4\" w:color=\"000000\"/><w:bottom w:val=\"single\" w:sz=\"4\" w:color=\"000000\"/><w:right w:val=\"single\" w:sz=\"4\" w:color=\"000000\"/><w:insideH w:val=\"single\" w:sz=\"4\" w:color=\"000000\"/><w:insideV w:val=\"single\" w:sz=\"4\" w:color=\"000000\"/></w:tblBorders>";
+    let direction = if vertical { "<w:bidiVisual/>" } else { "" };
+    let cell_direction = if vertical {
+        "<w:textDirection w:val=\"tbRl\"/>"
+    } else {
+        ""
+    };
     let grid = (0..columns)
         .map(|_| format!("<w:gridCol w:w=\"{column_width}\"/>"))
         .collect::<String>();
@@ -577,14 +585,14 @@ fn table_xml(node: &Value, profile: &ResolvedExportProfile, context: &mut Contex
                         },
                         (profile.typesetting.font_size * 2.0).round() as i64,
                     );
-                    format!("<w:tc><w:tcPr><w:tcW w:w=\"{column_width}\" w:type=\"dxa\"/></w:tcPr><w:p>{content}</w:p></w:tc>")
+                    format!("<w:tc><w:tcPr><w:tcW w:w=\"{column_width}\" w:type=\"dxa\"/>{cell_direction}</w:tcPr><w:p>{content}</w:p></w:tc>")
                 })
                 .collect::<String>();
             format!("<w:tr>{cells}</w:tr>")
         })
         .collect::<String>();
     format!(
-        "<w:tbl><w:tblPr><w:tblW w:w=\"{usable}\" w:type=\"dxa\"/><w:tblLayout w:type=\"fixed\"/></w:tblPr><w:tblGrid>{grid}</w:tblGrid>{rows_xml}</w:tbl>"
+        "<w:tbl><w:tblPr>{direction}<w:tblW w:w=\"{usable}\" w:type=\"dxa\"/>{borders}<w:tblLayout w:type=\"fixed\"/></w:tblPr><w:tblGrid>{grid}</w:tblGrid>{rows_xml}</w:tbl>"
     )
 }
 

--- a/mdi-core/src/lib.rs
+++ b/mdi-core/src/lib.rs
@@ -1147,6 +1147,15 @@ pub fn render_html_document(document: &Document) -> String {
     } else {
         ""
     };
+    // Browsers keep wheel input on the physical vertical axis, while a
+    // vertical-rl document overflows horizontally. Translate ordinary wheel
+    // movement into the reading axis so a standalone exported document is
+    // comfortable to read without a horizontal scrollbar drag.
+    let wheel_scroll = if vertical {
+        VERTICAL_WHEEL_SCROLL_SCRIPT
+    } else {
+        ""
+    };
     let mut body = String::new();
     let mut footnotes = Vec::new();
     for child in &document.children {
@@ -1176,7 +1185,7 @@ pub fn render_html_document(document: &Document) -> String {
         body.push_str("</ol></section>");
     }
     format!(
-        "<!DOCTYPE html><html lang=\"{}\"{}><head><meta charset=\"utf-8\">{}<style>{}</style></head><body>{}</body></html>",
+        "<!DOCTYPE html><html lang=\"{}\"{}><head><meta charset=\"utf-8\">{}<style>{}</style>{wheel_scroll}</head><body>{}</body></html>",
         escape_html(lang),
         writing_mode,
         title,
@@ -2538,6 +2547,8 @@ fn css_value(value: &str) -> String {
 /// The base stylesheet is intentionally shipped by the core alongside the
 /// semantic HTML. Hosts may add presentation CSS, but not reinterpret nodes.
 pub const MDI_STYLESHEET: &str = ".mdi-tcy{text-combine-upright:all}.mdi-nobr{white-space:nowrap}.mdi-warichu{font-size:.6em}.mdi-em{text-emphasis:var(--mdi-em,filled sesame)}.mdi-kern{letter-spacing:var(--mdi-kern)}.mdi-blank{min-block-size:1lh}.mdi-indent{margin-inline-start:calc(var(--mdi-indent)*1em)}.mdi-bottom{text-align:end}.mdi-pagebreak{break-after:page}";
+
+const VERTICAL_WHEEL_SCROLL_SCRIPT: &str = "<script>(function(){document.addEventListener('wheel',function(event){if(event.defaultPrevented||event.ctrlKey||event.shiftKey)return;var delta=event.deltaY;if(event.deltaMode===1)delta*=16;else if(event.deltaMode===2)delta*=window.innerWidth;if(!delta)return;var root=document.scrollingElement;var before=root.scrollLeft;window.scrollBy({left:-delta,behavior:'auto'});if(root.scrollLeft!==before)event.preventDefault()},{passive:false})})()</script>";
 
 #[derive(Debug, Clone)]
 pub struct EpubCover {
@@ -4492,6 +4503,11 @@ mod tests {
         assert!(html.contains("<h1>題</h1>"));
         assert!(html.contains("<ruby class=\"mdi-ruby\">東京<rp>（</rp><rt>とうきょう</rt>"));
         assert!(html.contains("<span class=\"mdi-tcy\">12</span>"));
+        assert!(html.contains("document.addEventListener('wheel'"));
+        assert!(html.contains("window.scrollBy({left:-delta,behavior:'auto'})"));
+
+        let horizontal = render_html("本文");
+        assert!(!horizontal.contains("document.addEventListener('wheel'"));
     }
 
     #[test]

--- a/mdi-core/src/lib.rs
+++ b/mdi-core/src/lib.rs
@@ -4939,6 +4939,50 @@ mod tests {
     }
 
     #[test]
+    fn configured_docx_applies_table_direction_rules() {
+        let vertical_table = render_docx_with_profile(
+            "| 項目 | 値 |\n| --- | --- |\n| セル | 縦書き |",
+            r#"{
+                "layout":{"system":"japanese-publisher"},
+                "typesetting":{"writingMode":"vertical","fontSize":10.5},
+                "pagination":{"pageSize":"A5","charactersPerLine":10,"linesPerPage":10,"gridMode":"typographic"}
+            }"#,
+        )
+        .unwrap();
+        let mut zip = ZipArchive::new(Cursor::new(vertical_table)).unwrap();
+        let mut document = String::new();
+        zip.by_name("word/document.xml")
+            .unwrap()
+            .read_to_string(&mut document)
+            .unwrap();
+        assert!(document.contains("<w:tblPr><w:bidiVisual/>"));
+        assert!(document.contains("<w:textDirection w:val=\"tbRl\"/>"));
+        assert!(document.contains("<w:tblBorders>"));
+        assert!(document.contains("<w:top w:val=\"single\""));
+        assert!(document.contains("<w:insideV w:val=\"single\""));
+
+        let horizontal_table = render_docx_with_profile(
+            "| Item | Value |\n| --- | --- |\n| Cell | Horizontal |",
+            r#"{
+                "layout":{"system":"word"},
+                "typesetting":{"writingMode":"horizontal","fontSize":11},
+                "pagination":{"pageSize":"A4","charactersPerLine":20,"linesPerPage":20,"gridMode":"typographic"}
+            }"#,
+        )
+        .unwrap();
+        let mut zip = ZipArchive::new(Cursor::new(horizontal_table)).unwrap();
+        let mut document = String::new();
+        zip.by_name("word/document.xml")
+            .unwrap()
+            .read_to_string(&mut document)
+            .unwrap();
+        assert!(!document.contains("<w:bidiVisual/>"));
+        assert!(!document.contains("<w:textDirection w:val=\"tbRl\"/>"));
+        assert!(document.contains("<w:tblBorders>"));
+        assert!(document.contains("<w:top w:val=\"single\""));
+    }
+
+    #[test]
     fn configured_docx_rejects_word_limits_and_uses_typographic_spacing() {
         let oversized = render_docx_with_profile(
             "text",

--- a/nodejs/packages/to-docx/src/index.test.ts
+++ b/nodejs/packages/to-docx/src/index.test.ts
@@ -220,6 +220,22 @@ describe("mdiToDocx edge cases", () => {
     expect(document).toContain('w:type="dxa"');
   });
 
+  it("renders bordered right-to-left tables with vertical cell text", async () => {
+    const zip = await JSZip.loadAsync(
+      await mdiToDocx(
+        parse(
+          "---\nwriting-mode: vertical\n---\n\n| 見出し 1 | 見出し 2 |\n| --- | --- |\n| セル | 東京 |"
+        )
+      )
+    );
+    const document = await zip.file("word/document.xml")!.async("string");
+    expect(document).toContain("<w:bidiVisual/>");
+    expect(document).toContain('<w:textDirection w:val="tbRl"/>');
+    expect(document).toContain("<w:tblBorders>");
+    expect(document).toContain('<w:top w:val="single" w:sz="4" w:color="000000"/>');
+    expect(document).toContain('<w:insideV w:val="single" w:sz="4" w:color="000000"/>');
+  });
+
   it("preserves inline code, image alt text, links, and footnote references", async () => {
     const zip = await JSZip.loadAsync(
       await mdiToDocx(

--- a/nodejs/packages/to-html/src/index.test.ts
+++ b/nodejs/packages/to-html/src/index.test.ts
@@ -14,6 +14,8 @@ describe("mdiToHtml", () => it("wraps rendered MDI in a vertical HTML document",
 	expect(html).toContain('<html lang="ja" style="writing-mode: vertical-rl;">');
 	expect(html).toContain("<title>雪女</title>");
 	expect(html).toContain("<style>");
+	expect(html).toContain("document.addEventListener('wheel'");
+	expect(html).toContain("window.scrollBy({left:-delta,behavior:'auto'})");
 	expect(html).toContain('<ruby class="mdi-ruby">東京<rp>（</rp><rt>とうきょう</rt>');
 }));
 
@@ -38,6 +40,7 @@ describe("mdiToHtml edge cases", () => {
 		expect(html).toContain('<html lang="en">');
 		expect(html).toContain("<title>Horizontal</title>");
 		expect(html).not.toContain("writing-mode:");
+		expect(html).not.toContain("document.addEventListener('wheel'");
 	});
 
 	it("defaults the language when only other front matter fields are present", () => {


### PR DESCRIPTION
## What changed

- Add explicit DOCX table borders and vertical right-to-left cell direction for vertical documents.
- Map ordinary mouse-wheel input to the horizontal reading axis in standalone vertical HTML exports.

## Why

Vertical DOCX tables previously lacked visible ruling and retained horizontal cell text. Vertical HTML overflows on the horizontal reading axis, while ordinary mouse wheels emit vertical deltas.

## Impact

Readers can navigate vertical HTML with a normal mouse wheel, and exported vertical DOCX tables retain readable vertical cells, right-to-left column order, and visible grid lines.

## Validation

- `cargo test --manifest-path mdi-core/Cargo.toml`
- `pnpm --filter @illusions-lab/mdi-to-docx test`
- `pnpm --filter @illusions-lab/mdi-to-docx typecheck`
- `pnpm --filter @illusions-lab/mdi-to-html test`
- `pnpm --filter @illusions-lab/mdi-to-html typecheck`