### PR TITLE
test: add large-document performance CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,13 +227,13 @@ jobs:
       matrix:
         include:
           - label: 100k characters
-            test: hundred_thousand_character_book
+            test: case_100k
           - label: 1M characters
-            test: million_character_book
+            test: case_1m
           - label: 10M characters
-            test: ten_million_character_book
+            test: case_10m
           - label: 100M characters
-            test: hundred_million_character_book
+            test: case_100m
     defaults:
       run:
         working-directory: mdi-core

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,9 +218,77 @@ jobs:
     uses: ./.github/workflows/android.yml
     secrets: inherit
 
+  large-document-performance:
+    name: Large document performance (${{ matrix.label }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: 100k characters
+            test: hundred_thousand_character_book
+          - label: 1M characters
+            test: million_character_book
+          - label: 10M characters
+            test: ten_million_character_book
+          - label: 100M characters
+            test: hundred_million_character_book
+    defaults:
+      run:
+        working-directory: mdi-core
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Measure parse and canonical serialization throughput
+        run: |
+          cargo test --release --test large_document_performance "${{ matrix.test }}" -- \
+            --ignored --nocapture --test-threads=1 | tee performance.log
+          grep '^PERF_RESULT ' performance.log > "performance-${{ matrix.test }}.jsonl"
+
+      - name: Upload case result
+        uses: actions/upload-artifact@v4
+        with:
+          name: large-document-performance-${{ matrix.test }}
+          path: mdi-core/performance-${{ matrix.test }}.jsonl
+          if-no-files-found: error
+          retention-days: 90
+
+  large-document-performance-report:
+    name: Large document performance report
+    needs: large-document-performance
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download parallel case results
+        uses: actions/download-artifact@v4
+        with:
+          pattern: large-document-performance-*
+          path: performance-results
+          merge-multiple: true
+
+      - name: Write traceable performance report
+        run: node scripts/write-large-document-performance-report.mjs performance-results performance-report
+
+      - name: Publish report in the workflow summary
+        run: cat performance-report/large-document-performance.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload combined performance report
+        uses: actions/upload-artifact@v4
+        with:
+          name: large-document-performance-report-${{ github.run_id }}
+          path: performance-report/
+          if-no-files-found: error
+          retention-days: 90
+
   publication-contracts:
     name: Publication contracts
-    needs: [nodejs, rust-native, safari-browser, swift, python, android]
+    needs: [nodejs, rust-native, safari-browser, swift, python, android, large-document-performance-report]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,7 +246,7 @@ jobs:
         run: |
           cargo test --release --test large_document_performance "${{ matrix.test }}" -- \
             --ignored --nocapture --test-threads=1 | tee performance.log
-          grep '^PERF_RESULT ' performance.log > "performance-${{ matrix.test }}.jsonl"
+          sed -n 's/.*PERF_RESULT //p' performance.log > "performance-${{ matrix.test }}.jsonl"
 
       - name: Upload case result
         uses: actions/upload-artifact@v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,22 @@ CI runs these publication contracts only after the Node.js, Rust, Swift,
 Python, and Android unit/coverage jobs have all passed. A renderer change is
 ready to merge only when both layers are green.
 
+### Large-document performance
+
+CI runs the Rust-authoritative parser and canonical serializer on book-like
+Japanese MDI inputs of exactly 100,000, 1,000,000, 10,000,000, and
+100,000,000 characters. The four cases use parallel runners. A final CI job
+publishes their commit-addressed JSON and Markdown report as an artifact and in
+the workflow summary, so performance changes can be compared across runs.
+
+To run one of the same cases locally when investigating a performance change:
+
+```sh
+cd mdi-core
+cargo test --release --test large_document_performance -- \
+  --ignored --nocapture --test-threads=1
+```
+
 ### Android
 
 Android work requires JDK 17+, the Android SDK/NDK, Rust Android targets, and `cargo-ndk`. See [android/README.md](./android/README.md) for setup and test commands.

--- a/mdi-core/tests/large_document_performance.rs
+++ b/mdi-core/tests/large_document_performance.rs
@@ -105,24 +105,24 @@ fn run_case(characters: usize) {
 
 #[test]
 #[ignore = "run in the Large document performance CI job"]
-fn hundred_thousand_character_book() {
+fn case_100k() {
     run_case(HUNDRED_THOUSAND);
 }
 
 #[test]
 #[ignore = "run in the Large document performance CI job"]
-fn million_character_book() {
+fn case_1m() {
     run_case(MILLION);
 }
 
 #[test]
 #[ignore = "run in the Large document performance CI job"]
-fn ten_million_character_book() {
+fn case_10m() {
     run_case(TEN_MILLION);
 }
 
 #[test]
 #[ignore = "run in the Large document performance CI job"]
-fn hundred_million_character_book() {
+fn case_100m() {
     run_case(HUNDRED_MILLION);
 }

--- a/mdi-core/tests/large_document_performance.rs
+++ b/mdi-core/tests/large_document_performance.rs
@@ -1,0 +1,114 @@
+//! Large-document throughput and integrity checks.
+//!
+//! These are intentionally ignored in the ordinary test suite.  Run them with
+//! `cargo test --release --test large_document_performance -- --ignored
+//! --nocapture --test-threads=1`.  CI runs every case in its own matrix job and
+//! publishes the JSON lines printed below as a combined, commit-addressed
+//! artifact.  Throughput remains a report rather than a microbenchmark gate,
+//! because hosted runners have variable CPU shares.
+
+use std::hint::black_box;
+use std::time::Instant;
+
+use mdi_core::{parse_document, serialize_mdi_document};
+
+const HUNDRED_THOUSAND: usize = 100_000;
+const MILLION: usize = 1_000_000;
+const TEN_MILLION: usize = 10_000_000;
+const HUNDRED_MILLION: usize = 100_000_000;
+
+/// Generate a book-like Japanese MDI source with an exact Unicode scalar
+/// count.  It has headings, paragraphs, ruby, emphasis, and tate-chu-yoko so
+/// this exercises more than a repeated plain-text fast path.
+fn book_source(characters: usize) -> String {
+    const CHAPTER: &str = "# 第一章\n\n吾輩は{猫|ねこ}である。[[em:名前]]はまだない。第^12^話。\n\n";
+    const PARAGRAPH: &str = "東京の空は青く、{言葉|ことば}は静かに続く。\n\n";
+
+    let mut source = String::with_capacity(characters.saturating_mul(3));
+    let chapter_characters = CHAPTER.chars().count();
+    let paragraph_characters = PARAGRAPH.chars().count();
+    let mut used_characters = 0;
+
+    let mut paragraphs = 0;
+    while used_characters + paragraph_characters <= characters {
+        // Keep headings frequent enough to exercise block lowering as well as
+        // inline syntax, without scanning the source to find the next split.
+        if paragraphs % 64 == 0
+            && used_characters + chapter_characters + paragraph_characters <= characters
+        {
+            source.push_str(CHAPTER);
+            used_characters += chapter_characters;
+        }
+        source.push_str(PARAGRAPH);
+        used_characters += paragraph_characters;
+        paragraphs += 1;
+    }
+
+    // Japanese publishing work commonly budgets by characters.  Pad with a
+    // plain CJK scalar so the public cases are exactly 100k, 1M, 10M, and 100M
+    // characters even when a structured unit does not divide them evenly.
+    source.extend(std::iter::repeat_n('字', characters - used_characters));
+    assert_eq!(source.chars().count(), characters);
+    source
+}
+
+fn run_case(characters: usize) {
+    let source = book_source(characters);
+    let source_bytes = source.len();
+
+    let parse_started = Instant::now();
+    let document = parse_document(black_box(&source));
+    let parse_elapsed = parse_started.elapsed();
+
+    assert_eq!(document.span.start_byte, 0);
+    assert_eq!(document.span.end_byte as usize, source_bytes);
+    assert!(!document.children.is_empty(), "large source was truncated");
+
+    let serialize_started = Instant::now();
+    let canonical = serialize_mdi_document(black_box(&document));
+    let serialize_elapsed = serialize_started.elapsed();
+
+    assert!(!canonical.is_empty(), "canonical serialization was truncated");
+    // The 100M case is intentionally large.  Release the parsed tree before
+    // parsing its canonical form so round-trip validation does not retain two
+    // complete document trees at once.
+    drop(document);
+    let reparsed = parse_document(black_box(&canonical));
+    assert_eq!(reparsed.span.end_byte as usize, canonical.len());
+    assert!(!reparsed.children.is_empty(), "canonical document was truncated");
+
+    // Keep the result machine-readable for the workflow artifact.  Throughput
+    // is reported instead of enforced: hosted runners have variable CPU shares.
+    println!(
+        "PERF_RESULT {{\"characters\":{characters},\"source_bytes\":{source_bytes},\"canonical_bytes\":{},\"parse_ms\":{},\"serialize_ms\":{},\"parse_chars_per_second\":{:.2},\"serialize_chars_per_second\":{:.2}}}",
+        canonical.len(),
+        parse_elapsed.as_millis(),
+        serialize_elapsed.as_millis(),
+        characters as f64 / parse_elapsed.as_secs_f64(),
+        characters as f64 / serialize_elapsed.as_secs_f64(),
+    );
+}
+
+#[test]
+#[ignore = "run in the Large document performance CI job"]
+fn hundred_thousand_character_book() {
+    run_case(HUNDRED_THOUSAND);
+}
+
+#[test]
+#[ignore = "run in the Large document performance CI job"]
+fn million_character_book() {
+    run_case(MILLION);
+}
+
+#[test]
+#[ignore = "run in the Large document performance CI job"]
+fn ten_million_character_book() {
+    run_case(TEN_MILLION);
+}
+
+#[test]
+#[ignore = "run in the Large document performance CI job"]
+fn hundred_million_character_book() {
+    run_case(HUNDRED_MILLION);
+}

--- a/mdi-core/tests/large_document_performance.rs
+++ b/mdi-core/tests/large_document_performance.rs
@@ -23,11 +23,18 @@ const HUNDRED_MILLION: usize = 100_000_000;
 fn book_source(characters: usize) -> String {
     const CHAPTER: &str =
         "# 第一章\n\n吾輩は{猫|ねこ}である。[[em:名前]]はまだない。第^12^話。\n\n";
-    const PARAGRAPH: &str = "東京の空は青く、{言葉|ことば}は静かに続く。\n\n";
+    const FILLER: &str = "本文は静かに続き、季節は移ろう。";
 
     let mut source = String::with_capacity(characters.saturating_mul(3));
     let chapter_characters = CHAPTER.chars().count();
-    let paragraph_characters = PARAGRAPH.chars().count();
+    // A long book has long prose paragraphs, not millions of two-sentence
+    // blocks.  Keep each paragraph around 2,000 characters while retaining
+    // representative MDI syntax at its beginning.
+    let paragraph = format!(
+        "東京の空は青く、{{言葉|ことば}}は[[em:静か]]に続く。第^12^話。{}\n\n",
+        FILLER.repeat(96)
+    );
+    let paragraph_characters = paragraph.chars().count();
     let mut used_characters = 0;
 
     let mut paragraphs = 0;
@@ -40,7 +47,7 @@ fn book_source(characters: usize) -> String {
             source.push_str(CHAPTER);
             used_characters += chapter_characters;
         }
-        source.push_str(PARAGRAPH);
+        source.push_str(&paragraph);
         used_characters += paragraph_characters;
         paragraphs += 1;
     }

--- a/mdi-core/tests/large_document_performance.rs
+++ b/mdi-core/tests/large_document_performance.rs
@@ -21,7 +21,8 @@ const HUNDRED_MILLION: usize = 100_000_000;
 /// count.  It has headings, paragraphs, ruby, emphasis, and tate-chu-yoko so
 /// this exercises more than a repeated plain-text fast path.
 fn book_source(characters: usize) -> String {
-    const CHAPTER: &str = "# 第一章\n\n吾輩は{猫|ねこ}である。[[em:名前]]はまだない。第^12^話。\n\n";
+    const CHAPTER: &str =
+        "# 第一章\n\n吾輩は{猫|ねこ}である。[[em:名前]]はまだない。第^12^話。\n\n";
     const PARAGRAPH: &str = "東京の空は青く、{言葉|ことば}は静かに続く。\n\n";
 
     let mut source = String::with_capacity(characters.saturating_mul(3));
@@ -68,14 +69,20 @@ fn run_case(characters: usize) {
     let canonical = serialize_mdi_document(black_box(&document));
     let serialize_elapsed = serialize_started.elapsed();
 
-    assert!(!canonical.is_empty(), "canonical serialization was truncated");
+    assert!(
+        !canonical.is_empty(),
+        "canonical serialization was truncated"
+    );
     // The 100M case is intentionally large.  Release the parsed tree before
     // parsing its canonical form so round-trip validation does not retain two
     // complete document trees at once.
     drop(document);
     let reparsed = parse_document(black_box(&canonical));
     assert_eq!(reparsed.span.end_byte as usize, canonical.len());
-    assert!(!reparsed.children.is_empty(), "canonical document was truncated");
+    assert!(
+        !reparsed.children.is_empty(),
+        "canonical document was truncated"
+    );
 
     // Keep the result machine-readable for the workflow artifact.  Throughput
     // is reported instead of enforced: hosted runners have variable CPU shares.

--- a/scripts/write-large-document-performance-report.mjs
+++ b/scripts/write-large-document-performance-report.mjs
@@ -1,0 +1,62 @@
+import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+
+const [inputDirectory, outputDirectory] = process.argv.slice(2);
+if (!inputDirectory || !outputDirectory) {
+  throw new Error("usage: node scripts/write-large-document-performance-report.mjs <input-dir> <output-dir>");
+}
+
+const expectedCharacters = [100_000, 1_000_000, 10_000_000, 100_000_000];
+const reportFiles = (await readdir(inputDirectory, { recursive: true }))
+  .filter((file) => file.endsWith(".jsonl"));
+const results = [];
+
+for (const file of reportFiles) {
+  const lines = (await readFile(resolve(inputDirectory, file), "utf8"))
+    .split("\n")
+    .filter(Boolean);
+  for (const line of lines) {
+    results.push(JSON.parse(line));
+  }
+}
+
+results.sort((left, right) => left.characters - right.characters);
+if (results.length !== expectedCharacters.length || !results.every((result, index) => result.characters === expectedCharacters[index])) {
+  throw new Error(`expected one result for ${expectedCharacters.join(", ")} characters; received ${results.map((result) => result.characters).join(", ")}`);
+}
+
+const report = {
+  schemaVersion: 1,
+  commit: process.env.GITHUB_SHA ?? "local",
+  runId: process.env.GITHUB_RUN_ID ?? "local",
+  runAttempt: process.env.GITHUB_RUN_ATTEMPT ?? "1",
+  generatedAt: new Date().toISOString(),
+  results,
+};
+const tableRows = results.map((result) => [
+  result.characters.toLocaleString("en-US"),
+  result.source_bytes.toLocaleString("en-US"),
+  result.canonical_bytes.toLocaleString("en-US"),
+  result.parse_ms.toLocaleString("en-US"),
+  result.serialize_ms.toLocaleString("en-US"),
+  Math.round(result.parse_chars_per_second).toLocaleString("en-US"),
+  Math.round(result.serialize_chars_per_second).toLocaleString("en-US"),
+]);
+const markdown = [
+  "# Large-document performance report",
+  "",
+  `- Commit: \`${report.commit}\``,
+  `- CI run: ${report.runId} (attempt ${report.runAttempt})`,
+  `- Generated: ${report.generatedAt}`,
+  "",
+  "| Characters | Source bytes | Canonical bytes | Parse ms | Serialize ms | Parse chars/s | Serialize chars/s |",
+  "| ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+  ...tableRows.map((row) => `| ${row.join(" | ")} |`),
+  "",
+  "Compare this artifact with earlier CI runs for the same runner class; throughput is reported rather than hard-gated because GitHub-hosted CPU allocation varies.",
+  "",
+].join("\n");
+
+await mkdir(outputDirectory, { recursive: true });
+await writeFile(resolve(outputDirectory, "large-document-performance.json"), `${JSON.stringify(report, null, 2)}\n`);
+await writeFile(resolve(outputDirectory, "large-document-performance.md"), markdown);


### PR DESCRIPTION
Adds Rust-authoritative 100k, 1M, 10M, and 100M-character book-like MDI performance cases. CI runs the four cases in parallel and publishes a commit-addressed JSON/Markdown aggregate artifact and workflow summary for regression tracking.