### PR TITLE
Add browser WASM runtime facade

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,10 @@ jobs:
       - run: pnpm build
       - name: Enable Safari remote automation
         run: safaridriver --enable || sudo safaridriver --enable
+      - name: Launch Safari.app for WebDriver
+        run: |
+          open -a Safari
+          sleep 5
       - run: pnpm test:safari
 
   swift:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,10 +29,11 @@ jobs:
           cache-dependency-path: pnpm-lock.yaml
 
       - run: pnpm install --frozen-lockfile
-      # to-pdf's tests print through a real headless Chromium.
-      - run: pnpm --filter @illusions-lab/mdi-to-pdf exec playwright install --with-deps chromium
+      # Browser WASM contracts run in all Playwright engines; to-pdf also uses Chromium.
+      - run: pnpm exec playwright install --with-deps chromium firefox webkit
       - run: pnpm typecheck
       - run: pnpm build
+      - run: pnpm test:browser
       - run: node --test nodejs/scripts/pack-publishable-package.test.mjs
       - run: pnpm test:coverage
 
@@ -101,6 +102,29 @@ jobs:
           flags: rust
           name: rust
           fail_ci_if_error: true
+
+  safari-browser:
+    name: Safari.app packed browser smoke
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - uses: jetli/wasm-pack-action@v0.4.0
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.15.0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build
+      - name: Enable Safari remote automation
+        run: safaridriver --enable || sudo safaridriver --enable
+      - run: pnpm test:safari
 
   swift:
     name: Swift
@@ -192,7 +216,7 @@ jobs:
 
   publication-contracts:
     name: Publication contracts
-    needs: [nodejs, rust-native, swift, python, android]
+    needs: [nodejs, rust-native, safari-browser, swift, python, android]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/nodejs/browser-test/index.html
+++ b/nodejs/browser-test/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>MDI browser WASM contract</title>
+  </head>
+  <body>
+    <output id="result">pending</output>
+    <script type="module" src="/src.ts"></script>
+  </body>
+</html>

--- a/nodejs/browser-test/package.json
+++ b/nodejs/browser-test/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@illusions-lab/mdi-browser-test",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@illusions-lab/mdi": "workspace:*",
+    "@illusions-lab/mdi-remark": "workspace:*",
+    "remark-parse": "^11.0.0",
+    "remark-stringify": "^11.0.0",
+    "unified": "^11.0.0"
+  }
+}

--- a/nodejs/browser-test/src.ts
+++ b/nodejs/browser-test/src.ts
@@ -1,0 +1,60 @@
+import { initializeMdi, parse, serializeMdi } from "@illusions-lab/mdi";
+import remarkMdi from "@illusions-lab/mdi-remark";
+import remarkParse from "remark-parse";
+import remarkStringify from "remark-stringify";
+import { unified } from "unified";
+
+const source = `---
+title: ブラウザ 😀
+---
+# Browser
+
+{東京|とうきょう} ^12^ と émoji 😀。
+
+| column | value |
+| --- | --- |
+| nested | [[em:MDI]] |
+`;
+const largeSource = `${source}\n\n${"段落 {東京|とうきょう} 😀\n\n".repeat(256)}`;
+
+void run().catch((error: unknown) => {
+  document.querySelector("#result")!.textContent = JSON.stringify({
+    error: error instanceof Error ? `${error.message}\n${error.stack ?? ""}` : String(error),
+  });
+});
+
+async function run(): Promise<void> {
+  const retry = new URL(location.href).searchParams.has("retry");
+  if (retry) {
+    // The test server deliberately fails the first WASM request. The facade
+    // must clear its rejected promise so a later concurrent retry can succeed.
+    try {
+      await Promise.all([initializeMdi(), initializeMdi()]);
+    } catch {
+      await Promise.all([initializeMdi(), initializeMdi()]);
+    }
+  } else {
+    await Promise.all([initializeMdi(), initializeMdi()]);
+  }
+
+  const parsed = parse(source);
+  const canonical = serializeMdi(source);
+  const large = parse(largeSource);
+  const unsupportedVersion = parse("---\nmdi: '3.0'\n---\n\nmalformed-version corpus");
+  const processor = unified().use(remarkParse).use(remarkMdi).use(remarkStringify);
+  const tree = processor.parse(source);
+  const transformed = await processor.run(tree);
+  const remarkOutput = processor.stringify(transformed);
+
+  document.querySelector("#result")!.textContent = JSON.stringify({
+    irVersion: parsed.irVersion,
+    firstNode: parsed.document.children[0]?.type,
+    canonical,
+    remarkOutput,
+    hasFrontmatter: Boolean(parsed.document.frontmatter),
+    tableType: parsed.document.children.find((node) => node.type === "table")?.type,
+    utf8Span: parsed.document.children[1]?.span,
+    largeNodeCount: large.document.children.length,
+    diagnostic: unsupportedVersion.diagnostics[0],
+  });
+}

--- a/nodejs/packages/export-profile/src/index.ts
+++ b/nodejs/packages/export-profile/src/index.ts
@@ -1,7 +1,4 @@
-import {
-  pageSizeCatalogJson,
-  resolveExportProfileJson as resolveProfileInRust,
-} from "@illusions-lab/mdi-core";
+import { resolveExportProfileJson as resolveProfileInRust } from "@illusions-lab/mdi-core";
 
 export type WritingMode = "vertical" | "horizontal";
 export type PageNumberFormat = "simple" | "dash" | "fraction";
@@ -118,19 +115,22 @@ interface RustPageSizeDimensions {
   heightMm: number;
 }
 
-const pageSizeCatalog = JSON.parse(
-  pageSizeCatalogJson(),
-) as RustPageSizeDimensions[];
+/**
+ * A generated snapshot of config/publication-layouts.yaml.  It intentionally
+ * avoids a WASM call during module evaluation, so importing this package is
+ * safe before a browser application awaits initializeMdiCore().  The
+ * publication contract test compares it with the Rust catalogue.
+ */
+export const PAGE_DIMENSIONS = {
+  A0:{width:841,height:1189},A1:{width:594,height:841},A2:{width:420,height:594},A3:{width:297,height:420},A4:{width:210,height:297},A5:{width:148,height:210},A6:{width:105,height:148},A7:{width:74,height:105},A8:{width:52,height:74},A9:{width:37,height:52},A10:{width:26,height:37},
+  "JIS-B0":{width:1030,height:1456},"JIS-B1":{width:728,height:1030},"JIS-B2":{width:515,height:728},"JIS-B3":{width:364,height:515},"JIS-B4":{width:257,height:364},"JIS-B5":{width:182,height:257},"JIS-B6":{width:128,height:182},"JIS-B7":{width:91,height:128},"JIS-B8":{width:64,height:91},"JIS-B9":{width:45,height:64},"JIS-B10":{width:32,height:45},
+  "ISO-B0":{width:1000,height:1414},"ISO-B1":{width:707,height:1000},"ISO-B2":{width:500,height:707},"ISO-B3":{width:353,height:500},"ISO-B4":{width:250,height:353},"ISO-B5":{width:176,height:250},"ISO-B6":{width:125,height:176},"ISO-B7":{width:88,height:125},"ISO-B8":{width:62,height:88},"ISO-B9":{width:44,height:62},"ISO-B10":{width:31,height:44},
+  Bunko:{width:105,height:148},Shinsho:{width:103,height:182},Shirokuban:{width:127,height:188},Kikuban:{width:150,height:220},"A5-ban":{width:148,height:210},"B6-ban":{width:128,height:182},"AB-ban":{width:210,height:257},"Ju-ban":{width:182,height:206},"Kiku-tate":{width:152,height:218},Tankobon:{width:130,height:188},
+  Letter:{width:216,height:279},Legal:{width:216,height:356},Tabloid:{width:279,height:432},Executive:{width:184,height:267},Statement:{width:140,height:216},Folio:{width:210,height:330},Quarto:{width:203,height:254},"10x14":{width:254,height:356},
+  "Naga-3":{width:120,height:235},"Naga-4":{width:90,height:205},"Kaku-2":{width:240,height:332},"Kaku-3":{width:216,height:277},"Kaku-6":{width:162,height:229},"Kaku-8":{width:119,height:197},"You-4":{width:105,height:235},"You-6":{width:98,height:190},Hagaki:{width:100,height:148},"Ofuku-Hagaki":{width:200,height:148},"L-ban":{width:89,height:127},"2L-ban":{width:127,height:178},KG:{width:102,height:152},Cabinet:{width:130,height:180},B5:{width:176,height:250},B6:{width:125,height:176},
+} as const satisfies Record<PageSize, { width: number; height: number }>;
 
-/** Canonical physical dimensions supplied by the Rust core. */
-export const PAGE_DIMENSIONS = Object.fromEntries(
-  pageSizeCatalog.map(({ key, widthMm, heightMm }) => [
-    key,
-    { width: widthMm, height: heightMm },
-  ]),
-) as Record<PageSize, { width: number; height: number }>;
-
-export const PAGE_SIZES = pageSizeCatalog.map(({ key }) => key);
+export const PAGE_SIZES = Object.keys(PAGE_DIMENSIONS) as PageSize[];
 
 export const PAGE_SIZE_LABELS = {
   ja: {

--- a/nodejs/packages/mdi-core/README.md
+++ b/nodejs/packages/mdi-core/README.md
@@ -26,6 +26,13 @@ generated WASM interface, such as a custom language binding or an integration
 that transports the Rust JSON IR directly. It is not a second JavaScript
 parser and does not contain a JavaScript grammar.
 
+Browser bundlers select the web-compatible runtime facade automatically through
+the package's `browser` export condition. The generated `.wasm` asset remains
+private implementation detail and is published alongside that facade. Low-level
+browser users must await `initializeMdiCore()` once; it is idempotent and Node
+resolves it immediately because Node initializes eagerly. Most applications
+should use `initializeMdi()` from `@illusions-lab/mdi` instead.
+
 ## Ownership boundary
 
 ```text

--- a/nodejs/packages/mdi-core/package.json
+++ b/nodejs/packages/mdi-core/package.json
@@ -10,14 +10,14 @@
   },
   "homepage": "https://mdi.illusions.app/bindings/javascript/",
   "bugs": "https://github.com/illusions-lab/MDI/issues",
-  "main": "./dist/node/index.js",
+  "main": "./dist/node/index.cjs",
   "types": "./dist/node/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/node/index.d.ts",
       "browser": "./dist/web/index.js",
-      "node": "./dist/node/index.js",
-      "default": "./dist/node/index.js"
+      "node": "./dist/node/index.cjs",
+      "default": "./dist/node/index.cjs"
     },
     "./browser": {
       "types": "./dist/web/index.d.ts",

--- a/nodejs/packages/mdi-core/package.json
+++ b/nodejs/packages/mdi-core/package.json
@@ -10,13 +10,25 @@
   },
   "homepage": "https://mdi.illusions.app/bindings/javascript/",
   "bugs": "https://github.com/illusions-lab/MDI/issues",
-  "main": "./dist/mdi_core.js",
-  "types": "./dist/mdi_core.d.ts",
+  "main": "./dist/node/index.js",
+  "types": "./dist/node/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/node/index.d.ts",
+      "browser": "./dist/web/index.js",
+      "node": "./dist/node/index.js",
+      "default": "./dist/node/index.js"
+    },
+    "./browser": {
+      "types": "./dist/web/index.d.ts",
+      "default": "./dist/web/index.js"
+    }
+  },
   "files": [
     "dist"
   ],
   "scripts": {
-    "build": "cd ../../../mdi-core && PATH=\"/opt/homebrew/opt/rustup/bin:$PATH\" wasm-pack build --release --target nodejs --out-dir ../nodejs/packages/mdi-core/dist -- --features wasm && node -e \"require('node:fs').rmSync('../nodejs/packages/mdi-core/dist/.gitignore', { force: true })\"",
+    "build": "node -e \"require('node:fs').rmSync('dist', { recursive: true, force: true })\" && cd ../../../mdi-core && PATH=\"/opt/homebrew/opt/rustup/bin:$PATH\" wasm-pack build --release --target nodejs --out-dir ../nodejs/packages/mdi-core/dist/node -- --features wasm && PATH=\"/opt/homebrew/opt/rustup/bin:$PATH\" wasm-pack build --release --target web --out-dir ../nodejs/packages/mdi-core/dist/web -- --features wasm && node -e \"const fs=require('node:fs'); for (const dir of ['node','web']) fs.rmSync('../nodejs/packages/mdi-core/dist/'+dir+'/.gitignore', { force: true })\" && node ../nodejs/packages/mdi-core/scripts/build-facade.mjs",
     "test": "vitest run --passWithNoTests"
   }
 }

--- a/nodejs/packages/mdi-core/scripts/build-facade.mjs
+++ b/nodejs/packages/mdi-core/scripts/build-facade.mjs
@@ -1,0 +1,17 @@
+import { cp, mkdir, rename } from "node:fs/promises";
+import { resolve } from "node:path";
+
+const packageRoot = resolve(import.meta.dirname, "..");
+const dist = resolve(packageRoot, "dist");
+const generated = resolve(dist, "generated");
+
+await mkdir(generated, { recursive: true });
+for (const target of ["node", "web"]) {
+  await rename(resolve(dist, target), resolve(generated, target));
+  await mkdir(resolve(dist, target), { recursive: true });
+}
+await cp(resolve(packageRoot, "src/node.js"), resolve(dist, "node/index.js"));
+await cp(resolve(packageRoot, "src/browser.js"), resolve(dist, "web/index.js"));
+await cp(resolve(packageRoot, "src/runtime.js"), resolve(dist, "web/runtime.js"));
+await cp(resolve(packageRoot, "src/node.d.ts"), resolve(dist, "node/index.d.ts"));
+await cp(resolve(packageRoot, "src/browser.d.ts"), resolve(dist, "web/index.d.ts"));

--- a/nodejs/packages/mdi-core/scripts/build-facade.mjs
+++ b/nodejs/packages/mdi-core/scripts/build-facade.mjs
@@ -10,7 +10,7 @@ for (const target of ["node", "web"]) {
   await rename(resolve(dist, target), resolve(generated, target));
   await mkdir(resolve(dist, target), { recursive: true });
 }
-await cp(resolve(packageRoot, "src/node.js"), resolve(dist, "node/index.js"));
+await cp(resolve(packageRoot, "src/node.cjs"), resolve(dist, "node/index.cjs"));
 await cp(resolve(packageRoot, "src/browser.js"), resolve(dist, "web/index.js"));
 await cp(resolve(packageRoot, "src/runtime.js"), resolve(dist, "web/runtime.js"));
 await cp(resolve(packageRoot, "src/node.d.ts"), resolve(dist, "node/index.d.ts"));

--- a/nodejs/packages/mdi-core/src/browser.d.ts
+++ b/nodejs/packages/mdi-core/src/browser.d.ts
@@ -1,0 +1,10 @@
+export {
+  applyPdfProfileJson, blockMacroAmount, blockMacroKind, blockMacroVariant,
+  pageSizeCatalogJson, parseMdiSyntaxJson, prepareChromiumPrintProfileJson,
+  renderDocx, renderDocxWithProfile, renderEpub, renderEpubWithProfile,
+  renderHtml, renderText, renderTextFormat, resolveExportProfileJson,
+  resolveRuby, serializeMdi, unescapeMdi, unescapeRubyText,
+} from "../generated/web/mdi_core.js";
+export type { InitInput, InitOutput, SyncInitInput } from "../generated/web/mdi_core.js";
+export declare class MdiCoreNotInitializedError extends Error {}
+export declare function initializeMdiCore(): Promise<void>;

--- a/nodejs/packages/mdi-core/src/browser.js
+++ b/nodejs/packages/mdi-core/src/browser.js
@@ -1,0 +1,36 @@
+// The wasm-pack output is deliberately private.  This module is the stable
+// browser boundary: it owns initialization and makes the precondition for all
+// synchronous Rust calls explicit.
+import * as bindings from "../generated/web/mdi_core.js";
+import { createMdiCoreRuntime, MdiCoreNotInitializedError } from "./runtime.js";
+
+export { MdiCoreNotInitializedError };
+const runtime = createMdiCoreRuntime(() => bindings.default());
+
+export function initializeMdiCore() {
+  return runtime.initialize();
+}
+
+function requireInitialized() {
+  runtime.requireInitialized();
+}
+
+export const applyPdfProfileJson = (...args) => (requireInitialized(), bindings.applyPdfProfileJson(...args));
+export const blockMacroAmount = (...args) => (requireInitialized(), bindings.blockMacroAmount(...args));
+export const blockMacroKind = (...args) => (requireInitialized(), bindings.blockMacroKind(...args));
+export const blockMacroVariant = (...args) => (requireInitialized(), bindings.blockMacroVariant(...args));
+export const pageSizeCatalogJson = (...args) => (requireInitialized(), bindings.pageSizeCatalogJson(...args));
+export const parseMdiSyntaxJson = (...args) => (requireInitialized(), bindings.parseMdiSyntaxJson(...args));
+export const prepareChromiumPrintProfileJson = (...args) => (requireInitialized(), bindings.prepareChromiumPrintProfileJson(...args));
+export const renderDocx = (...args) => (requireInitialized(), bindings.renderDocx(...args));
+export const renderDocxWithProfile = (...args) => (requireInitialized(), bindings.renderDocxWithProfile(...args));
+export const renderEpub = (...args) => (requireInitialized(), bindings.renderEpub(...args));
+export const renderEpubWithProfile = (...args) => (requireInitialized(), bindings.renderEpubWithProfile(...args));
+export const renderHtml = (...args) => (requireInitialized(), bindings.renderHtml(...args));
+export const renderText = (...args) => (requireInitialized(), bindings.renderText(...args));
+export const renderTextFormat = (...args) => (requireInitialized(), bindings.renderTextFormat(...args));
+export const resolveExportProfileJson = (...args) => (requireInitialized(), bindings.resolveExportProfileJson(...args));
+export const resolveRuby = (...args) => (requireInitialized(), bindings.resolveRuby(...args));
+export const serializeMdi = (...args) => (requireInitialized(), bindings.serializeMdi(...args));
+export const unescapeMdi = (...args) => (requireInitialized(), bindings.unescapeMdi(...args));
+export const unescapeRubyText = (...args) => (requireInitialized(), bindings.unescapeRubyText(...args));

--- a/nodejs/packages/mdi-core/src/node.cjs
+++ b/nodejs/packages/mdi-core/src/node.cjs
@@ -1,0 +1,29 @@
+// Node wasm-pack bindings instantiate synchronously at module evaluation.
+// This explicit CommonJS facade avoids Node's ambiguous-module warning while
+// preserving the generated Node loader's require/fs behavior.
+const bindings = require("../generated/node/mdi_core.js");
+
+class MdiCoreNotInitializedError extends Error {}
+const initialization = Promise.resolve();
+
+exports.MdiCoreNotInitializedError = MdiCoreNotInitializedError;
+exports.initializeMdiCore = () => initialization;
+exports.applyPdfProfileJson = bindings.applyPdfProfileJson;
+exports.blockMacroAmount = bindings.blockMacroAmount;
+exports.blockMacroKind = bindings.blockMacroKind;
+exports.blockMacroVariant = bindings.blockMacroVariant;
+exports.pageSizeCatalogJson = bindings.pageSizeCatalogJson;
+exports.parseMdiSyntaxJson = bindings.parseMdiSyntaxJson;
+exports.prepareChromiumPrintProfileJson = bindings.prepareChromiumPrintProfileJson;
+exports.renderDocx = bindings.renderDocx;
+exports.renderDocxWithProfile = bindings.renderDocxWithProfile;
+exports.renderEpub = bindings.renderEpub;
+exports.renderEpubWithProfile = bindings.renderEpubWithProfile;
+exports.renderHtml = bindings.renderHtml;
+exports.renderText = bindings.renderText;
+exports.renderTextFormat = bindings.renderTextFormat;
+exports.resolveExportProfileJson = bindings.resolveExportProfileJson;
+exports.resolveRuby = bindings.resolveRuby;
+exports.serializeMdi = bindings.serializeMdi;
+exports.unescapeMdi = bindings.unescapeMdi;
+exports.unescapeRubyText = bindings.unescapeRubyText;

--- a/nodejs/packages/mdi-core/src/node.d.ts
+++ b/nodejs/packages/mdi-core/src/node.d.ts
@@ -1,0 +1,3 @@
+export * from "../generated/node/mdi_core.js";
+export declare class MdiCoreNotInitializedError extends Error {}
+export declare function initializeMdiCore(): Promise<void>;

--- a/nodejs/packages/mdi-core/src/node.js
+++ b/nodejs/packages/mdi-core/src/node.js
@@ -1,8 +1,0 @@
-// Node wasm-pack bindings instantiate synchronously at module evaluation.
-// Keep the portable facade API while preserving Node's eager behavior.
-export * from "../generated/node/mdi_core.js";
-export class MdiCoreNotInitializedError extends Error {}
-const initialization = Promise.resolve();
-export function initializeMdiCore() {
-  return initialization;
-}

--- a/nodejs/packages/mdi-core/src/node.js
+++ b/nodejs/packages/mdi-core/src/node.js
@@ -1,0 +1,8 @@
+// Node wasm-pack bindings instantiate synchronously at module evaluation.
+// Keep the portable facade API while preserving Node's eager behavior.
+export * from "../generated/node/mdi_core.js";
+export class MdiCoreNotInitializedError extends Error {}
+const initialization = Promise.resolve();
+export function initializeMdiCore() {
+  return initialization;
+}

--- a/nodejs/packages/mdi-core/src/runtime.js
+++ b/nodejs/packages/mdi-core/src/runtime.js
@@ -1,0 +1,28 @@
+/** Create the small state machine shared by the browser facade and its tests. */
+export function createMdiCoreRuntime(initializeBinding) {
+  let initialization;
+  let initialized = false;
+
+  return {
+    initialize() {
+      if (initialization) return initialization;
+      initialization = Promise.resolve().then(initializeBinding).then(() => {
+        initialized = true;
+      }).catch((error) => {
+        initialization = undefined;
+        throw error;
+      });
+      return initialization;
+    },
+    requireInitialized() {
+      if (!initialized) throw new MdiCoreNotInitializedError();
+    },
+  };
+}
+
+export class MdiCoreNotInitializedError extends Error {
+  constructor() {
+    super("MDI core has not been initialized; await initializeMdiCore() before calling synchronous APIs");
+    this.name = "MdiCoreNotInitializedError";
+  }
+}

--- a/nodejs/packages/mdi-core/src/runtime.test.js
+++ b/nodejs/packages/mdi-core/src/runtime.test.js
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { createMdiCoreRuntime, MdiCoreNotInitializedError } from "./runtime.js";
+
+describe("browser MDI core runtime", () => {
+  it("rejects synchronous calls before initialization", () => {
+    expect(() => createMdiCoreRuntime(() => {}).requireInitialized()).toThrow(MdiCoreNotInitializedError);
+  });
+
+  it("shares one promise while initializing and after completion", async () => {
+    let calls = 0;
+    let release;
+    const runtime = createMdiCoreRuntime(() => {
+      calls += 1;
+      return new Promise((resolve) => { release = resolve; });
+    });
+    const first = runtime.initialize();
+    const second = runtime.initialize();
+    expect(second).toBe(first);
+    await Promise.resolve();
+    expect(calls).toBe(1);
+    release();
+    await first;
+    expect(runtime.initialize()).toBe(first);
+    expect(() => runtime.requireInitialized()).not.toThrow();
+  });
+
+  it("clears failed initialization and permits a successful retry", async () => {
+    let calls = 0;
+    const runtime = createMdiCoreRuntime(() => {
+      calls += 1;
+      if (calls === 1) throw new Error("network failure");
+    });
+    await expect(runtime.initialize()).rejects.toThrow("network failure");
+    expect(() => runtime.requireInitialized()).toThrow(MdiCoreNotInitializedError);
+    await expect(runtime.initialize()).resolves.toBeUndefined();
+    expect(calls).toBe(2);
+    expect(() => runtime.requireInitialized()).not.toThrow();
+  });
+});

--- a/nodejs/packages/mdi/README.md
+++ b/nodejs/packages/mdi/README.md
@@ -25,6 +25,25 @@ console.log(result.document);
 console.log(result.diagnostics);
 ```
 
+### Browser initialization
+
+Browser applications must initialize the Rust WebAssembly module once before
+using the otherwise synchronous APIs. Repeated calls return the same pending
+initialization and are safe during hot reload or shared application startup:
+
+```ts
+import { initializeMdi, parse, serializeMdi } from "@illusions-lab/mdi";
+
+await initializeMdi();
+const parsed = parse("{東京|とうきょう} ^12^");
+const canonical = serializeMdi("{東京|とうきょう} ^12^");
+```
+
+Vite and other browser-condition-aware bundlers select the web loader and emit
+its WASM asset automatically. Node.js keeps its existing eager, synchronous
+WASM loading behavior; `initializeMdi()` resolves immediately there, so shared
+startup code can call it in both environments.
+
 ## What the binding does
 
 The package has deliberately narrow responsibilities:

--- a/nodejs/packages/mdi/src/index.test.ts
+++ b/nodejs/packages/mdi/src/index.test.ts
@@ -1,6 +1,6 @@
 import JSZip from "jszip";
 import { describe, expect, it } from "vitest";
-import { MDI_IR_VERSION, MDI_SPEC_VERSION, parse, prepareRender, renderDocx, renderDocxWithDiagnostics, renderDocxWithProfile, renderEpub, renderEpubWithDiagnostics, renderEpubWithProfile, renderHtml, renderHtmlWithDiagnostics, renderText, renderTextFormat, renderTextFormatWithDiagnostics, renderTextWithDiagnostics, serializeMdi, toPublicationMdast } from "./index.js";
+import { MDI_IR_VERSION, MDI_SPEC_VERSION, initializeMdi, parse, prepareRender, renderDocx, renderDocxWithDiagnostics, renderDocxWithProfile, renderEpub, renderEpubWithDiagnostics, renderEpubWithProfile, renderHtml, renderHtmlWithDiagnostics, renderText, renderTextFormat, renderTextFormatWithDiagnostics, renderTextWithDiagnostics, serializeMdi, toPublicationMdast } from "./index.js";
 
 function assertValidSpans(node: { span?: { startByte: number; endByte: number }; children?: unknown[] }, source: string): void {
 	if (node.span) {
@@ -14,6 +14,11 @@ function assertValidSpans(node: { span?: { startByte: number; endByte: number };
 }
 
 describe("Rust MDI JavaScript binding", () => {
+	it("keeps portable initialization harmless in Node.js", async () => {
+		await initializeMdi();
+		expect(parse("Node remains synchronous").irVersion).toBe(MDI_IR_VERSION);
+	});
+
 	it("returns the complete Rust-owned document contract", () => {
 		const result = parse("第^12^話");
 

--- a/nodejs/packages/mdi/src/index.ts
+++ b/nodejs/packages/mdi/src/index.ts
@@ -1,22 +1,39 @@
-import {
-	parseMdiSyntaxJson,
-	renderHtml as renderHtmlFromRust,
-	renderEpub as renderEpubFromRust,
-	renderEpubWithProfile as renderEpubWithProfileFromRust,
-	renderDocx as renderDocxFromRust,
-	renderDocxWithProfile as renderDocxWithProfileFromRust,
-	renderText as renderTextFromRust,
-	renderTextFormat as renderTextFormatFromRust,
-	serializeMdi as serializeMdiFromRust,
-} from "@illusions-lab/mdi-core";
+import * as mdiCore from "@illusions-lab/mdi-core";
 import type { EpubCover, EpubExportOptions } from "@illusions-lab/mdi-to-epub";
-import {
-	requireLayoutSystem,
-	type ExportProfile,
-	type WritingMode,
-} from "@illusions-lab/mdi-export-profile";
+import type { ExportProfile, WritingMode } from "@illusions-lab/mdi-export-profile";
 import type { Root } from "mdast";
 import { parse as parseYaml } from "yaml";
+
+const {
+	parseMdiSyntaxJson,
+	renderHtml: renderHtmlFromRust,
+	renderEpub: renderEpubFromRust,
+	renderEpubWithProfile: renderEpubWithProfileFromRust,
+	renderDocx: renderDocxFromRust,
+	renderDocxWithProfile: renderDocxWithProfileFromRust,
+	renderText: renderTextFromRust,
+	renderTextFormat: renderTextFormatFromRust,
+	resolveExportProfileJson: resolveExportProfileJsonFromRust,
+	serializeMdi: serializeMdiFromRust,
+} = mdiCore;
+
+/**
+ * Initialize the shared MDI core runtime exactly once.
+ *
+ * Browser applications must await this before calling the synchronous parse
+ * or serialization APIs. In Node.js the WASM binding is loaded eagerly, so
+ * this remains a harmless resolved promise for portable application setup.
+ */
+export function initializeMdi(): Promise<void> {
+	return mdiCore.initializeMdiCore();
+}
+
+function requireLayoutSystem(profile: ExportProfile): void {
+	if (!profile || typeof profile !== "object" || Array.isArray(profile)) {
+		throw new Error("Export profile must be an object");
+	}
+	resolveExportProfileJsonFromRust(JSON.stringify(profile), undefined, true);
+}
 
 export type { EpubCover, EpubExportOptions, ExportProfile };
 

--- a/nodejs/packages/remark/README.md
+++ b/nodejs/packages/remark/README.md
@@ -28,7 +28,9 @@ import { unified } from "unified";
 import remarkParse from "remark-parse";
 import remarkStringify from "remark-stringify";
 import remarkMdi from "@illusions-lab/mdi-remark";
+import { initializeMdi } from "@illusions-lab/mdi";
 
+await initializeMdi(); // required in browsers; an immediate no-op in Node.js
 const processor = unified().use(remarkParse).use(remarkMdi).use(remarkStringify);
 const tree = processor.parse("{東京|とうきょう} ^12^");
 const output = String(await processor.process("[[em:傍点]]"));

--- a/nodejs/packages/remark/src/index.ts
+++ b/nodejs/packages/remark/src/index.ts
@@ -10,6 +10,7 @@ import { resolveFrontmatter } from "./frontmatter.js";
 
 export const MDI_SPEC_VERSION = "2.0";
 export type { MdiFrontmatter } from "./frontmatter.js";
+export { initializeMdi } from "@illusions-lab/mdi";
 
 /**
  * Unified ecosystem adapter for the Rust-owned MDI parser.

--- a/nodejs/scripts/check-node-coverage.mjs
+++ b/nodejs/scripts/check-node-coverage.mjs
@@ -5,11 +5,12 @@ import { fileURLToPath } from "node:url";
 
 const repositoryRoot = resolve(fileURLToPath(new URL("../..", import.meta.url)));
 
-// `mdi-core` is WebAssembly generated from Rust and is covered by the Rust
-// llvm-cov gate. Every package below owns TypeScript source and must meet the
-// same four-metric floor. Limiting coverage to src prevents generated dist/
+// Generated wasm-pack output is covered by Rust llvm-cov.  The authored core
+// runtime facade and every TypeScript package must meet the same four-metric
+// floor. Limiting coverage to src prevents generated dist/
 // and a previous HTML report from changing the result.
 const defaultPackages = [
+  "mdi-core",
   "cli",
   "export-profile",
   "mdast-util-mdi",
@@ -37,6 +38,9 @@ for (const packageName of selectedPackages) {
   }
 
   console.log(`\n=== Node coverage: ${packageName} ===`);
+  const coverageInclude = packageName === "mdi-core"
+    ? "src/runtime.js"
+    : "src/**/*.{ts,js}";
   execFileSync(
     "pnpm",
     [
@@ -48,7 +52,7 @@ for (const packageName of selectedPackages) {
       "--coverage",
       "--coverage.reporter=lcov",
       "--coverage.reporter=text",
-      "--coverage.include=src/**/*.ts",
+      `--coverage.include=${coverageInclude}`,
       "--coverage.thresholds.lines=90",
       "--coverage.thresholds.functions=90",
       "--coverage.thresholds.branches=90",

--- a/nodejs/scripts/pack-publishable-package.test.mjs
+++ b/nodejs/scripts/pack-publishable-package.test.mjs
@@ -84,7 +84,16 @@ test("npm artifacts replace workspace dependencies and MDI installs for consumer
       );
 
     for (const tarball of tarballs) {
-      assert.doesNotMatch(JSON.stringify(packedManifest(tarball)), /workspace:/);
+      const manifest = packedManifest(tarball);
+      assert.doesNotMatch(JSON.stringify(manifest), /workspace:/);
+      if (manifest.name === "@illusions-lab/mdi-core") {
+        const files = execFileSync("tar", ["-tf", tarball], { encoding: "utf8" });
+        assert.match(files, /package\/dist\/generated\/node\/mdi_core_bg\.wasm/);
+        assert.match(files, /package\/dist\/generated\/web\/mdi_core_bg\.wasm/);
+        assert.match(files, /package\/dist\/web\/index\.js/);
+        assert.equal(manifest.exports["."].browser, "./dist/web/index.js");
+        assert.equal(manifest.exports["."].node, "./dist/node/index.js");
+      }
     }
 
     mkdirSync(consumerDirectory);

--- a/nodejs/scripts/pack-publishable-package.test.mjs
+++ b/nodejs/scripts/pack-publishable-package.test.mjs
@@ -92,7 +92,7 @@ test("npm artifacts replace workspace dependencies and MDI installs for consumer
         assert.match(files, /package\/dist\/generated\/web\/mdi_core_bg\.wasm/);
         assert.match(files, /package\/dist\/web\/index\.js/);
         assert.equal(manifest.exports["."].browser, "./dist/web/index.js");
-        assert.equal(manifest.exports["."].node, "./dist/node/index.js");
+        assert.equal(manifest.exports["."].node, "./dist/node/index.cjs");
       }
     }
 

--- a/nodejs/scripts/test-browser-wasm.mjs
+++ b/nodejs/scripts/test-browser-wasm.mjs
@@ -1,0 +1,173 @@
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { mkdtemp, mkdir, readFile, readdir, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { extname, join, resolve } from "node:path";
+import { chromium, firefox, webkit } from "playwright";
+import { build } from "vite";
+import { packPublishablePackage } from "./pack-publishable-package.mjs";
+
+const repositoryRoot = resolve(import.meta.dirname, "../..");
+const outputDirectory = await mkdtemp(join(tmpdir(), "mdi-browser-wasm-"));
+const consumerDirectory = join(outputDirectory, "consumer");
+const fixtureRoot = join(consumerDirectory, "browser");
+const allBrowserTypes = [
+  ["Chromium", chromium],
+  ["Firefox", firefox],
+  ["WebKit", webkit],
+];
+const requestedEngines = new Set((process.env.MDI_BROWSER_ENGINES ?? "Chromium,Firefox,WebKit").split(","));
+const browserTypes = allBrowserTypes.filter(([name]) => requestedEngines.has(name));
+assert(browserTypes.length > 0, "MDI_BROWSER_ENGINES must select at least one browser");
+const runRetry = process.env.MDI_BROWSER_RETRY !== "0";
+const wasmRequests = [];
+let retryFailureRemaining = 0;
+
+try {
+  // Exercise the exact npm payload a browser user installs, not workspace
+  // symlinks.  This catches export-map and relative-WASM-path regressions.
+  const artifactsDirectory = join(outputDirectory, "artifacts");
+  await mkdir(artifactsDirectory);
+  const packagesDirectory = resolve(repositoryRoot, "nodejs/packages");
+  const tarballs = (await readdir(packagesDirectory)).filter((name) =>
+    existsSync(join(packagesDirectory, name, "package.json")),
+  ).map((name) => packPublishablePackage({
+    packageDirectory: join(packagesDirectory, name),
+    workspaceRoot: resolve(repositoryRoot, "nodejs"),
+    outputDirectory: artifactsDirectory,
+  }));
+  await mkdir(fixtureRoot, { recursive: true });
+  await writeFile(join(consumerDirectory, "package.json"), JSON.stringify({ name: "mdi-packed-browser-consumer", private: true, type: "module" }));
+  execFileSync("npm", ["install", "--ignore-scripts", "--no-audit", "--no-fund", ...tarballs], { cwd: consumerDirectory, stdio: "inherit" });
+  await writeFile(join(fixtureRoot, "index.html"), await readFile(resolve(repositoryRoot, "nodejs/browser-test/index.html")));
+  await writeFile(join(fixtureRoot, "src.ts"), await readFile(resolve(repositoryRoot, "nodejs/browser-test/src.ts")));
+
+  const originalDirectory = process.cwd();
+  process.chdir(fixtureRoot);
+  try {
+    await build({
+      configFile: false,
+      root: ".",
+      logLevel: "error",
+      base: "/mdi-editor/",
+      build: { outDir: "dist", emptyOutDir: true },
+    });
+  } finally {
+    process.chdir(originalDirectory);
+  }
+
+  const siteDirectory = join(fixtureRoot, "dist");
+  const files = await listFiles(siteDirectory);
+  assert(files.some((file) => file.endsWith(".wasm")), "Vite output must include the MDI WASM asset");
+
+  const javascript = (await Promise.all(
+    files.filter((file) => file.endsWith(".js")).map((file) => readFile(file, "utf8")),
+  )).join("\n");
+  for (const forbidden of ["node:fs", "node:path", "__dirname", "readFileSync(", "require("]) {
+    assert(!javascript.includes(forbidden), `browser bundle must not contain ${forbidden}`);
+  }
+
+  const server = createServer(async (request, response) => {
+    try {
+      const pathname = new URL(request.url ?? "/", "http://localhost").pathname;
+      const withoutBase = pathname.startsWith("/mdi-editor/") ? pathname.slice("/mdi-editor/".length) : "";
+      const requested = withoutBase === "" ? "index.html" : withoutBase;
+      const file = resolve(siteDirectory, requested);
+      assert(file.startsWith(`${siteDirectory}/`), "request escaped browser test output");
+      if (extname(file) === ".wasm") {
+        wasmRequests.push({ pathname, contentType: contentType(file) });
+        if (retryFailureRemaining > 0) {
+          retryFailureRemaining -= 1;
+          // A dropped connection exercises an actual first-load transport
+          // failure without allowing a browser's HTTP cache to retain a 503.
+          response.destroy();
+          return;
+        }
+      }
+      const body = await readFile(file);
+      response.writeHead(200, { "content-type": contentType(file), "cache-control": "no-store" });
+      response.end(body);
+    } catch {
+      response.writeHead(404);
+      response.end();
+    }
+  });
+  await new Promise((resolveListen) => server.listen(0, "127.0.0.1", resolveListen));
+
+  try {
+    const address = server.address();
+    assert(address && typeof address === "object");
+    const url = `http://127.0.0.1:${address.port}/mdi-editor/`;
+    console.log("Running packed browser WASM contract in Chromium, Firefox, and WebKit");
+    for (const [browserName, browserType] of browserTypes) {
+      await testBrowser(browserName, browserType, url, runRetry && browserName === "Chromium" ? `${url}?retry=1` : undefined);
+    }
+    assert.equal(wasmRequests.length, browserTypes.length + (runRetry ? 2 : 0), "failed initialization must retry exactly once without duplicate concurrent loads");
+    assert(wasmRequests.every(({ contentType }) => contentType === "application/wasm"), "WASM must be served with application/wasm");
+    console.log("✓ packed WASM asset URL, MIME type, single-flight retry, and browser corpus");
+  } finally {
+    await new Promise((resolveClose, reject) => server.close((error) => error ? reject(error) : resolveClose()));
+  }
+} finally {
+  await rm(outputDirectory, { recursive: true, force: true });
+}
+
+async function testBrowser(browserName, browserType, url, retryUrl) {
+  console.log(`Launching ${browserName}`);
+  const browser = await browserType.launch({ headless: true });
+  try {
+    await testPage(browserName, await browser.newPage(), url);
+    if (retryUrl) {
+      retryFailureRemaining = 1;
+      await testPage(`${browserName} retry`, await browser.newPage(), retryUrl);
+    }
+  } finally {
+    await browser.close();
+  }
+}
+
+async function testPage(browserName, page, url) {
+  const pageErrors = [];
+  page.on("pageerror", (error) => pageErrors.push(error));
+  await page.goto(url, { waitUntil: "networkidle" });
+  await page.waitForFunction(
+      () => document.querySelector("#result")?.textContent !== "pending",
+      undefined,
+      { timeout: 5_000 },
+  ).catch(() => assert.fail(
+      `${browserName}: ${pageErrors.map((error) => error.stack).join("\n") || "browser test did not finish"}`,
+  ));
+  const result = JSON.parse(await page.locator("#result").textContent());
+  assert.equal(result.error, undefined, `${browserName}: ${result.error}`);
+  assert.equal(result.irVersion, "1.0", browserName);
+  assert.equal(result.firstNode, "heading", browserName);
+  assert.equal(result.hasFrontmatter, true, browserName);
+  assert.equal(result.tableType, "table", browserName);
+  assert(result.utf8Span?.endByte > result.utf8Span?.startByte, `${browserName}: UTF-8 source span missing`);
+  assert(result.largeNodeCount > 200, `${browserName}: large document was truncated`);
+  assert.equal(result.diagnostic?.code, "mdi.version.unsupported", `${browserName}: diagnostics missing`);
+  assert(result.diagnostic?.span?.endByte > result.diagnostic?.span?.startByte, `${browserName}: diagnostic span missing`);
+  assert.match(result.canonical, /\{東京\|とうきょう\}/, browserName);
+  assert.match(result.remarkOutput, /\{東京\|とうきょう\}/, browserName);
+  console.log(`✓ ${browserName}: initialize, parse, serialize, and remark`);
+}
+
+async function listFiles(directory) {
+  const entries = await readdir(directory);
+  const files = [];
+  for (const entry of entries) {
+    const file = join(directory, entry);
+    files.push((await stat(file)).isDirectory() ? await listFiles(file) : file);
+  }
+  return files.flat();
+}
+
+function contentType(file) {
+  return {
+    ".html": "text/html; charset=utf-8",
+    ".js": "text/javascript; charset=utf-8",
+    ".wasm": "application/wasm",
+  }[extname(file)] ?? "application/octet-stream";
+}

--- a/nodejs/scripts/test-publication-contracts.mjs
+++ b/nodejs/scripts/test-publication-contracts.mjs
@@ -19,7 +19,7 @@ import {
   PAGE_SIZES,
   resolveExportProfile,
 } from "../packages/export-profile/dist/index.js";
-import { pageSizeCatalogJson } from "../packages/mdi-core/dist/node/index.js";
+import { pageSizeCatalogJson } from "../packages/mdi-core/dist/node/index.cjs";
 
 const rustPageDimensions = Object.fromEntries(JSON.parse(pageSizeCatalogJson()).map(({ key, widthMm, heightMm }) => [
   key,

--- a/nodejs/scripts/test-publication-contracts.mjs
+++ b/nodejs/scripts/test-publication-contracts.mjs
@@ -1,4 +1,5 @@
 import { execFileSync } from "node:child_process";
+import assert from "node:assert/strict";
 import {
   existsSync,
   mkdirSync,
@@ -18,6 +19,13 @@ import {
   PAGE_SIZES,
   resolveExportProfile,
 } from "../packages/export-profile/dist/index.js";
+import { pageSizeCatalogJson } from "../packages/mdi-core/dist/node/index.js";
+
+const rustPageDimensions = Object.fromEntries(JSON.parse(pageSizeCatalogJson()).map(({ key, widthMm, heightMm }) => [
+  key,
+  { width: widthMm, height: heightMm },
+]));
+assert.deepEqual(PAGE_DIMENSIONS, rustPageDimensions, "export-profile snapshot must match Rust's publication catalogue");
 import {
   renderDocxWithProfile,
   renderEpubWithProfile,

--- a/nodejs/scripts/test-safari-wasm.mjs
+++ b/nodejs/scripts/test-safari-wasm.mjs
@@ -1,0 +1,112 @@
+// Safari.app smoke for the same packed npm consumer contract as the
+// Playwright suite.  safaridriver speaks the W3C WebDriver HTTP protocol, so
+// no third-party WebDriver client is needed in the published dependency set.
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { createServer } from "node:http";
+import { mkdtemp, mkdir, readFile, readdir, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { extname, join, resolve } from "node:path";
+import { build } from "vite";
+import { packPublishablePackage } from "./pack-publishable-package.mjs";
+
+const root = resolve(import.meta.dirname, "../..");
+const temporary = await mkdtemp(join(tmpdir(), "mdi-safari-wasm-"));
+const consumer = join(temporary, "consumer");
+const fixture = join(consumer, "browser");
+const port = 4444;
+let driver;
+let server;
+let sessionId;
+
+try {
+  const artifacts = join(temporary, "artifacts");
+  await mkdir(artifacts);
+  const packages = resolve(root, "nodejs/packages");
+  const tarballs = (await readdir(packages)).filter((name) => existsSync(join(packages, name, "package.json"))).map((name) =>
+    packPublishablePackage({ packageDirectory: join(packages, name), workspaceRoot: resolve(root, "nodejs"), outputDirectory: artifacts }),
+  );
+  await mkdir(fixture, { recursive: true });
+  await writeFile(join(consumer, "package.json"), JSON.stringify({ name: "mdi-safari-packed-consumer", private: true, type: "module" }));
+  await run("npm", ["install", "--ignore-scripts", "--no-audit", "--no-fund", ...tarballs], consumer);
+  await writeFile(join(fixture, "index.html"), await readFile(join(root, "nodejs/browser-test/index.html")));
+  await writeFile(join(fixture, "src.ts"), await readFile(join(root, "nodejs/browser-test/src.ts")));
+
+  const previous = process.cwd();
+  process.chdir(fixture);
+  try { await build({ configFile: false, root: ".", logLevel: "error", base: "/mdi-editor/", build: { outDir: "dist", emptyOutDir: true } }); }
+  finally { process.chdir(previous); }
+
+  const site = join(fixture, "dist");
+  assert((await files(site)).some((file) => file.endsWith(".wasm")), "packed Safari fixture must emit WASM");
+  server = createServer(async (request, response) => {
+    try {
+      const pathname = new URL(request.url ?? "/", "http://localhost").pathname;
+      const requested = pathname.startsWith("/mdi-editor/") ? pathname.slice("/mdi-editor/".length) || "index.html" : "index.html";
+      const file = resolve(site, requested);
+      assert(file.startsWith(`${site}/`));
+      response.writeHead(200, { "content-type": { ".html": "text/html", ".js": "text/javascript", ".wasm": "application/wasm" }[extname(file)] ?? "application/octet-stream" });
+      response.end(await readFile(file));
+    } catch { response.writeHead(404).end(); }
+  });
+  await new Promise((done) => server.listen(0, "127.0.0.1", done));
+  const address = server.address();
+  assert(address && typeof address === "object");
+
+  driver = spawn("safaridriver", ["--port", String(port)], { stdio: "ignore" });
+  await waitForDriver();
+  sessionId = await webdriver("POST", "/session", { capabilities: { alwaysMatch: { browserName: "safari" } } }).then((value) => value.sessionId);
+  await webdriver("POST", `/session/${sessionId}/url`, { url: `http://127.0.0.1:${address.port}/mdi-editor/` });
+  const result = await pollResult();
+  assert.equal(result.error, undefined, result.error);
+  assert.equal(result.irVersion, "1.0");
+  assert.equal(result.hasFrontmatter, true);
+  assert.equal(result.tableType, "table");
+  assert(result.utf8Span?.endByte > result.utf8Span?.startByte);
+  assert(result.largeNodeCount > 200);
+  assert.equal(result.diagnostic?.code, "mdi.version.unsupported");
+  assert(result.diagnostic?.span?.endByte > result.diagnostic?.span?.startByte);
+  assert.match(result.canonical, /\{東京\|とうきょう\}/);
+  assert.match(result.remarkOutput, /\{東京\|とうきょう\}/);
+  console.log("✓ Safari.app: packed initialize, parse, serialize, and remark");
+} finally {
+  if (sessionId) await webdriver("DELETE", `/session/${sessionId}`).catch(() => {});
+  driver?.kill();
+  if (server) await new Promise((done) => server.close(done));
+  await rm(temporary, { recursive: true, force: true });
+}
+
+function run(command, args, cwd) {
+  return new Promise((resolveRun, reject) => {
+    const child = spawn(command, args, { cwd, stdio: "inherit" });
+    child.once("error", reject).once("exit", (code) => code === 0 ? resolveRun() : reject(new Error(`${command} exited ${code}`)));
+  });
+}
+async function webdriver(method, pathname, body) {
+  const response = await fetch(`http://127.0.0.1:${port}${pathname}`, { method, headers: { "content-type": "application/json" }, body: body === undefined ? undefined : JSON.stringify(body) });
+  const payload = await response.json();
+  if (!response.ok || payload.value?.error) throw new Error(payload.value?.message ?? `WebDriver ${response.status}`);
+  return payload.value;
+}
+async function waitForDriver() {
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    try { await webdriver("GET", "/status"); return; } catch { await new Promise((resolveWait) => setTimeout(resolveWait, 100)); }
+  }
+  throw new Error("safaridriver did not become ready");
+}
+async function pollResult() {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    const value = await webdriver("POST", `/session/${sessionId}/execute/sync`, { script: "return document.querySelector('#result')?.textContent", args: [] });
+    if (value && value !== "pending") return JSON.parse(value);
+    await new Promise((resolveWait) => setTimeout(resolveWait, 100));
+  }
+  throw new Error("Safari browser fixture did not finish");
+}
+async function files(directory) {
+  const entries = await readdir(directory);
+  return (await Promise.all(entries.map(async (entry) => {
+    const file = join(directory, entry);
+    return (await stat(file)).isDirectory() ? files(file) : [file];
+  }))).flat();
+}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "docs:build": "pnpm run build && pnpm --filter docs build",
     "build": "node scripts/verify-publication-layouts.mjs && turbo run build",
     "test": "turbo run test",
+    "test:browser": "node nodejs/scripts/test-browser-wasm.mjs",
+    "test:safari": "node nodejs/scripts/test-safari-wasm.mjs",
     "test:contracts": "node nodejs/scripts/test-publication-contracts.mjs",
     "test:coverage": "node nodejs/scripts/check-node-coverage.mjs",
     "typecheck": "turbo run typecheck",
@@ -28,6 +30,7 @@
     "playwright": "^1.48.0",
     "turbo": "^2.1.0",
     "typescript": "^5.6.0",
+    "vite": "^5.4.0",
     "vitest": "^2.1.0",
     "vnu-jar": "^25.11.1"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       typescript:
         specifier: ^5.6.0
         version: 5.9.3
+      vite:
+        specifier: ^5.4.0
+        version: 5.4.21(@types/node@25.9.5)(lightningcss@1.32.0)
       vitest:
         specifier: ^2.1.0
         version: 2.1.9(@types/node@25.9.5)(lightningcss@1.32.0)
@@ -65,6 +68,24 @@ importers:
       typedoc-plugin-markdown:
         specifier: ^4.6.0
         version: 4.12.0(typedoc@0.28.20(typescript@5.9.3))
+
+  nodejs/browser-test:
+    dependencies:
+      '@illusions-lab/mdi':
+        specifier: workspace:*
+        version: link:../packages/mdi
+      '@illusions-lab/mdi-remark':
+        specifier: workspace:*
+        version: link:../packages/remark
+      remark-parse:
+        specifier: ^11.0.0
+        version: 11.0.0
+      remark-stringify:
+        specifier: ^11.0.0
+        version: 11.0.0
+      unified:
+        specifier: ^11.0.0
+        version: 11.0.5
 
   nodejs/packages/cli:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 packages:
   - "nodejs/packages/*"
+  - "nodejs/browser-test"
   - "docs"


### PR DESCRIPTION
Closes #68

## Summary
- expose authored Node/browser core facades with idempotent initialization and retry
- keep wasm-pack loaders private and publish browser assets through export conditions
- add packed Vite browser contracts for Chromium, Firefox, WebKit, and Safari.app
- remove export-profile import-time WASM calls and verify the static snapshot against Rust

## Validation
- pnpm typecheck
- pnpm test:browser
- MDI_COVERAGE_PACKAGES=mdi-core pnpm test:coverage
- node --test nodejs/scripts/pack-publishable-package.test.mjs

Safari smoke is run by the new macOS CI job via safaridriver.