### PR TITLE
docs: explain browser WASM initialization

### DIFF
--- a/docs/src/content/docs/bindings/javascript.md
+++ b/docs/src/content/docs/bindings/javascript.md
@@ -31,6 +31,26 @@ console.log(html.headings);  // source-order heading text, depth, and spans
 
 `renderHtml(source)` returns a standalone document with the MDI stylesheet. Pass `{ bodyOnly: true }` when the application owns the outer page. `renderHtmlWithDiagnostics` also exposes headings, so navigation and chapter controls need not scrape generated HTML. The stable MDI classes (`mdi-ruby`, `mdi-tcy`, `mdi-em`, `mdi-pagebreak`, and related classes) are part of that semantic HTML.
 
+## Browser initialization
+
+In a browser, await the WebAssembly runtime once before calling the synchronous
+API. `initializeMdi()` is single-flight and idempotent: concurrent calls share
+one initialization, and Node.js resolves it immediately because its runtime is
+loaded eagerly.
+
+```ts
+import { initializeMdi, parse, serializeMdi } from "@illusions-lab/mdi";
+
+await initializeMdi();
+const parsed = parse("{東京|とうきょう} ^12^");
+const canonical = serializeMdi("{東京|とうきょう} ^12^");
+```
+
+Vite and other bundlers that honor the `browser` export condition select the
+web facade and emit its private WASM asset automatically. Do not import the
+generated wasm-pack loader directly. A failed browser initialization can be
+retried safely by calling `initializeMdi()` again.
+
 ## Choose the export level
 
 The one-argument EPUB and DOCX calls are synchronous Rust baseline exports:

--- a/docs/src/content/docs/ja/bindings/javascript.md
+++ b/docs/src/content/docs/ja/bindings/javascript.md
@@ -30,6 +30,26 @@ console.log(result.headings); // depth、text、span を持つ source-order head
 
 `renderHtml(source)` は MDI stylesheet 付き standalone HTML を返します。app が外側の page を持つなら `{ bodyOnly: true }` を使います。semantic HTML は stable な `mdi-ruby`、`mdi-tcy`、`mdi-em`、`mdi-pagebreak` 等の class を付けます。
 
+## Browser の初期化
+
+browser では synchronous API を呼ぶ前に、WebAssembly runtime を一度だけ
+`await` してください。`initializeMdi()` は single-flight かつ idempotent です。
+同時呼び出しは一つの初期化を共有します。Node.js は eager load のため直ちに
+resolve します。
+
+```ts
+import { initializeMdi, parse, serializeMdi } from "@illusions-lab/mdi";
+
+await initializeMdi();
+const parsed = parse("{東京|とうきょう} ^12^");
+const canonical = serializeMdi("{東京|とうきょう} ^12^");
+```
+
+`browser` export condition を使う Vite などの bundler は web facade を選び、
+private な WASM asset を自動で emit します。generated wasm-pack loader を直接
+import しないでください。browser の初期化が失敗しても、`initializeMdi()` を
+再度呼べば安全に retry できます。
+
 ## baseline と設定付き EPUB/DOCX
 
 一引数の API は synchronous Rust baseline export です。

--- a/docs/src/content/docs/zh-tw/bindings/javascript.md
+++ b/docs/src/content/docs/zh-tw/bindings/javascript.md
@@ -30,6 +30,24 @@ console.log(result.headings); // source-order heading 的 depth、text、span
 
 `renderHtml(source)` 回傳含 MDI stylesheet 的 standalone HTML；app 擁有外層頁面時傳 `{ bodyOnly: true }`。semantic HTML 有穩定的 `mdi-ruby`、`mdi-tcy`、`mdi-em`、`mdi-pagebreak` 等 class。
 
+## Browser 初始化
+
+在 browser 中呼叫同步 API 前，先 `await` 一次 WebAssembly runtime。
+`initializeMdi()` 是 single-flight 且 idempotent：並行呼叫會共用同一個初始化；
+Node.js 因為 eager load，會立刻 resolve。
+
+```ts
+import { initializeMdi, parse, serializeMdi } from "@illusions-lab/mdi";
+
+await initializeMdi();
+const parsed = parse("{東京|とうきょう} ^12^");
+const canonical = serializeMdi("{東京|とうきょう} ^12^");
+```
+
+Vite 與其他遵循 `browser` export condition 的 bundler 會自動選擇 web facade 並
+emit 私有 WASM asset。不要直接 import generated wasm-pack loader。若 browser
+初始化失敗，可再次呼叫 `initializeMdi()` 安全地重試。
+
 ## baseline 與可設定 EPUB/DOCX
 
 一個參數的 API 是 synchronous Rust baseline export：


### PR DESCRIPTION
Documents the required browser initialization path, Vite/browser export behavior, single-flight semantics, and safe retry in English, Japanese, and Traditional Chinese.