### PR TITLE
feat: add MDI text block projection

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,7 @@ Android work requires JDK 17+, the Android SDK/NDK, Rust Android targets, and `c
 4. Update the specification and user-facing documentation when public syntax, output, or APIs change.
 5. Run the checks relevant to the directories you touched before opening a PR.
 
-For JavaScript packages, add a Changeset when the change warrants a published package release. Do not add one for internal-only work, documentation-only changes, or test-only changes.
+For user-visible JavaScript package changes, update the public documentation and add focused tests. The release workflow calculates the next registry patch after the change merges to `main`; do not manually bump published npm package versions for an ordinary release. Internal-only, documentation-only, and test-only changes do not trigger package publication on their own.
 
 ## Pull request expectations
 

--- a/README.md
+++ b/README.md
@@ -94,13 +94,7 @@ Building the WASM bridge also requires the `wasm32-unknown-unknown` Rust target 
 
 ## Releases
 
-Package versions use `<MDI spec version>.<package release number>`; for MDI 2.0, releases begin at `2.0.1`. Use a patch Changeset for ordinary releases. Merging to `main` makes GitHub Actions build and publish packages through npm Trusted Publishing (OIDC).
-
-```bash
-cd nodejs
-pnpm changeset
-pnpm version
-```
+Package versions use `<MDI spec version>.<package release number>`; for MDI 2.0, releases begin at `2.0.1`. Merging a user-visible JavaScript change to `main` makes GitHub Actions calculate the next registry patch, build the publishable tarballs, and publish through npm Trusted Publishing (OIDC). Do not manually edit published npm package versions for a normal release.
 
 For an MDI specification version bump, run `pnpm bump-spec-version 2.1` from `nodejs/`.
 

--- a/docs/src/content/docs/bindings/javascript.md
+++ b/docs/src/content/docs/bindings/javascript.md
@@ -27,7 +27,7 @@ console.log(html.output);    // semantic contents of <body>
 console.log(html.headings);  // source-order heading text, depth, and spans
 ```
 
-`parse()` returns Rust-owned `document`, `diagnostics`, and UTF-8-byte source spans. At present the only implemented diagnostic code is `mdi.version.unsupported`; malformed inline notation normally uses its literal fallback rather than throwing. `prepareRender(source)` is the same parse-first convenience for a host workflow. The `*WithDiagnostics` helpers return that parser result alongside output; they do not make an invalid document fail automatically.
+`parse()` returns Rust-owned `document`, `diagnostics`, and UTF-8-byte source spans. Malformed inline notation normally uses its literal fallback rather than throwing; see [Diagnostics](/core/diagnostics/) for the complete warning list. `prepareRender(source)` is the same parse-first convenience for a host workflow. The `*WithDiagnostics` helpers return that parser result alongside output; they do not make an invalid document fail automatically.
 
 `renderHtml(source)` returns a standalone document with the MDI stylesheet. Pass `{ bodyOnly: true }` when the application owns the outer page. `renderHtmlWithDiagnostics` also exposes headings, so navigation and chapter controls need not scrape generated HTML. The stable MDI classes (`mdi-ruby`, `mdi-tcy`, `mdi-em`, `mdi-pagebreak`, and related classes) are part of that semantic HTML.
 
@@ -50,6 +50,31 @@ Vite and other bundlers that honor the `browser` export condition select the
 web facade and emit its private WASM asset automatically. Do not import the
 generated wasm-pack loader directly. A failed browser initialization can be
 retried safely by calling `initializeMdi()` again.
+
+## Build a plaintext search index
+
+`getMdiTextBlocks(source)` parses once in Rust and returns source-order text
+blocks alongside the complete document IR and diagnostics. A position such as
+`3:18` means the eighteenth one-based Unicode grapheme in the third block.
+Ruby readings remain searchable annotations whose `anchor` points back to the
+base-text range.
+
+```ts
+import { getMdiTextBlocks, sourceSpansForTextRange } from "@illusions-lab/mdi";
+
+const result = getMdiTextBlocks("# 題\n\n{東京|とうきょう}");
+const paragraph = result.blocks[1];
+const match = { start: "2:1", end: "2:3" } as const;
+
+console.log(paragraph.text); // 東京
+console.log(paragraph.annotations[0].text); // とうきょう
+console.log(sourceSpansForTextRange(paragraph, match)); // UTF-8 source spans
+```
+
+`sourceMap.synthetic` identifies separators added by the projection, such as
+table tabs and row newlines; these deliberately produce no source span.
+`parseMdiTextPosition`, `formatMdiTextPosition`, and `formatMdiTextRange` are
+stateless helpers for the canonical coordinate spelling.
 
 ## Choose the export level
 

--- a/docs/src/content/docs/bindings/python.md
+++ b/docs/src/content/docs/bindings/python.md
@@ -69,7 +69,7 @@ There is currently **no `render_pdf`** in this binding — see "What this bindin
 
 ## Diagnostics and error handling
 
-Ordinary malformed MDI syntax never raises — it's handled by each construct's literal-fallback rule, exactly like every other binding, and `diagnostics` in the returned dict reports the one currently-implemented case (`mdi.version.unsupported`; see [Diagnostics](/core/diagnostics/)):
+Ordinary malformed MDI syntax never raises — it's handled by each construct's literal-fallback rule, exactly like every other binding. See [Diagnostics](/core/diagnostics/) for the complete warning list:
 
 ```python
 result = mdi.parse("---\nmdi: '3.0'\n---\n\n本文")

--- a/docs/src/content/docs/core/diagnostics.md
+++ b/docs/src/content/docs/core/diagnostics.md
@@ -20,7 +20,7 @@ Diagnostics live in the `diagnostics` array of a parse result — they are alway
 
 ## Every diagnostic code today
 
-There is currently exactly **one** diagnostic code implemented in `mdi-core`:
+There are currently **two** diagnostic codes implemented in `mdi-core`:
 
 ### `mdi.version.unsupported`
 
@@ -42,6 +42,19 @@ mdi: "2.1"
 ```
 
 Per `SYNTAX.md`, encountering a newer-than-supported version is a **SHOULD warn and continue**, never a **MUST reject** — parsing proceeds on a best-effort basis using the rules the parser knows, and the rest of the document still produces a normal tree alongside this one diagnostic.
+
+### `mdi.parser.recovered`
+
+- **Severity:** `warning`
+- **When it fires:** a malformed, frontmatter-shaped sequence would trigger an
+  upstream Markdown parser failure. MDI preserves the complete source as one
+  literal text block instead of failing or trapping in WebAssembly.
+- **Span:** the complete document.
+- **Message:** `"The parser recovered by projecting the source as literal text"`.
+
+This is a defensive recovery path, not a normal syntax diagnostic. Ordinary
+malformed inline MDI continues to use its construct-specific literal fallback
+without adding a diagnostic.
 
 :::caution[Current implementation status]
 The comparison `mdi-core` uses today is a plain **string** comparison (`declared > MDI_SPEC_VERSION`), not a semantic version comparison. This is correct for every realistic case while MDI is at a single digit `major.minor`, but note it is not semver-aware in general — e.g. `"2.10"` would compare as lexicographically *less than* `"2.9"`. This is a known limitation of the current implementation, not a documented part of the spec's version-comparison rule.

--- a/docs/src/content/docs/core/rust-api.md
+++ b/docs/src/content/docs/core/rust-api.md
@@ -46,7 +46,12 @@ This page lists only symbols present in [`mdi-core/src/lib.rs`](https://github.c
 
 ## Public data types
 
-`ParseOutput`, `ParserCapabilities`, `Diagnostic`, `DiagnosticSeverity`, `SourceSpan`, `Document`, `Frontmatter`, `FrontmatterEntry`, `PdfOptions`, `EpubCover`, `ResolvedExportProfile` and its nested profile/Chromium print types (current-generation API); `MdiSyntaxDocument`, `MdiBlock`, `PagebreakVariant`, `Inline`, `RubyReading` (the older, `parse_mdi_syntax`-only shape — `Inline`/`RubyReading` are also reused internally to build the current-generation `Document`'s MDI nodes, but their `serde` output is what appears inside `Document.children`, not `MdiSyntaxDocument`).
+`ParseOutput`, `ParserCapabilities`, `Diagnostic`, `DiagnosticSeverity`, `SourceSpan`, `Document`, `Frontmatter`, `FrontmatterEntry`, `MdiTextBlocksResult`, `MdiTextBlock`, `MdiTextPosition`, `MdiTextRange`, `MdiTextSourceMap`, `MdiTextSourceRun`, `MdiTextAnnotation`, `PdfOptions`, `EpubCover`, `ResolvedExportProfile` and its nested profile/Chromium print types (current-generation API); `MdiSyntaxDocument`, `MdiBlock`, `PagebreakVariant`, `Inline`, `RubyReading` (the older, `parse_mdi_syntax`-only shape — `Inline`/`RubyReading` are also reused internally to build the current-generation `Document`'s MDI nodes, but their `serde` output is what appears inside `Document.children`, not `MdiSyntaxDocument`).
+
+Use `get_mdi_text_blocks(source)` or `get_mdi_text_blocks_json(source)` for the
+Rust-owned plaintext search projection. It returns source-order blocks with
+one-based Unicode-grapheme positions, UTF-8 source-map boundaries, ruby reading
+annotations, and the same document/diagnostic envelope as `parse_output`.
 
 ## Not yet implemented
 

--- a/docs/src/content/docs/ja/bindings/javascript.md
+++ b/docs/src/content/docs/ja/bindings/javascript.md
@@ -26,7 +26,7 @@ console.log(result.output);   // <body> の semantic contents
 console.log(result.headings); // depth、text、span を持つ source-order headings
 ```
 
-`parse` は Rust-owned `document`、`diagnostics`、UTF-8 byte span を返します。現時点で実装済み diagnostic code は `mdi.version.unsupported` だけです。構文の誤りの多くは throw ではなく literal fallback になります。`prepareRender(source)` も parse-first 用です。`*WithDiagnostics` は output と同じ parser result を返しますが、warning を error に変えるものではありません。
+`parse` は Rust-owned `document`、`diagnostics`、UTF-8 byte span を返します。構文の誤りの多くは throw ではなく literal fallback になります。warning の全一覧は [Diagnostics](/ja/core/diagnostics/) を参照してください。`prepareRender(source)` も parse-first 用です。`*WithDiagnostics` は output と同じ parser result を返しますが、warning を error に変えるものではありません。
 
 `renderHtml(source)` は MDI stylesheet 付き standalone HTML を返します。app が外側の page を持つなら `{ bodyOnly: true }` を使います。semantic HTML は stable な `mdi-ruby`、`mdi-tcy`、`mdi-em`、`mdi-pagebreak` 等の class を付けます。
 
@@ -49,6 +49,30 @@ const canonical = serializeMdi("{東京|とうきょう} ^12^");
 private な WASM asset を自動で emit します。generated wasm-pack loader を直接
 import しないでください。browser の初期化が失敗しても、`initializeMdi()` を
 再度呼べば安全に retry できます。
+
+## プレーンテキスト検索 index
+
+`getMdiTextBlocks(source)` は Rust で一度だけ parse し、source order の text
+block、完全な document IR、diagnostics を返します。`3:18` は三つ目の block の
+十八番目の Unicode grapheme を表します。ruby の reading は別 channel の
+annotation として検索でき、`anchor` は base text の range を指します。
+
+```ts
+import { getMdiTextBlocks, sourceSpansForTextRange } from "@illusions-lab/mdi";
+
+const result = getMdiTextBlocks("# 題\n\n{東京|とうきょう}");
+const paragraph = result.blocks[1];
+const match = { start: "2:1", end: "2:3" } as const;
+
+console.log(paragraph.text); // 東京
+console.log(paragraph.annotations[0].text); // とうきょう
+console.log(sourceSpansForTextRange(paragraph, match)); // UTF-8 source span
+```
+
+`sourceMap.synthetic` は table の tab や row newline など projection が追加した
+separator を示し、source span は作りません。`parseMdiTextPosition`、
+`formatMdiTextPosition`、`formatMdiTextRange` は canonical な座標表記用の
+stateless helper です。
 
 ## baseline と設定付き EPUB/DOCX
 

--- a/docs/src/content/docs/ja/bindings/python.md
+++ b/docs/src/content/docs/ja/bindings/python.md
@@ -49,7 +49,7 @@ mdi.parse_mdi_syntax  # deprecated alias
 
 ## Diagnostic と error handling
 
-不正な MDI 記法は例外ではなく literal fallback と diagnostics で扱います。現在実装されている diagnostic は [唯一の `mdi.version.unsupported`](/ja/core/diagnostics/) です。non-string input は PyO3 により `TypeError`、未知の text format は `ValueError`、EPUB/DOCX archive writer の実際の失敗だけは `mdi.MdiRenderError` です。`mdi.parse()` を diagnostics の代わりに `try`/`except` で包まないでください。
+不正な MDI 記法は例外ではなく literal fallback と diagnostics で扱います。warning の全一覧は [Diagnostics](/ja/core/diagnostics/) を参照してください。non-string input は PyO3 により `TypeError`、未知の text format は `ValueError`、EPUB/DOCX archive writer の実際の失敗だけは `mdi.MdiRenderError` です。`mdi.parse()` を diagnostics の代わりに `try`/`except` で包まないでください。
 
 ```python
 mdi.parse(None)                              # TypeError

--- a/docs/src/content/docs/ja/core/diagnostics.md
+++ b/docs/src/content/docs/ja/core/diagnostics.md
@@ -15,7 +15,7 @@ Diagnostic は parse 結果の `diagnostics` 配列に入るデータで、例�
 
 ## 現在の全コード
 
-実装されているコードは一つだけです。
+実装されている code は二つです。
 
 ### `mdi.version.unsupported`
 
@@ -36,6 +36,19 @@ mdi: "2.1"
 ```
 
 これは warn して継続する仕様で、文書は通常どおり木になります。現在の `mdi-core` は semver ではなく文字列比較を使用します。従って一般には `"2.10" < "2.9"` となり得る、実装上の既知の制限です。invalid kerning や split-ruby segment の不一致などに別 diagnostic はありません。各構文の literal fallback が意図して text として扱います。
+
+### `mdi.parser.recovered`
+
+- severity: `warning`
+- malformed な frontmatter 風の並びが upstream Markdown parser の failure を
+  起こし得るときに出ます。MDI は failure や WebAssembly の trap にせず、source
+  全体を一つの literal text block として保持します。
+- span は document 全体です。
+- message は `The parser recovered by projecting the source as literal text` です。
+
+これは防御的な recovery path であり、通常の構文 diagnostic ではありません。
+通常の不正な MDI inline は従来どおり construct ごとの literal fallback になり、
+diagnostic は追加されません。
 
 ## Span
 

--- a/docs/src/content/docs/learn/core-concepts.md
+++ b/docs/src/content/docs/learn/core-concepts.md
@@ -66,7 +66,7 @@ A **diagnostic** reports a recoverable problem — it is a plain object in the `
 { "severity": "warning", "code": "mdi.version.unsupported", "message": "MDI 2.1 is newer than the supported 2.0", "span": { "startByte": 0, "endByte": 34 } }
 ```
 
-`parse()` almost never throws. Malformed or ambiguous MDI syntax (an unmatched `^`, a `[[kern:` with an invalid amount, mismatched ruby dot segments) is handled by the **literal-fallback rule** documented on each syntax page — the text is kept as-is in the tree, usually without even a diagnostic, because it's the same tolerant behavior Markdown itself has for unrecognized syntax. Exceptions are reserved for things a diagnostic can't describe: a non-string argument, or a native resource failure (e.g., no Chromium executable for PDF). See [Diagnostics and UTF-8 source spans](/core/diagnostics/) for the complete current list of diagnostic codes (today, exactly one).
+`parse()` almost never throws. Malformed or ambiguous MDI syntax (an unmatched `^`, a `[[kern:` with an invalid amount, mismatched ruby dot segments) is handled by the **literal-fallback rule** documented on each syntax page — the text is kept as-is in the tree, usually without even a diagnostic, because it's the same tolerant behavior Markdown itself has for unrecognized syntax. Exceptions are reserved for things a diagnostic can't describe: a non-string argument, or a native resource failure (e.g., no Chromium executable for PDF). See [Diagnostics and UTF-8 source spans](/core/diagnostics/) for the complete current list of diagnostic codes.
 
 ## 5. Capabilities describe *this* parse, not a promise about the future
 

--- a/docs/src/content/docs/zh-tw/bindings/javascript.md
+++ b/docs/src/content/docs/zh-tw/bindings/javascript.md
@@ -26,7 +26,7 @@ console.log(result.output);   // <body> 的 semantic contents
 console.log(result.headings); // source-order heading 的 depth、text、span
 ```
 
-`parse` 回傳 Rust-owned `document`、`diagnostics` 與 UTF-8 byte span。目前唯一已實作 diagnostic code 為 `mdi.version.unsupported`；多數格式錯誤採 literal fallback，不會 throw。`prepareRender(source)` 也適合 parse-first workflow。`*WithDiagnostics` 會保留 output 與 parser result，但不會自動把 warning 變成 error。
+`parse` 回傳 Rust-owned `document`、`diagnostics` 與 UTF-8 byte span。多數格式錯誤採 literal fallback，不會 throw；完整 warning 清單見[診斷](/zh-tw/core/diagnostics/)。`prepareRender(source)` 也適合 parse-first workflow。`*WithDiagnostics` 會保留 output 與 parser result，但不會自動把 warning 變成 error。
 
 `renderHtml(source)` 回傳含 MDI stylesheet 的 standalone HTML；app 擁有外層頁面時傳 `{ bodyOnly: true }`。semantic HTML 有穩定的 `mdi-ruby`、`mdi-tcy`、`mdi-em`、`mdi-pagebreak` 等 class。
 
@@ -47,6 +47,29 @@ const canonical = serializeMdi("{東京|とうきょう} ^12^");
 Vite 與其他遵循 `browser` export condition 的 bundler 會自動選擇 web facade 並
 emit 私有 WASM asset。不要直接 import generated wasm-pack loader。若 browser
 初始化失敗，可再次呼叫 `initializeMdi()` 安全地重試。
+
+## 建立純文字搜尋索引
+
+`getMdiTextBlocks(source)` 只在 Rust parse 一次，回傳依 source order 排列的 text
+blocks、完整 document IR 與 diagnostics。`3:18` 表示第三個 block 的第十八個
+Unicode grapheme。Ruby 讀音會作為可搜尋的獨立 annotation channel，而 `anchor`
+仍指回正文 base text 的 range。
+
+```ts
+import { getMdiTextBlocks, sourceSpansForTextRange } from "@illusions-lab/mdi";
+
+const result = getMdiTextBlocks("# 題\n\n{東京|とうきょう}");
+const paragraph = result.blocks[1];
+const match = { start: "2:1", end: "2:3" } as const;
+
+console.log(paragraph.text); // 東京
+console.log(paragraph.annotations[0].text); // とうきょう
+console.log(sourceSpansForTextRange(paragraph, match)); // UTF-8 source spans
+```
+
+`sourceMap.synthetic` 指出 projection 額外加入的 separator，例如 table 的 tab 與
+row newline；它們不會偽造 source span。`parseMdiTextPosition`、
+`formatMdiTextPosition`、`formatMdiTextRange` 是 canonical 座標格式的無狀態 helper。
 
 ## baseline 與可設定 EPUB/DOCX
 

--- a/docs/src/content/docs/zh-tw/bindings/python.md
+++ b/docs/src/content/docs/zh-tw/bindings/python.md
@@ -61,7 +61,7 @@ mdi.parse_mdi_syntax  # deprecated alias
 
 ## 診斷與錯誤處理
 
-一般格式不正確的 MDI 不會 raise，而以 literal fallback 處理；回傳 dict 的 `diagnostics` 唯一已實作 code 是 `mdi.version.unsupported`（見[診斷](/zh-tw/core/diagnostics/)）：
+一般格式不正確的 MDI 不會 raise，而以 literal fallback 處理；回傳 dict 的 `diagnostics` warning 完整清單見[診斷](/zh-tw/core/diagnostics/)：
 
 ```python
 result = mdi.parse("---\nmdi: '3.0'\n---\n\n本文")

--- a/docs/src/content/docs/zh-tw/core/diagnostics.md
+++ b/docs/src/content/docs/zh-tw/core/diagnostics.md
@@ -15,7 +15,7 @@ interface MdiDiagnostic { severity: "warning" | "error"; code: string; message: 
 
 ## 今天所有 diagnostic code
 
-`mdi-core` 目前只有**一個** diagnostic code：
+`mdi-core` 目前有**兩個** diagnostic code：
 
 ### `mdi.version.unsupported`
 
@@ -37,6 +37,17 @@ mdi: "2.1"
 ```
 
 依 `SYNTAX.md`，遇到高於支援版本時是**SHOULD 警告並繼續**，絕非 **MUST 拒絕**；parser 以已知規則盡力處理，仍產出正常 tree 與此 diagnostic。
+
+### `mdi.parser.recovered`
+
+- **Severity：**`warning`
+- **觸發時機：**畸形的 frontmatter 樣式序列可能使上游 Markdown parser failure。
+  MDI 會把完整 source 保留為一個 literal text block，而非失敗或讓 WebAssembly trap。
+- **Span：**整份 document。
+- **Message：**`"The parser recovered by projecting the source as literal text"`。
+
+這是防禦性的 recovery path，不是一般構文 diagnostic。一般格式不正確的 MDI
+inline 仍依各 construct 的 literal fallback 處理，不會額外加入 diagnostic。
 
 :::caution[目前實作狀態]
 `mdi-core` 現在使用一般**字串**比較（`declared > MDI_SPEC_VERSION`），不是 semantic-version 比較。當 MDI 維持單位數 `major.minor` 時實際案例都正確，但一般而言不具 semver awareness，例如 `"2.10"` 在字典序會小於 `"2.9"`。這是目前實作限制，並非規範的 version-comparison rule。

--- a/docs/src/content/docs/zh-tw/learn/core-concepts.md
+++ b/docs/src/content/docs/zh-tw/learn/core-concepts.md
@@ -66,7 +66,7 @@ description: 文法、IR、span、診斷、capabilities ―― 每個 MDI 接口
 { "severity": "warning", "code": "mdi.version.unsupported", "message": "MDI 2.1 is newer than the supported 2.0", "span": { "startByte": 0, "endByte": 34 } }
 ```
 
-`parse()` 幾乎不會丟例外。錯誤或有歧義的 MDI 語法（沒配對的 `^`、無效數值的 `[[kern:`、對不上的 ruby 分割點）都由每個構文自己的**純文字退回規則**處理（見[完整語法參考](/zh-tw/syntax/reference/)各節），通常連診斷都不會產生 ―— 這跟 Markdown 本身處理未知語法的寬容作法一致：保留成文字，別讓整份文件失敗。例外只保留給診斷描述不了的狀況：引數不是字串，或原生資源失敗（例如找不到 PDF 用的 Chromium）。目前完整的診斷代碼列表（目前恰好一個）請見[診斷與 UTF-8 原始碼 span](/zh-tw/core/diagnostics/)。
+`parse()` 幾乎不會丟例外。錯誤或有歧義的 MDI 語法（沒配對的 `^`、無效數值的 `[[kern:`、對不上的 ruby 分割點）都由每個構文自己的**純文字退回規則**處理（見[完整語法參考](/zh-tw/syntax/reference/)各節），通常連診斷都不會產生 ―— 這跟 Markdown 本身處理未知語法的寬容作法一致：保留成文字，別讓整份文件失敗。例外只保留給診斷描述不了的狀況：引數不是字串，或原生資源失敗（例如找不到 PDF 用的 Chromium）。完整的診斷代碼列表請見[診斷與 UTF-8 原始碼 span](/zh-tw/core/diagnostics/)。
 
 ## 5. capabilities 描述的是「這一次剖析」，不是對未來的承諾
 

--- a/mdi-core/Cargo.lock
+++ b/mdi-core/Cargo.lock
@@ -18,6 +18,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitflags"
+version = "2.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -82,6 +109,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -90,6 +133,12 @@ dependencies = [
  "crc32fast",
  "miniz_oxide",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "futures-core"
@@ -113,6 +162,29 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
 ]
 
 [[package]]
@@ -149,6 +221,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "libc"
+version = "0.2.189"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -166,10 +250,11 @@ dependencies = [
 
 [[package]]
 name = "mdi-core"
-version = "2.0.5"
+version = "2.0.6"
 dependencies = [
  "js-sys",
  "markdown",
+ "proptest",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -202,6 +287,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -220,6 +314,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -227,6 +330,31 @@ checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
@@ -238,10 +366,91 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -340,6 +549,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -391,6 +613,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-id"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -413,6 +641,24 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -457,6 +703,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/mdi-core/Cargo.toml
+++ b/mdi-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mdi-core"
-version = "2.0.5"
+version = "2.0.6"
 description = "Language-neutral parser for MDI 2.0 syntax"
 edition = "2024"
 rust-version = "1.85"
@@ -24,6 +24,9 @@ unicode-segmentation = "1.12.0"
 zip = { version = "2.2", default-features = false, features = ["deflate"] }
 wasm-bindgen = { version = "0.2", optional = true }
 js-sys = { version = "0.3", optional = true }
+
+[dev-dependencies]
+proptest = "1.7"
 
 [features]
 wasm = ["dep:wasm-bindgen", "dep:js-sys"]

--- a/mdi-core/README.md
+++ b/mdi-core/README.md
@@ -26,6 +26,10 @@ let html = render_html(source);
 ```
 
 Use `parse_output` when you also need parser capabilities and diagnostics.
+Use `get_mdi_text_blocks` when a search or annotation index needs source-order
+plaintext blocks with one-based Unicode-grapheme coordinates and exact UTF-8
+source maps. The result includes the same document IR and diagnostics, and the
+source is parsed only once.
 When rendering one parsed document in multiple formats, use the
 `*_document` functions, such as `render_html_document`, to avoid parsing it
 again.

--- a/mdi-core/src/lib.rs
+++ b/mdi-core/src/lib.rs
@@ -17,12 +17,18 @@ use zip::{CompressionMethod, ZipWriter, write::SimpleFileOptions};
 
 mod docx;
 mod publication_profile;
+mod text_projection;
 pub use publication_profile::{
     ChromiumPrintPage, ChromiumPrintPageNumbers, ChromiumPrintProfile, Margins, PageNumbers,
     PageSizeDimensions, ResolvedEpub, ResolvedExportProfile, ResolvedLayout, ResolvedPagination,
     ResolvedText, ResolvedTypesetting, apply_pdf_profile, apply_pdf_profile_json, page_dimensions,
     page_size_catalog_json, prepare_chromium_print_profile, prepare_chromium_print_profile_json,
     prepare_chromium_print_profile_resolved, resolve_export_profile, resolve_export_profile_json,
+};
+pub use text_projection::{
+    MDI_TEXT_PROJECTION_VERSION, MdiAnnotationSourceMap, MdiTextAnnotation, MdiTextBlock,
+    MdiTextBlockKind, MdiTextBlocksResult, MdiTextPosition, MdiTextRange, MdiTextSourceMap,
+    MdiTextSourceRun, get_mdi_text_blocks, get_mdi_text_blocks_json,
 };
 
 /// MDI syntax version implemented by this crate.
@@ -276,15 +282,33 @@ pub fn parse_mdi_syntax(source: &str) -> MdiSyntaxDocument {
 /// parsed by `markdown-rs`; MDI is then lowered into the same tagged tree in
 /// Rust.  The host never tokenizes Markdown or MDI.
 pub fn parse_document(source: &str) -> Document {
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        parse_document_unchecked(source)
+    }))
+    .unwrap_or_else(|_| literal_fallback_document(source))
+}
+
+fn parse_document_unchecked(source: &str) -> Document {
+    // markdown-rs 1.0 can corrupt its mdast parent stack when a document
+    // contains a second frontmatter-shaped fence later in the body. On Wasm,
+    // that panic aborts before `catch_unwind` can recover, so reject this
+    // malformed shape before entering the dependency and preserve it literally.
+    if has_late_frontmatter_like_block(source) {
+        return literal_fallback_document(source);
+    }
     let prepared = prepare_block_markers(source);
     let mut constructs = markdown::Constructs::gfm();
-    constructs.frontmatter = true;
+    // `markdown-rs`' frontmatter state machine is only relevant when a YAML
+    // fence starts the document. Enabling it for arbitrary later `---` lines
+    // can panic on malformed combinations instead of returning an error.
+    constructs.frontmatter = source.starts_with("---\n") || source.starts_with("---\r\n");
     let options = markdown::ParseOptions {
         constructs,
         ..markdown::ParseOptions::default()
     };
-    let tree = markdown::to_mdast(&prepared.markdown, &options)
-        .expect("MDI does not enable MDX, so Markdown parsing cannot fail");
+    let Ok(tree) = markdown::to_mdast(&prepared.markdown, &options) else {
+        return literal_fallback_document(source);
+    };
     let mut root = serde_json::to_value(tree).expect("markdown AST is serializable");
     let frontmatter = extract_frontmatter(&root, source);
     annotate_and_lower(&mut root, source, false);
@@ -308,6 +332,73 @@ pub fn parse_document(source: &str) -> Document {
             end_byte: source.len() as u32,
         },
         frontmatter,
+        children,
+    }
+}
+
+fn has_late_frontmatter_like_block(source: &str) -> bool {
+    let mut lines = Vec::new();
+    let mut offset = 0;
+    for line in source.split_inclusive('\n') {
+        let without_lf = line.strip_suffix('\n').unwrap_or(line);
+        let content = without_lf.strip_suffix('\r').unwrap_or(without_lf);
+        lines.push((offset, content));
+        offset += line.len();
+    }
+    if offset < source.len() {
+        lines.push((offset, &source[offset..]));
+    }
+
+    let mut index = 0;
+    let mut frontmatter_blocks = 0;
+    while index < lines.len() {
+        if lines[index].1 != "---" {
+            index += 1;
+            continue;
+        }
+        let Some(close) = (index + 1..lines.len()).find(|candidate| lines[*candidate].1 == "---")
+        else {
+            break;
+        };
+        let yaml_like = lines[index + 1..close].iter().any(|(_, line)| {
+            line.split_once(':').is_some_and(|(key, _)| {
+                !key.is_empty()
+                    && key.chars().all(|character| {
+                        character.is_ascii_alphanumeric() || "_-".contains(character)
+                    })
+            })
+        });
+        if yaml_like {
+            frontmatter_blocks += 1;
+            if lines[index].0 != 0 || frontmatter_blocks > 1 {
+                return true;
+            }
+            index = close + 1;
+        } else {
+            index += 1;
+        }
+    }
+    false
+}
+
+fn literal_fallback_document(source: &str) -> Document {
+    let span = SourceSpan {
+        start_byte: 0,
+        end_byte: source.len() as u32,
+    };
+    let children = if source.is_empty() {
+        Vec::new()
+    } else {
+        vec![serde_json::json!({
+            "type": "paragraph",
+            "children": [{ "type": "text", "value": source, "span": span }],
+            "span": span,
+            "_mdiParserRecovery": true,
+        })]
+    };
+    Document {
+        span,
+        frontmatter: None,
         children,
     }
 }
@@ -821,15 +912,24 @@ fn annotate_and_lower(node: &mut serde_json::Value, source: &str, protected: boo
     // still recognize the decoded spelling (notably `\|` inside a GFM table
     // cell), but its spans must refer to the original bytes.  Keep a mapping
     // from decoded byte boundaries back to the source range for that case.
-    let source_offsets = span
+    let raw_source = span
         .as_ref()
-        .and_then(|span| source.get(span.start_byte as usize..span.end_byte as usize))
-        .and_then(|raw| decoded_byte_offsets(rendered_value, raw));
-    if !looks_like_mdi(rendered_value) {
+        .and_then(|span| source.get(span.start_byte as usize..span.end_byte as usize));
+    let source_offsets = raw_source.and_then(|raw| decoded_byte_offsets(rendered_value, raw));
+    let raw_parts = raw_source
+        .filter(|raw| *raw != rendered_value && source_offsets.is_some() && looks_like_mdi(raw))
+        .map(parse_document_inline_parts)
+        .filter(|parts| {
+            parts
+                .iter()
+                .any(|(inline, _, _)| matches!(inline, Inline::Ruby { .. }))
+        });
+    if !looks_like_mdi(rendered_value) && raw_parts.is_none() {
         return;
     }
     let span = object.get("span").cloned();
-    let parsed = parse_inline_parts(rendered_value);
+    let parsing_raw = raw_parts.is_some();
+    let parsed = raw_parts.unwrap_or_else(|| parse_inline_parts(rendered_value));
     if let Some((Inline::Text(value), _, _)) = parsed.first()
         && parsed.len() == 1
         && value == rendered_value
@@ -845,14 +945,22 @@ fn annotate_and_lower(node: &mut serde_json::Value, source: &str, protected: boo
                     .get("startByte")
                     .and_then(serde_json::Value::as_u64);
                 if let Some(start_byte) = start_byte {
-                    let start = source_offsets
-                        .as_ref()
-                        .and_then(|offsets| source_offset(offsets, start))
-                        .unwrap_or(start);
-                    let end = source_offsets
-                        .as_ref()
-                        .and_then(|offsets| source_offset(offsets, end))
-                        .unwrap_or(end);
+                    let start = if parsing_raw {
+                        start
+                    } else {
+                        source_offsets
+                            .as_ref()
+                            .and_then(|offsets| source_offset(offsets, start))
+                            .unwrap_or(start)
+                    };
+                    let end = if parsing_raw {
+                        end
+                    } else {
+                        source_offsets
+                            .as_ref()
+                            .and_then(|offsets| source_offset(offsets, end))
+                            .unwrap_or(end)
+                    };
                     object.insert(
                         "span".to_owned(),
                         serde_json::json!(SourceSpan {
@@ -910,6 +1018,19 @@ fn extract_frontmatter(root: &serde_json::Value, source: &str) -> Option<Frontma
 }
 
 fn diagnostics(document: &Document) -> Vec<Diagnostic> {
+    if document.children.iter().any(|child| {
+        child
+            .get("_mdiParserRecovery")
+            .and_then(serde_json::Value::as_bool)
+            == Some(true)
+    }) {
+        return vec![Diagnostic {
+            severity: DiagnosticSeverity::Warning,
+            code: "mdi.parser.recovered".to_owned(),
+            message: "The parser recovered by projecting the source as literal text".to_owned(),
+            span: Some(document.span),
+        }];
+    }
     let Some(frontmatter) = document.frontmatter.as_ref() else {
         return Vec::new();
     };
@@ -2157,22 +2278,6 @@ fn render_text_node(node: &serde_json::Value, out: &mut String) {
         .and_then(serde_json::Value::as_str)
         .unwrap_or_default()
     {
-        "text" | "inlineCode" | "code" | "html" | "tcy" => out.push_str(
-            node.get("value")
-                .and_then(serde_json::Value::as_str)
-                .unwrap_or_default(),
-        ),
-        "ruby" => out.push_str(
-            node.get("base")
-                .and_then(serde_json::Value::as_str)
-                .unwrap_or_default(),
-        ),
-        "image" => out.push_str(
-            node.get("alt")
-                .and_then(serde_json::Value::as_str)
-                .unwrap_or_default(),
-        ),
-        "break" => out.push('\n'),
         "blank" => out.push('\n'),
         "pagebreak" => out.push_str("\n\x0C\n"),
         "heading" | "paragraph" | "blockquote" | "listItem" | "tableRow" => {
@@ -2183,7 +2288,12 @@ fn render_text_node(node: &serde_json::Value, out: &mut String) {
             render_text_children(node, out);
             out.push('\t');
         }
-        _ => render_text_children(node, out),
+        _ => match text_projection::plain_inline(node) {
+            text_projection::PlainInline::Value(value) => out.push_str(value),
+            text_projection::PlainInline::Break => out.push('\n'),
+            text_projection::PlainInline::Skip => {}
+            text_projection::PlainInline::Children => render_text_children(node, out),
+        },
     }
 }
 
@@ -3386,10 +3496,21 @@ pub fn parse_inlines(source: &str) -> Vec<Inline> {
         .collect()
 }
 
+fn parse_document_inline_parts(source: &str) -> Vec<(Inline, usize, usize)> {
+    parse_inline_parts_with(source, true)
+}
+
 /// Parse MDI inline syntax and retain each node's raw byte range relative to
 /// `source`.  Escaped text deliberately retains the range of its spelling in
 /// the source even when its rendered value is shorter.
 fn parse_inline_parts(source: &str) -> Vec<(Inline, usize, usize)> {
+    parse_inline_parts_with(source, false)
+}
+
+fn parse_inline_parts_with(
+    source: &str,
+    decode_commonmark_escapes: bool,
+) -> Vec<(Inline, usize, usize)> {
     let mut out = Vec::new();
     let mut text = String::new();
     let mut text_start = 0;
@@ -3405,7 +3526,7 @@ fn parse_inline_parts(source: &str) -> Vec<(Inline, usize, usize)> {
                 index += slash.len_utf8();
                 continue;
             };
-            if is_escapable(next) {
+            if is_escapable(next) || (decode_commonmark_escapes && next.is_ascii_punctuation()) {
                 text.push(next);
             } else {
                 text.push(slash);
@@ -3864,10 +3985,11 @@ fn classify_block_macro(source: &str) -> BlockMacroClass {
 mod wasm {
     use super::{
         BlockMacroClass, EpubCover, PagebreakVariant, RubyReading, TextFormat,
-        apply_pdf_profile_json, classify_block_macro, page_size_catalog_json, parse_json,
-        prepare_chromium_print_profile_json, render_docx, render_docx_with_profile, render_epub,
-        render_epub_with_profile, render_html, render_text, render_text_format,
-        resolve_export_profile_json, serialize_mdi, split_ruby, unescape_mdi, unescape_ruby,
+        apply_pdf_profile_json, classify_block_macro, get_mdi_text_blocks_json,
+        page_size_catalog_json, parse_json, prepare_chromium_print_profile_json, render_docx,
+        render_docx_with_profile, render_epub, render_epub_with_profile, render_html, render_text,
+        render_text_format, resolve_export_profile_json, serialize_mdi, split_ruby, unescape_mdi,
+        unescape_ruby,
     };
     use wasm_bindgen::prelude::*;
 
@@ -3877,6 +3999,12 @@ mod wasm {
     #[wasm_bindgen(js_name = parseMdiSyntaxJson)]
     pub fn wasm_parse_mdi_syntax_json(source: &str) -> String {
         parse_json(source)
+    }
+
+    /// Project source-order searchable text and exact UTF-8 source maps in Rust.
+    #[wasm_bindgen(js_name = getMdiTextBlocksJson)]
+    pub fn wasm_get_mdi_text_blocks_json(source: &str) -> String {
+        get_mdi_text_blocks_json(source)
     }
 
     /// Render source through the Rust parser and Rust HTML renderer.

--- a/mdi-core/src/text_projection.rs
+++ b/mdi-core/src/text_projection.rs
@@ -1,0 +1,1441 @@
+use crate::{
+    Diagnostic, DiagnosticSeverity, Document, MDI_IR_VERSION, MDI_SPEC_VERSION, ParserCapabilities,
+    SourceSpan, diagnostics, parse_document,
+};
+use serde::Serialize;
+use unicode_segmentation::UnicodeSegmentation;
+
+pub(crate) enum PlainInline<'a> {
+    Value(&'a str),
+    Break,
+    Skip,
+    Children,
+}
+
+/// The single plaintext rule table used by both `render_text` and the mapped
+/// block projection. Source-map construction is layered on top of this value.
+pub(crate) fn plain_inline(node: &serde_json::Value) -> PlainInline<'_> {
+    match node_type(node) {
+        "text" | "inlineCode" | "code" | "html" | "tcy" => PlainInline::Value(
+            node.get("value")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or_default(),
+        ),
+        "ruby" => PlainInline::Value(
+            node.get("base")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or_default(),
+        ),
+        "image" => PlainInline::Value(
+            node.get("alt")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or_default(),
+        ),
+        "break" => PlainInline::Break,
+        "footnoteReference" => PlainInline::Skip,
+        _ if node.get("children").is_some() => PlainInline::Children,
+        _ => node
+            .get("value")
+            .and_then(serde_json::Value::as_str)
+            .map_or(PlainInline::Skip, PlainInline::Value),
+    }
+}
+
+pub const MDI_TEXT_PROJECTION_VERSION: &str = "1.0";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MdiTextBlocksResult {
+    pub projection_version: &'static str,
+    pub position_encoding: &'static str,
+    pub ir_version: &'static str,
+    pub syntax_version: &'static str,
+    pub capabilities: ParserCapabilities,
+    pub blocks: Vec<MdiTextBlock>,
+    pub document: Document,
+    pub diagnostics: Vec<Diagnostic>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MdiTextBlock {
+    pub index: u32,
+    pub kind: MdiTextBlockKind,
+    pub text: String,
+    pub range: MdiTextRange,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub span: Option<SourceSpan>,
+    pub source_map: MdiTextSourceMap,
+    pub annotations: Vec<MdiTextAnnotation>,
+    pub node: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum MdiTextBlockKind {
+    Heading,
+    Paragraph,
+    ListItem,
+    Blockquote,
+    Code,
+    Table,
+    Footnote,
+    Html,
+    Other,
+}
+
+/// A one-based block/Unicode-grapheme position, serialized as `3:18`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MdiTextPosition {
+    pub block: u32,
+    pub character: u32,
+}
+
+impl Serialize for MdiTextPosition {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&format!("{}:{}", self.block, self.character))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct MdiTextRange {
+    pub start: MdiTextPosition,
+    pub end: MdiTextPosition,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize)]
+pub struct MdiTextSourceMap {
+    pub runs: Vec<MdiTextSourceRun>,
+    pub synthetic: Vec<MdiTextRange>,
+    pub unmapped: Vec<MdiTextRange>,
+}
+
+/// Annotation text uses the containing block number and its own one-based
+/// character offsets. This keeps the run format identical in both channels.
+pub type MdiAnnotationSourceMap = MdiTextSourceMap;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MdiTextSourceRun {
+    pub range: MdiTextRange,
+    pub source_boundaries: Vec<u32>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MdiTextAnnotation {
+    pub kind: &'static str,
+    pub text: String,
+    pub anchor: MdiTextRange,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub span: Option<SourceSpan>,
+    pub source_map: MdiAnnotationSourceMap,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum UnitMap {
+    Mapped(SourceSpan),
+    Synthetic,
+    Unmapped,
+}
+
+struct AnnotationDraft {
+    text: String,
+    anchor_start: usize,
+    anchor_end: usize,
+    span: Option<SourceSpan>,
+    units: Vec<UnitMap>,
+}
+
+struct BlockDraft {
+    kind: MdiTextBlockKind,
+    text: String,
+    units: Vec<UnitMap>,
+    unit_texts: Vec<String>,
+    annotations: Vec<AnnotationDraft>,
+    span: Option<SourceSpan>,
+    node: serde_json::Value,
+    mapping_warning: bool,
+    source_cursor: u32,
+    source_end: u32,
+}
+
+impl BlockDraft {
+    fn new(kind: MdiTextBlockKind, node: &serde_json::Value) -> Self {
+        let span = node_span(node);
+        Self {
+            kind,
+            text: String::new(),
+            units: Vec::new(),
+            unit_texts: Vec::new(),
+            annotations: Vec::new(),
+            span,
+            node: node.clone(),
+            mapping_warning: false,
+            source_cursor: span.map_or(0, |span| span.start_byte),
+            source_end: span.map_or(0, |span| span.end_byte),
+        }
+    }
+
+    fn grapheme_len(&self) -> usize {
+        self.text.graphemes(true).count()
+    }
+
+    fn append_synthetic(&mut self, value: &str) {
+        self.text.push_str(value);
+        for grapheme in value.graphemes(true) {
+            self.unit_texts.push(grapheme.to_owned());
+            self.units.push(UnitMap::Synthetic);
+        }
+    }
+
+    fn append_unmapped(&mut self, value: &str) {
+        if value.is_empty() {
+            return;
+        }
+        self.text.push_str(value);
+        for grapheme in value.graphemes(true) {
+            self.unit_texts.push(grapheme.to_owned());
+            self.units.push(UnitMap::Unmapped);
+        }
+        self.mapping_warning = true;
+    }
+
+    fn append_mapped(&mut self, value: &str, spans: Option<Vec<SourceSpan>>) {
+        if value.is_empty() {
+            return;
+        }
+        let count = value.graphemes(true).count();
+        match spans {
+            Some(spans) if spans.len() == count => {
+                self.text.push_str(value);
+                for (grapheme, span) in value.graphemes(true).zip(spans) {
+                    self.unit_texts.push(grapheme.to_owned());
+                    self.units.push(UnitMap::Mapped(span));
+                }
+            }
+            _ => self.append_unmapped(value),
+        }
+    }
+}
+
+struct Collector<'a> {
+    source: &'a str,
+    blocks: Vec<MdiTextBlock>,
+    diagnostics: Vec<Diagnostic>,
+}
+
+/// Parse once and produce the complete IR envelope plus the Rust-owned text
+/// projection and its UTF-8 source map.
+pub fn get_mdi_text_blocks(source: &str) -> MdiTextBlocksResult {
+    let document = parse_document(source);
+    let mut collector = Collector {
+        source,
+        blocks: Vec::new(),
+        diagnostics: diagnostics(&document),
+    };
+    for node in &document.children {
+        collector.collect(node, false);
+    }
+    MdiTextBlocksResult {
+        projection_version: MDI_TEXT_PROJECTION_VERSION,
+        position_encoding: "unicode-grapheme-cluster-1-based",
+        ir_version: MDI_IR_VERSION,
+        syntax_version: MDI_SPEC_VERSION,
+        capabilities: ParserCapabilities {
+            mdi: true,
+            common_mark: true,
+            gfm: true,
+            front_matter: true,
+            source_spans: true,
+        },
+        blocks: collector.blocks,
+        document,
+        diagnostics: collector.diagnostics,
+    }
+}
+
+pub fn get_mdi_text_blocks_json(source: &str) -> String {
+    serde_json::to_string(&get_mdi_text_blocks(source))
+        .expect("serializing the MDI text projection cannot fail")
+}
+
+impl Collector<'_> {
+    fn collect(&mut self, node: &serde_json::Value, quoted: bool) {
+        let kind = node_type(node);
+        match kind {
+            "heading" => self.inline_block(MdiTextBlockKind::Heading, node),
+            "paragraph" => self.inline_block(
+                if quoted {
+                    MdiTextBlockKind::Blockquote
+                } else {
+                    MdiTextBlockKind::Paragraph
+                },
+                node,
+            ),
+            "blockquote" => {
+                for child in children(node) {
+                    self.collect(child, true);
+                }
+            }
+            "list" => {
+                for child in children(node) {
+                    self.collect(child, quoted);
+                }
+            }
+            "listItem" => self.list_item(node, quoted),
+            "code" => self.scalar_block(MdiTextBlockKind::Code, node, "value"),
+            "html" => self.scalar_block(MdiTextBlockKind::Html, node, "value"),
+            "table" => self.table(node),
+            "footnoteDefinition" => self.footnote(node),
+            "yaml" | "definition" | "blank" | "pagebreak" | "thematicBreak" => {}
+            _ => {
+                if node_span(node).is_some() {
+                    let mut draft = BlockDraft::new(MdiTextBlockKind::Other, node);
+                    self.project_inline(node, &mut draft);
+                    self.finish(draft);
+                }
+            }
+        }
+    }
+
+    fn inline_block(&mut self, kind: MdiTextBlockKind, node: &serde_json::Value) {
+        let mut draft = BlockDraft::new(kind, node);
+        self.project_children(node, &mut draft);
+        self.finish(draft);
+    }
+
+    fn scalar_block(&mut self, kind: MdiTextBlockKind, node: &serde_json::Value, field: &str) {
+        let mut draft = BlockDraft::new(kind, node);
+        if let Some(value) = node.get(field).and_then(serde_json::Value::as_str) {
+            // markdown-rs preserves the source line ending inside fenced code.
+            // Projection coordinates use a single `\n` text unit regardless of
+            // whether that unit came from LF or CRLF source bytes.
+            let normalized;
+            let value = if kind == MdiTextBlockKind::Code && value.contains('\r') {
+                normalized = value.replace("\r\n", "\n").replace('\r', "\n");
+                normalized.as_str()
+            } else {
+                value
+            };
+            let spans = if kind == MdiTextBlockKind::Code {
+                self.map_code_block(value, &mut draft)
+            } else {
+                self.map_value_in_block(value, &mut draft)
+            };
+            draft.append_mapped(value, spans);
+        }
+        self.finish(draft);
+    }
+
+    fn list_item(&mut self, node: &serde_json::Value, quoted: bool) {
+        let paragraphs: Vec<_> = children(node)
+            .filter(|child| node_type(child) == "paragraph")
+            .collect();
+        if !paragraphs.is_empty() {
+            let mut draft = BlockDraft::new(MdiTextBlockKind::ListItem, node);
+            for (index, paragraph) in paragraphs.into_iter().enumerate() {
+                if index > 0 {
+                    draft.append_synthetic("\n\n");
+                }
+                self.project_children(paragraph, &mut draft);
+            }
+            self.finish(draft);
+        }
+        for child in children(node) {
+            if node_type(child) != "paragraph" {
+                self.collect(child, quoted);
+            }
+        }
+    }
+
+    fn footnote(&mut self, node: &serde_json::Value) {
+        let mut draft = BlockDraft::new(MdiTextBlockKind::Footnote, node);
+        for (index, child) in children(node).enumerate() {
+            if index > 0 {
+                draft.append_synthetic("\n\n");
+            }
+            if node_type(child) == "paragraph" {
+                self.project_children(child, &mut draft);
+            } else {
+                self.project_inline(child, &mut draft);
+            }
+        }
+        self.finish(draft);
+    }
+
+    fn table(&mut self, node: &serde_json::Value) {
+        let mut draft = BlockDraft::new(MdiTextBlockKind::Table, node);
+        for (row_index, row) in children(node).enumerate() {
+            if row_index > 0 {
+                draft.append_synthetic("\n");
+            }
+            for (cell_index, cell) in children(row).enumerate() {
+                if cell_index > 0 {
+                    draft.append_synthetic("\t");
+                }
+                self.project_children(cell, &mut draft);
+            }
+        }
+        self.finish(draft);
+    }
+
+    fn project_children(&mut self, node: &serde_json::Value, draft: &mut BlockDraft) {
+        for child in children(node) {
+            self.project_inline(child, draft);
+        }
+    }
+
+    fn project_inline(&mut self, node: &serde_json::Value, draft: &mut BlockDraft) {
+        match plain_inline(node) {
+            PlainInline::Value(value) => {
+                if node_type(node) == "ruby" {
+                    self.project_ruby(node, draft);
+                    return;
+                }
+                let spans = match node_type(node) {
+                    "tcy" => self.map_delimited_in_block(value, &mut *draft, '^', '^'),
+                    "image" => self.map_image_in_block(value, draft),
+                    "inlineCode" => self.map_inline_code_in_block(value, draft),
+                    _ => self.map_value_from_node(value, node, draft),
+                };
+                draft.append_mapped(value, spans);
+            }
+            PlainInline::Break => {
+                let spans = self.map_break_in_block(draft);
+                draft.append_mapped("\n", spans);
+            }
+            PlainInline::Skip => {}
+            PlainInline::Children => {
+                self.project_children(node, draft);
+                self.advance_after_container(node, draft);
+            }
+        }
+    }
+
+    fn project_ruby(&mut self, node: &serde_json::Value, draft: &mut BlockDraft) {
+        let base = node
+            .get("base")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_default();
+        let base_start = draft.grapheme_len();
+        let reading_value = node
+            .pointer("/ruby/value")
+            .map(|value| match value {
+                serde_json::Value::String(value) => value.clone(),
+                serde_json::Value::Array(values) => values
+                    .iter()
+                    .filter_map(serde_json::Value::as_str)
+                    .collect::<String>(),
+                _ => String::new(),
+            })
+            .unwrap_or_default();
+        let parts = find_ruby_parts(
+            base,
+            &reading_value,
+            self.source,
+            draft.source_cursor,
+            draft.source_end,
+        );
+        if let Some(parts) = &parts {
+            draft.source_cursor = parts.token_end;
+        }
+        let base_spans = parts
+            .as_ref()
+            .and_then(|parts| map_decoded(base, parts.base, parts.base_start));
+        draft.append_mapped(base, base_spans);
+        let base_end = draft.grapheme_len();
+
+        let ruby = node.get("ruby");
+        let ruby_type = ruby
+            .and_then(|value| value.get("type"))
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("group");
+        if ruby_type == "split" {
+            let readings = ruby
+                .and_then(|value| value.get("value"))
+                .and_then(serde_json::Value::as_array);
+            if let Some(readings) = readings {
+                let raw_parts = parts.as_ref().map(|value| split_raw_reading(value));
+                for (index, reading) in readings
+                    .iter()
+                    .filter_map(serde_json::Value::as_str)
+                    .enumerate()
+                {
+                    let raw = raw_parts.as_ref().and_then(|parts| parts.get(index));
+                    let units = annotation_units(reading, raw.copied());
+                    draft.annotations.push(AnnotationDraft {
+                        text: reading.to_owned(),
+                        anchor_start: base_start + index,
+                        anchor_end: base_start + index + 1,
+                        span: raw.map(|part| SourceSpan {
+                            start_byte: part.1,
+                            end_byte: part.1 + part.0.len() as u32,
+                        }),
+                        units,
+                    });
+                }
+                return;
+            }
+        }
+
+        let reading = ruby
+            .and_then(|value| value.get("value"))
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_default();
+        if reading.is_empty() {
+            return;
+        }
+        let raw = parts
+            .as_ref()
+            .map(|parts| (parts.reading, parts.reading_start));
+        let had_split_syntax = parts
+            .as_ref()
+            .is_some_and(|parts| split_unescaped_offsets(parts.reading, '.').len() > 1);
+        if had_split_syntax {
+            self.diagnostics.push(Diagnostic {
+                severity: DiagnosticSeverity::Warning,
+                code: "mdi.textProjection.rubySplitMismatch".to_owned(),
+                message: "split ruby component count does not match the base grapheme count; the reading was anchored to the complete base".to_owned(),
+                span: parts.as_ref().map(|parts| SourceSpan {
+                    start_byte: parts.token_start,
+                    end_byte: parts.token_end,
+                }),
+            });
+        }
+        draft.annotations.push(AnnotationDraft {
+            text: reading.to_owned(),
+            anchor_start: base_start,
+            anchor_end: base_end,
+            span: raw.map(|(raw, start)| SourceSpan {
+                start_byte: start,
+                end_byte: start + raw.len() as u32,
+            }),
+            units: annotation_ruby_units(reading, raw),
+        });
+    }
+
+    fn finish(&mut self, draft: BlockDraft) {
+        if draft.text.is_empty() {
+            return;
+        }
+        let index = self.blocks.len() as u32 + 1;
+        let grapheme_count = draft.text.graphemes(true).count();
+        let units = normalize_units(&draft.text, &draft.unit_texts, &draft.units);
+        let mapping_warning = draft.mapping_warning
+            || units.contains(&UnitMap::Unmapped)
+            || draft
+                .annotations
+                .iter()
+                .any(|annotation| annotation.units.contains(&UnitMap::Unmapped));
+        if mapping_warning {
+            self.diagnostics.push(Diagnostic {
+                severity: DiagnosticSeverity::Warning,
+                code: "mdi.textProjection.unmapped".to_owned(),
+                message: format!(
+                    "text block {index} contains text that could not be mapped precisely"
+                ),
+                span: draft.span,
+            });
+        }
+        let annotations = draft
+            .annotations
+            .into_iter()
+            .map(|annotation| MdiTextAnnotation {
+                kind: "rubyReading",
+                text: annotation.text,
+                anchor: text_range(index, annotation.anchor_start, annotation.anchor_end),
+                span: annotation.span,
+                source_map: source_map(index, &annotation.units),
+            })
+            .collect();
+        self.blocks.push(MdiTextBlock {
+            index,
+            kind: draft.kind,
+            text: draft.text,
+            range: text_range(index, 0, grapheme_count),
+            span: draft.span,
+            source_map: source_map(index, &units),
+            annotations,
+            node: draft.node,
+        });
+    }
+
+    fn map_value_in_block(&self, value: &str, draft: &mut BlockDraft) -> Option<Vec<SourceSpan>> {
+        let mapped = find_mapped_value(value, self.source, draft.source_cursor, draft.source_end)?;
+        draft.source_cursor = mapped.consumed_end;
+        Some(mapped.spans)
+    }
+
+    fn map_value_from_node(
+        &self,
+        value: &str,
+        node: &serde_json::Value,
+        draft: &mut BlockDraft,
+    ) -> Option<Vec<SourceSpan>> {
+        if let Some(span) = node_span(node) {
+            let mut suggested = span.start_byte;
+            if suggested > draft.source_cursor
+                && self.source.as_bytes().get(suggested as usize - 1) == Some(&b'\\')
+            {
+                suggested -= 1;
+            }
+            if suggested >= draft.source_cursor && suggested <= draft.source_end {
+                draft.source_cursor = suggested;
+            }
+        }
+        self.map_value_in_block(value, draft)
+    }
+
+    fn map_delimited_in_block(
+        &self,
+        value: &str,
+        draft: &mut BlockDraft,
+        open: char,
+        close: char,
+    ) -> Option<Vec<SourceSpan>> {
+        let needle = format!("{open}{value}{close}");
+        let raw = self
+            .source
+            .get(draft.source_cursor as usize..draft.source_end as usize)?;
+        let offset = raw.find(&needle)?;
+        let token_start = draft.source_cursor + offset as u32;
+        draft.source_cursor = token_start + needle.len() as u32;
+        map_direct(value, token_start + open.len_utf8() as u32)
+    }
+
+    fn map_image_in_block(&self, value: &str, draft: &mut BlockDraft) -> Option<Vec<SourceSpan>> {
+        let raw = self
+            .source
+            .get(draft.source_cursor as usize..draft.source_end as usize)?;
+        let image_start = raw.find("![")?;
+        let alt_start = image_start + 2;
+        let alt_end = first_unescaped(&raw[alt_start..], ']')? + alt_start;
+        let mapped = map_decoded(
+            value,
+            &raw[alt_start..alt_end],
+            draft.source_cursor + alt_start as u32,
+        )?;
+        let consumed = raw[alt_end..]
+            .find(')')
+            .map_or(alt_end + 1, |end| alt_end + end + 1);
+        draft.source_cursor += consumed as u32;
+        Some(mapped)
+    }
+
+    fn map_inline_code_in_block(
+        &self,
+        value: &str,
+        draft: &mut BlockDraft,
+    ) -> Option<Vec<SourceSpan>> {
+        let raw = self
+            .source
+            .get(draft.source_cursor as usize..draft.source_end as usize)?;
+        for (offset, _) in raw.match_indices('`') {
+            let opening = raw[offset..]
+                .chars()
+                .take_while(|character| *character == '`')
+                .count();
+            let delimiter = "`".repeat(opening);
+            let inner_start = offset + opening;
+            let Some(close_offset) = raw[inner_start..].find(&delimiter) else {
+                continue;
+            };
+            let inner_end = inner_start + close_offset;
+            let inner = &raw[inner_start..inner_end];
+            let mut normalized = String::new();
+            let mut spans = Vec::new();
+            for (grapheme_offset, grapheme) in inner.grapheme_indices(true) {
+                normalized.push_str(if grapheme == "\n" || grapheme == "\r\n" {
+                    " "
+                } else {
+                    grapheme
+                });
+                spans.push(SourceSpan {
+                    start_byte: draft.source_cursor + inner_start as u32 + grapheme_offset as u32,
+                    end_byte: draft.source_cursor
+                        + inner_start as u32
+                        + grapheme_offset as u32
+                        + grapheme.len() as u32,
+                });
+            }
+            if normalized.starts_with(' ')
+                && normalized.ends_with(' ')
+                && normalized.chars().any(|character| character != ' ')
+            {
+                normalized.remove(0);
+                normalized.pop();
+                spans.remove(0);
+                spans.pop();
+            }
+            if normalized == value {
+                draft.source_cursor += (inner_end + opening) as u32;
+                return Some(spans);
+            }
+        }
+        None
+    }
+
+    fn map_code_block(&self, value: &str, draft: &mut BlockDraft) -> Option<Vec<SourceSpan>> {
+        let raw = self
+            .source
+            .get(draft.source_cursor as usize..draft.source_end as usize)?;
+        let trimmed = raw.trim_start_matches([' ', '\t']);
+        let fenced = trimmed.starts_with("```") || trimmed.starts_with("~~~");
+        if fenced {
+            let opening_end = raw.find('\n')? + 1;
+            draft.source_cursor += opening_end as u32;
+        }
+        self.map_value_in_block(value, draft)
+    }
+
+    fn advance_after_container(&self, node: &serde_json::Value, draft: &mut BlockDraft) {
+        let Some(raw) = self
+            .source
+            .get(draft.source_cursor as usize..draft.source_end as usize)
+        else {
+            return;
+        };
+        let consumed = match node_type(node) {
+            "link" => raw.find(']').map(|label_end| {
+                let after_label = label_end + 1;
+                if raw[after_label..].starts_with('(') {
+                    raw[after_label + 1..]
+                        .find(')')
+                        .map_or(after_label, |end| after_label + end + 2)
+                } else if raw[after_label..].starts_with('[') {
+                    raw[after_label + 1..]
+                        .find(']')
+                        .map_or(after_label, |end| after_label + end + 2)
+                } else {
+                    after_label
+                }
+            }),
+            "noBreak" | "warichu" | "kern" => raw.find("\x5d\x5d").map(|offset| offset + 2),
+            "em" => raw
+                .find("\x5d\x5d")
+                .map(|offset| offset + 2)
+                .or_else(|| raw.find("》》").map(|offset| offset + "》》".len())),
+            "emphasis" | "strong" | "delete" => {
+                let width = if node_type(node) == "emphasis" { 1 } else { 2 };
+                raw.char_indices()
+                    .find(|(_, character)| matches!(character, '*' | '_' | '~'))
+                    .map(|(offset, character)| offset + character.len_utf8() * width)
+            }
+            _ => None,
+        };
+        if let Some(consumed) = consumed {
+            draft.source_cursor += consumed as u32;
+        }
+    }
+
+    fn map_break_in_block(&self, draft: &mut BlockDraft) -> Option<Vec<SourceSpan>> {
+        let raw = self
+            .source
+            .get(draft.source_cursor as usize..draft.source_end as usize)?;
+        if let Some(offset) = raw.find("[[br]]") {
+            let span = SourceSpan {
+                start_byte: draft.source_cursor + offset as u32,
+                end_byte: draft.source_cursor + offset as u32 + "[[br]]".len() as u32,
+            };
+            draft.source_cursor = span.end_byte;
+            return Some(vec![span]);
+        }
+        let newline = raw.find('\n')?;
+        let prefix = &raw[..newline];
+        let marker_prefix = prefix.strip_suffix('\r').unwrap_or(prefix);
+        let marker_start = marker_prefix
+            .rfind('\\')
+            .unwrap_or_else(|| marker_prefix.trim_end_matches(' ').len());
+        let span = SourceSpan {
+            start_byte: draft.source_cursor + marker_start as u32,
+            end_byte: draft.source_cursor + newline as u32 + 1,
+        };
+        draft.source_cursor = span.end_byte;
+        Some(vec![span])
+    }
+}
+
+fn annotation_units(value: &str, raw: Option<(&str, u32)>) -> Vec<UnitMap> {
+    raw.and_then(|(raw, start)| map_decoded(value, raw, start))
+        .map(|spans| spans.into_iter().map(UnitMap::Mapped).collect())
+        .unwrap_or_else(|| vec![UnitMap::Unmapped; value.graphemes(true).count()])
+}
+
+fn annotation_ruby_units(value: &str, raw: Option<(&str, u32)>) -> Vec<UnitMap> {
+    let Some((raw, start)) = raw else {
+        return vec![UnitMap::Unmapped; value.graphemes(true).count()];
+    };
+    let mut decoded = String::new();
+    let mut spans = Vec::new();
+    for (part_start, part_end) in split_unescaped_offsets(raw, '.') {
+        let part = &raw[part_start..part_end];
+        let part_decoded: String = decoded_atoms(part, start + part_start as u32)
+            .iter()
+            .map(|atom| atom.text.as_str())
+            .collect();
+        let Some(mut part_spans) = map_decoded(&part_decoded, part, start + part_start as u32)
+        else {
+            return vec![UnitMap::Unmapped; value.graphemes(true).count()];
+        };
+        decoded.push_str(&part_decoded);
+        spans.append(&mut part_spans);
+    }
+    if decoded == value && spans.len() == value.graphemes(true).count() {
+        spans.into_iter().map(UnitMap::Mapped).collect()
+    } else {
+        vec![UnitMap::Unmapped; value.graphemes(true).count()]
+    }
+}
+
+fn normalize_units(text: &str, unit_texts: &[String], units: &[UnitMap]) -> Vec<UnitMap> {
+    if unit_texts.len() == units.len()
+        && unit_texts
+            .iter()
+            .map(String::as_str)
+            .eq(text.graphemes(true))
+    {
+        return units.to_vec();
+    }
+    let mut pieces = Vec::with_capacity(unit_texts.len());
+    let mut offset = 0;
+    for (unit_text, unit) in unit_texts.iter().zip(units) {
+        let end = offset + unit_text.len();
+        pieces.push((offset, end, *unit));
+        offset = end;
+    }
+    if offset != text.len() {
+        return vec![UnitMap::Unmapped; text.graphemes(true).count()];
+    }
+    text.grapheme_indices(true)
+        .map(|(start, grapheme)| {
+            let end = start + grapheme.len();
+            let overlapping: Vec<_> = pieces
+                .iter()
+                .filter(|(piece_start, piece_end, _)| *piece_start < end && *piece_end > start)
+                .map(|(_, _, unit)| *unit)
+                .collect();
+            if overlapping
+                .iter()
+                .all(|unit| matches!(unit, UnitMap::Mapped(_)))
+            {
+                let first = match overlapping.first() {
+                    Some(UnitMap::Mapped(span)) => *span,
+                    _ => return UnitMap::Unmapped,
+                };
+                let last = match overlapping.last() {
+                    Some(UnitMap::Mapped(span)) => *span,
+                    _ => return UnitMap::Unmapped,
+                };
+                UnitMap::Mapped(SourceSpan {
+                    start_byte: first.start_byte,
+                    end_byte: last.end_byte,
+                })
+            } else if overlapping
+                .iter()
+                .all(|unit| matches!(unit, UnitMap::Synthetic))
+            {
+                UnitMap::Synthetic
+            } else {
+                UnitMap::Unmapped
+            }
+        })
+        .collect()
+}
+
+fn source_map(block: u32, units: &[UnitMap]) -> MdiTextSourceMap {
+    let mut map = MdiTextSourceMap::default();
+    let mut index = 0;
+    while index < units.len() {
+        match units[index] {
+            UnitMap::Mapped(first) => {
+                let start = index;
+                let mut boundaries = vec![first.start_byte, first.end_byte];
+                index += 1;
+                while let Some(UnitMap::Mapped(next)) = units.get(index).copied() {
+                    if boundaries.last().copied() != Some(next.start_byte) {
+                        break;
+                    }
+                    boundaries.push(next.end_byte);
+                    index += 1;
+                }
+                map.runs.push(MdiTextSourceRun {
+                    range: text_range(block, start, index),
+                    source_boundaries: boundaries,
+                });
+            }
+            UnitMap::Synthetic => {
+                let start = index;
+                while matches!(units.get(index), Some(UnitMap::Synthetic)) {
+                    index += 1;
+                }
+                map.synthetic.push(text_range(block, start, index));
+            }
+            UnitMap::Unmapped => {
+                let start = index;
+                while matches!(units.get(index), Some(UnitMap::Unmapped)) {
+                    index += 1;
+                }
+                map.unmapped.push(text_range(block, start, index));
+            }
+        }
+    }
+    map
+}
+
+fn text_range(block: u32, start: usize, end: usize) -> MdiTextRange {
+    MdiTextRange {
+        start: MdiTextPosition {
+            block,
+            character: start as u32 + 1,
+        },
+        end: MdiTextPosition {
+            block,
+            character: end as u32 + 1,
+        },
+    }
+}
+
+fn node_type(node: &serde_json::Value) -> &str {
+    node.get("type")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_default()
+}
+
+fn children(node: &serde_json::Value) -> impl Iterator<Item = &serde_json::Value> {
+    node.get("children")
+        .and_then(serde_json::Value::as_array)
+        .into_iter()
+        .flatten()
+}
+
+fn node_span(node: &serde_json::Value) -> Option<SourceSpan> {
+    Some(SourceSpan {
+        start_byte: node.pointer("/span/startByte")?.as_u64()? as u32,
+        end_byte: node.pointer("/span/endByte")?.as_u64()? as u32,
+    })
+}
+
+struct MappedValue {
+    spans: Vec<SourceSpan>,
+    consumed_end: u32,
+}
+
+fn find_mapped_value(value: &str, source: &str, start: u32, end: u32) -> Option<MappedValue> {
+    if value.contains('\n') {
+        let mut spans = Vec::new();
+        let mut cursor = start;
+        let lines: Vec<_> = value.split('\n').collect();
+        for (index, line) in lines.iter().enumerate() {
+            if !line.is_empty() {
+                let mapped = find_mapped_value(line, source, cursor, end)?;
+                cursor = mapped.consumed_end;
+                spans.extend(mapped.spans);
+            }
+            if index + 1 < lines.len() {
+                let remaining = source.get(cursor as usize..end as usize)?;
+                let newline = remaining.find('\n')?;
+                let newline_end = cursor + newline as u32 + 1;
+                let newline_start = if newline > 0 && remaining.as_bytes()[newline - 1] == b'\r' {
+                    newline_end - 2
+                } else {
+                    newline_end - 1
+                };
+                spans.push(SourceSpan {
+                    start_byte: newline_start,
+                    end_byte: newline_end,
+                });
+                cursor = newline_end;
+            }
+        }
+        return Some(MappedValue {
+            spans,
+            consumed_end: cursor,
+        });
+    }
+    let raw = source.get(start as usize..end as usize)?;
+    let direct_offset = raw
+        .find(value)
+        .filter(|offset| direct_match_is_source_literal(raw, *offset, value));
+    if direct_offset == Some(0) {
+        return Some(MappedValue {
+            spans: map_direct(value, start)?,
+            consumed_end: start + value.len() as u32,
+        });
+    }
+    for (candidate, _) in raw.char_indices() {
+        if direct_offset.is_some_and(|offset| candidate > offset) {
+            break;
+        }
+        if let Some((spans, consumed)) =
+            map_decoded_prefix(value, &raw[candidate..], start + candidate as u32)
+        {
+            return Some(MappedValue {
+                spans,
+                consumed_end: start + candidate as u32 + consumed as u32,
+            });
+        }
+    }
+    None
+}
+
+fn map_decoded_prefix(value: &str, raw: &str, start: u32) -> Option<(Vec<SourceSpan>, usize)> {
+    let atoms = decoded_atoms(raw, start);
+    let mut decoded = String::new();
+    for atom in atoms {
+        decoded.push_str(&atom.text);
+        if decoded == value {
+            let consumed = atom.span.end_byte.checked_sub(start)? as usize;
+            return map_decoded(value, &raw[..consumed], start).map(|spans| (spans, consumed));
+        }
+        if !value.starts_with(&decoded) {
+            return None;
+        }
+    }
+    None
+}
+
+fn direct_match_is_source_literal(raw: &str, offset: usize, value: &str) -> bool {
+    if offset > 0 && raw.as_bytes()[offset - 1] == b'\\' {
+        return false;
+    }
+    let candidate = &raw[offset..];
+    if candidate.starts_with('&')
+        && let Some(end) = candidate.find(';')
+        && decode_reference(&candidate[1..end]).as_deref() == Some(value)
+        && end + 1 != value.len()
+    {
+        return false;
+    }
+    true
+}
+
+fn map_direct(value: &str, start: u32) -> Option<Vec<SourceSpan>> {
+    Some(
+        value
+            .grapheme_indices(true)
+            .map(|(offset, grapheme)| SourceSpan {
+                start_byte: start + offset as u32,
+                end_byte: start + offset as u32 + grapheme.len() as u32,
+            })
+            .collect(),
+    )
+}
+
+struct Atom {
+    text: String,
+    span: SourceSpan,
+}
+
+fn map_decoded(value: &str, raw: &str, start: u32) -> Option<Vec<SourceSpan>> {
+    if value == raw {
+        return map_direct(value, start);
+    }
+    let atoms = decoded_atoms(raw, start);
+    let decoded: String = atoms.iter().map(|atom| atom.text.as_str()).collect();
+    if decoded != value {
+        return None;
+    }
+    let mut atom_ranges = Vec::with_capacity(atoms.len());
+    let mut decoded_offset = 0;
+    for atom in &atoms {
+        let end = decoded_offset + atom.text.len();
+        atom_ranges.push((decoded_offset, end, atom.span));
+        decoded_offset = end;
+    }
+    let mut result = Vec::new();
+    for (offset, grapheme) in value.grapheme_indices(true) {
+        let end = offset + grapheme.len();
+        let overlapping: Vec<_> = atom_ranges
+            .iter()
+            .filter(|(atom_start, atom_end, _)| *atom_start < end && *atom_end > offset)
+            .collect();
+        let first = overlapping.first()?.2;
+        let last = overlapping.last()?.2;
+        result.push(SourceSpan {
+            start_byte: first.start_byte,
+            end_byte: last.end_byte,
+        });
+    }
+    Some(result)
+}
+
+fn decoded_atoms(raw: &str, start: u32) -> Vec<Atom> {
+    let mut atoms = Vec::new();
+    let mut index = 0;
+    while index < raw.len() {
+        let rest = &raw[index..];
+        if rest.starts_with('\\')
+            && let Some(next) = rest.chars().nth(1)
+            && (next.is_ascii_punctuation() || "{}|^[]:《》\\.".contains(next))
+        {
+            let len = 1 + next.len_utf8();
+            atoms.push(Atom {
+                text: next.to_string(),
+                span: SourceSpan {
+                    start_byte: start + index as u32,
+                    end_byte: start + (index + len) as u32,
+                },
+            });
+            index += len;
+            continue;
+        }
+        if rest.starts_with('&')
+            && let Some(end) = rest.find(';')
+            && let Some(decoded) = decode_reference(&rest[1..end])
+        {
+            atoms.push(Atom {
+                text: decoded,
+                span: SourceSpan {
+                    start_byte: start + index as u32,
+                    end_byte: start + (index + end + 1) as u32,
+                },
+            });
+            index += end + 1;
+            continue;
+        }
+        let character = rest.chars().next().expect("non-empty remainder");
+        let len = character.len_utf8();
+        atoms.push(Atom {
+            text: character.to_string(),
+            span: SourceSpan {
+                start_byte: start + index as u32,
+                end_byte: start + (index + len) as u32,
+            },
+        });
+        index += len;
+    }
+    atoms
+}
+
+fn decode_reference(body: &str) -> Option<String> {
+    if let Some(hex) = body.strip_prefix("#x").or_else(|| body.strip_prefix("#X")) {
+        return (!hex.is_empty() && hex.chars().all(|character| character.is_ascii_hexdigit()))
+            .then(|| markdown::decode_numeric(hex, 16));
+    }
+    if let Some(decimal) = body.strip_prefix('#') {
+        return (!decimal.is_empty()
+            && decimal.chars().all(|character| character.is_ascii_digit()))
+        .then(|| markdown::decode_numeric(decimal, 10));
+    }
+    markdown::decode_named(body, true)
+}
+
+struct RubyParts<'a> {
+    token_start: u32,
+    base: &'a str,
+    base_start: u32,
+    reading: &'a str,
+    reading_start: u32,
+    token_end: u32,
+}
+
+fn find_ruby_parts<'a>(
+    base: &str,
+    reading: &str,
+    source: &'a str,
+    start: u32,
+    end: u32,
+) -> Option<RubyParts<'a>> {
+    let raw = source.get(start as usize..end as usize)?;
+    for (offset, _) in raw.match_indices('{') {
+        let candidate = &raw[offset..];
+        let Some(close) = first_unescaped(&candidate[1..], '}').map(|close| close + 1) else {
+            continue;
+        };
+        let body = &candidate[1..close];
+        let Some(separator) = first_unescaped(body, '|') else {
+            continue;
+        };
+        let raw_base = &body[..separator];
+        let raw_reading = &body[separator + 1..];
+        let decoded_base: String = decoded_atoms(raw_base, 0)
+            .into_iter()
+            .map(|atom| atom.text)
+            .collect();
+        let decoded_reading: String = split_unescaped_offsets(raw_reading, '.')
+            .into_iter()
+            .flat_map(|(part_start, part_end)| {
+                decoded_atoms(&raw_reading[part_start..part_end], 0)
+                    .into_iter()
+                    .map(|atom| atom.text)
+            })
+            .collect();
+        if decoded_base == base && decoded_reading == reading {
+            let token_start = start + offset as u32;
+            return Some(RubyParts {
+                token_start,
+                base: raw_base,
+                base_start: token_start + 1,
+                reading: raw_reading,
+                reading_start: token_start + 1 + separator as u32 + 1,
+                token_end: token_start + close as u32 + 1,
+            });
+        }
+    }
+    None
+}
+
+fn split_raw_reading<'a>(parts: &'a RubyParts<'a>) -> Vec<(&'a str, u32)> {
+    split_unescaped_offsets(parts.reading, '.')
+        .into_iter()
+        .map(|(start, end)| {
+            (
+                &parts.reading[start..end],
+                parts.reading_start + start as u32,
+            )
+        })
+        .collect()
+}
+
+fn first_unescaped(value: &str, needle: char) -> Option<usize> {
+    let mut escaped = false;
+    for (index, character) in value.char_indices() {
+        if escaped {
+            escaped = false;
+        } else if character == '\\' {
+            escaped = true;
+        } else if character == needle {
+            return Some(index);
+        }
+    }
+    None
+}
+
+fn split_unescaped_offsets(value: &str, separator: char) -> Vec<(usize, usize)> {
+    let mut result = Vec::new();
+    let mut start = 0;
+    let mut escaped = false;
+    for (index, character) in value.char_indices() {
+        if escaped {
+            escaped = false;
+        } else if character == '\\' {
+            escaped = true;
+        } else if character == separator {
+            result.push((start, index));
+            start = index + character.len_utf8();
+        }
+    }
+    result.push((start, value.len()));
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn position(range: &MdiTextRange) -> (u32, u32, u32, u32) {
+        (
+            range.start.block,
+            range.start.character,
+            range.end.block,
+            range.end.character,
+        )
+    }
+
+    fn assert_complete_mapping(block: &MdiTextBlock, source: &str) {
+        let count = block.text.graphemes(true).count();
+        let mut coverage = vec![0_u8; count];
+        for run in &block.source_map.runs {
+            let start = run.range.start.character as usize - 1;
+            let end = run.range.end.character as usize - 1;
+            assert_eq!(run.source_boundaries.len(), end - start + 1);
+            for boundary in &run.source_boundaries {
+                assert!((*boundary as usize) <= source.len());
+                assert!(source.is_char_boundary(*boundary as usize));
+            }
+            for covered in &mut coverage[start..end] {
+                *covered += 1;
+            }
+        }
+        for range in &block.source_map.synthetic {
+            let start = range.start.character as usize - 1;
+            let end = range.end.character as usize - 1;
+            for covered in &mut coverage[start..end] {
+                *covered += 1;
+            }
+        }
+        assert!(block.source_map.unmapped.is_empty(), "{block:#?}");
+        assert!(coverage.iter().all(|covered| *covered == 1), "{block:#?}");
+    }
+
+    #[test]
+    fn projects_grapheme_positions_and_ruby_channels() {
+        let result = get_mdi_text_blocks("# 序章\n\n我喜歡{東京|とうきょう}。\n\ne\u{301} 👩🏽‍💻");
+        assert_eq!(result.blocks.len(), 3);
+        assert_eq!(result.blocks[0].text, "序章");
+        assert_eq!(position(&result.blocks[0].range), (1, 1, 1, 3));
+        assert_eq!(result.blocks[1].text, "我喜歡東京。");
+        assert_eq!(position(&result.blocks[1].range), (2, 1, 2, 7));
+        let annotation = &result.blocks[1].annotations[0];
+        assert_eq!(annotation.text, "とうきょう");
+        assert_eq!(position(&annotation.anchor), (2, 4, 2, 6));
+        assert_eq!(result.blocks[2].text.graphemes(true).count(), 3);
+        assert_eq!(position(&result.blocks[2].range), (3, 1, 3, 4));
+        assert!(result.diagnostics.is_empty());
+
+        let across_wrapper = get_mdi_text_blocks("e*\u{301}*");
+        assert_eq!(across_wrapper.blocks[0].text, "e\u{301}");
+        assert_eq!(position(&across_wrapper.blocks[0].range), (1, 1, 1, 2));
+        assert!(across_wrapper.blocks[0].source_map.unmapped.is_empty());
+
+        let marker_text = get_mdi_text_blocks("# \\#\n\n- \\-\n\n> \\>");
+        assert_eq!(
+            marker_text
+                .blocks
+                .iter()
+                .map(|block| block.source_map.runs[0].source_boundaries[0])
+                .collect::<Vec<_>>(),
+            vec![2, 8, 14]
+        );
+    }
+
+    #[test]
+    fn maps_entities_escapes_and_mdi_delimiters_to_complete_source_tokens() {
+        let source = r"&amp; \* {東京|とうきょう} ^12^ 前[[br]]次";
+        let result = get_mdi_text_blocks(source);
+        let block = &result.blocks[0];
+        assert_eq!(block.text, "& * 東京 12 前\n次");
+        assert!(block.source_map.unmapped.is_empty(), "{block:#?}");
+        assert!(block.source_map.synthetic.is_empty());
+
+        let spans: Vec<_> = block
+            .source_map
+            .runs
+            .iter()
+            .flat_map(|run| run.source_boundaries.windows(2))
+            .map(|pair| &source[pair[0] as usize..pair[1] as usize])
+            .collect();
+        assert!(spans.contains(&"&amp;"));
+        assert!(spans.contains(&r"\*"));
+        assert!(spans.contains(&"[[br]]"));
+        assert!(!spans.contains(&"とうきょう"));
+        assert!(result.diagnostics.is_empty());
+    }
+
+    #[test]
+    fn gives_each_split_ruby_reading_its_base_grapheme_anchor() {
+        let result = get_mdi_text_blocks("{東京|とう.きょう}");
+        let annotations = &result.blocks[0].annotations;
+        assert_eq!(annotations.len(), 2);
+        assert_eq!(annotations[0].text, "とう");
+        assert_eq!(position(&annotations[0].anchor), (1, 1, 1, 2));
+        assert_eq!(annotations[1].text, "きょう");
+        assert_eq!(position(&annotations[1].anchor), (1, 2, 1, 3));
+        assert!(
+            annotations
+                .iter()
+                .all(|annotation| annotation.source_map.unmapped.is_empty())
+        );
+    }
+
+    #[test]
+    fn mismatched_split_ruby_degrades_to_a_mapped_group_warning() {
+        let result = get_mdi_text_blocks("{東京|とう.きょ.う}");
+        let annotation = &result.blocks[0].annotations[0];
+        assert_eq!(annotation.text, "とうきょう");
+        assert_eq!(position(&annotation.anchor), (1, 1, 1, 3));
+        assert!(annotation.source_map.unmapped.is_empty());
+        assert!(
+            result
+                .diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.code == "mdi.textProjection.rubySplitMismatch")
+        );
+    }
+
+    #[test]
+    fn collects_leaf_blocks_without_parent_text_duplication() {
+        let source = "- first\n\n  second\n  - nested\n\n> quote one\n>\n> quote two\n\n| a | b |\n| - | - |\n| c | d |\n\n```mdi\ncode\nline\n```\n\nbody[^n]\n\n[^n]: note\n\n---";
+        let result = get_mdi_text_blocks(source);
+        let summaries: Vec<_> = result
+            .blocks
+            .iter()
+            .map(|block| (block.kind, block.text.as_str()))
+            .collect();
+        assert_eq!(
+            summaries,
+            vec![
+                (MdiTextBlockKind::ListItem, "first\n\nsecond"),
+                (MdiTextBlockKind::ListItem, "nested"),
+                (MdiTextBlockKind::Blockquote, "quote one"),
+                (MdiTextBlockKind::Blockquote, "quote two"),
+                (MdiTextBlockKind::Table, "a\tb\nc\td"),
+                (MdiTextBlockKind::Code, "code\nline"),
+                (MdiTextBlockKind::Paragraph, "body"),
+                (MdiTextBlockKind::Footnote, "note"),
+            ]
+        );
+        assert_eq!(result.blocks[0].source_map.synthetic.len(), 1);
+        assert_eq!(result.blocks[4].source_map.synthetic.len(), 3);
+        assert!(
+            result
+                .blocks
+                .iter()
+                .all(|block| block.source_map.unmapped.is_empty())
+        );
+
+        let fenced = get_mdi_text_blocks("```rust\nrust\n```");
+        assert_eq!(fenced.blocks[0].text, "rust");
+        assert_eq!(fenced.blocks[0].source_map.runs[0].source_boundaries[0], 8);
+    }
+
+    #[test]
+    fn projection_json_is_deterministic_and_keeps_the_parse_envelope() {
+        let source = "---\nmdi: '2.0'\ntitle: x\n---\n\n# heading\n\ntext";
+        let first = get_mdi_text_blocks_json(source);
+        assert_eq!(first, get_mdi_text_blocks_json(source));
+        let value: serde_json::Value = serde_json::from_str(&first).unwrap();
+        assert_eq!(value["projectionVersion"], "1.0");
+        assert_eq!(
+            value["positionEncoding"],
+            "unicode-grapheme-cluster-1-based"
+        );
+        assert_eq!(value["irVersion"], MDI_IR_VERSION);
+        assert_eq!(value["document"]["frontmatter"]["entries"][0]["key"], "mdi");
+    }
+
+    #[test]
+    fn supported_inline_and_wrapped_markdown_is_fully_mapped() {
+        let source = "**強調** [label](https://example.test) ![代替](image.png) `code` \\* &amp; [[no-break:禁則]][[warichu:割注]][[kern:-0.1em:詰め]][[em:傍点]]\n\n> first\n> continued\n\n- item\n  continued";
+        let result = get_mdi_text_blocks(source);
+        assert_eq!(
+            result
+                .blocks
+                .iter()
+                .map(|block| block.text.as_str())
+                .collect::<Vec<_>>(),
+            vec![
+                "強調 label 代替 code * & 禁則割注詰め傍点",
+                "first\ncontinued",
+                "item\ncontinued",
+            ]
+        );
+        for block in &result.blocks {
+            assert_complete_mapping(block, source);
+        }
+    }
+
+    #[test]
+    fn malformed_literals_remain_searchable_and_precisely_mapped() {
+        for source in [
+            "{東京|とうきょう",
+            "[[em:未閉",
+            "《《未閉",
+            "^1234567^ ^12^",
+            "<custom>literal</custom>",
+        ] {
+            let result = get_mdi_text_blocks(source);
+            assert!(!result.blocks.is_empty(), "{source:?}");
+            for block in &result.blocks {
+                assert_complete_mapping(block, source);
+            }
+        }
+        let frontmatter = get_mdi_text_blocks("---\ntitle: hidden\n---\n\nvisible");
+        assert_eq!(frontmatter.blocks.len(), 1);
+        assert_eq!(frontmatter.blocks[0].text, "visible");
+    }
+}

--- a/mdi-core/tests/text_projection_golden_scale.rs
+++ b/mdi-core/tests/text_projection_golden_scale.rs
@@ -1,0 +1,449 @@
+use std::time::{Duration, Instant};
+
+use mdi_core::{
+    MdiTextBlock, MdiTextBlockKind, MdiTextRange, get_mdi_text_blocks, get_mdi_text_blocks_json,
+};
+use serde_json::{Value, json};
+use unicode_segmentation::UnicodeSegmentation;
+
+fn range_tuple(range: &MdiTextRange) -> (u32, u32, u32, u32) {
+    (
+        range.start.block,
+        range.start.character,
+        range.end.block,
+        range.end.character,
+    )
+}
+
+fn kind_name(kind: MdiTextBlockKind) -> &'static str {
+    match kind {
+        MdiTextBlockKind::Heading => "heading",
+        MdiTextBlockKind::Paragraph => "paragraph",
+        MdiTextBlockKind::ListItem => "listItem",
+        MdiTextBlockKind::Blockquote => "blockquote",
+        MdiTextBlockKind::Code => "code",
+        MdiTextBlockKind::Table => "table",
+        MdiTextBlockKind::Footnote => "footnote",
+        MdiTextBlockKind::Html => "html",
+        MdiTextBlockKind::Other => "other",
+    }
+}
+
+/// A deliberately small golden wire view. It freezes the public naming,
+/// indexing, grapheme ranges, synthetic separators, annotation anchors, and
+/// diagnostics without copying the parser's complete IR into this test.
+fn stable_projection(source: &str) -> Value {
+    let result = get_mdi_text_blocks(source);
+    json!({
+        "projectionVersion": result.projection_version,
+        "positionEncoding": result.position_encoding,
+        "irVersion": result.ir_version,
+        "syntaxVersion": result.syntax_version,
+        "documentSpan": [result.document.span.start_byte, result.document.span.end_byte],
+        "blocks": result.blocks.iter().map(|block| json!({
+            "index": block.index,
+            "kind": kind_name(block.kind),
+            "nodeType": block.node.get("type").and_then(Value::as_str),
+            "text": block.text,
+            "range": range_tuple(&block.range),
+            "synthetic": block.source_map.synthetic.iter().map(range_tuple).collect::<Vec<_>>(),
+            "unmapped": block.source_map.unmapped.iter().map(range_tuple).collect::<Vec<_>>(),
+            "annotations": block.annotations.iter().map(|annotation| json!({
+                "kind": annotation.kind,
+                "text": annotation.text,
+                "anchor": range_tuple(&annotation.anchor),
+                "unmapped": annotation.source_map.unmapped.iter().map(range_tuple).collect::<Vec<_>>(),
+            })).collect::<Vec<_>>(),
+        })).collect::<Vec<_>>(),
+        "diagnostics": result.diagnostics.iter().map(|diagnostic| {
+            json!({
+                "severity": format!("{:?}", diagnostic.severity).to_lowercase(),
+                "code": diagnostic.code,
+            })
+        }).collect::<Vec<_>>(),
+    })
+}
+
+fn block_summaries(source: &str) -> Vec<(MdiTextBlockKind, String)> {
+    get_mdi_text_blocks(source)
+        .blocks
+        .into_iter()
+        .map(|block| (block.kind, block.text))
+        .collect()
+}
+
+fn source_span_for_character<'a>(
+    block: &MdiTextBlock,
+    source: &'a str,
+    character: u32,
+) -> Option<(u32, u32, &'a str)> {
+    for run in &block.source_map.runs {
+        let start = run.range.start.character;
+        let end = run.range.end.character;
+        if (start..end).contains(&character) {
+            let index = (character - start) as usize;
+            let source_start = run.source_boundaries[index];
+            let source_end = run.source_boundaries[index + 1];
+            return Some((
+                source_start,
+                source_end,
+                &source[source_start as usize..source_end as usize],
+            ));
+        }
+    }
+    None
+}
+
+#[test]
+fn golden_selected_schema_covers_kitchen_sink_markdown_malformed_unicode_and_nesting() {
+    let cases = [
+        (
+            "kitchen sink",
+            "# 序章\n\n本文{東京|とうきょう} ^12^ 前[[br]]次\n\n| A | B |\n| - | - |\n| C | D |",
+            json!({
+                "projectionVersion": "1.0",
+                "positionEncoding": "unicode-grapheme-cluster-1-based",
+                "irVersion": "1.0",
+                "syntaxVersion": "2.0",
+                "documentSpan": [0, 89],
+                "blocks": [
+                    {
+                        "index": 1, "kind": "heading", "nodeType": "heading",
+                        "text": "序章", "range": [1, 1, 1, 3],
+                        "synthetic": [], "unmapped": [], "annotations": [],
+                    },
+                    {
+                        "index": 2, "kind": "paragraph", "nodeType": "paragraph",
+                        "text": "本文東京 12 前\n次", "range": [2, 1, 2, 12],
+                        "synthetic": [], "unmapped": [],
+                        "annotations": [{
+                            "kind": "rubyReading", "text": "とうきょう",
+                            "anchor": [2, 3, 2, 5], "unmapped": [],
+                        }],
+                    },
+                    {
+                        "index": 3, "kind": "table", "nodeType": "table",
+                        "text": "A\tB\nC\tD", "range": [3, 1, 3, 8],
+                        "synthetic": [[3, 2, 3, 3], [3, 4, 3, 5], [3, 6, 3, 7]],
+                        "unmapped": [], "annotations": [],
+                    },
+                ],
+                "diagnostics": [],
+            }),
+        ),
+        (
+            "Markdown heavy",
+            r"**bold** _em_ ~~gone~~ [label](https://example.test/rust) ![alt](rust.png) `code` \* &amp;",
+            json!({
+                "projectionVersion": "1.0",
+                "positionEncoding": "unicode-grapheme-cluster-1-based",
+                "irVersion": "1.0", "syntaxVersion": "2.0", "documentSpan": [0, 90],
+                "blocks": [{
+                    "index": 1, "kind": "paragraph", "nodeType": "paragraph",
+                    "text": "bold em gone label alt code * &", "range": [1, 1, 1, 32],
+                    "synthetic": [], "unmapped": [], "annotations": [],
+                }],
+                "diagnostics": [],
+            }),
+        ),
+        (
+            "malformed recovery",
+            "{未閉|よみ\n\n[[em:未閉\n\n<custom>literal</custom>",
+            json!({
+                "projectionVersion": "1.0",
+                "positionEncoding": "unicode-grapheme-cluster-1-based",
+                "irVersion": "1.0", "syntaxVersion": "2.0", "documentSpan": [0, 53],
+                "blocks": [
+                    {
+                        "index": 1, "kind": "paragraph", "nodeType": "paragraph",
+                        "text": "{未閉|よみ", "range": [1, 1, 1, 7],
+                        "synthetic": [], "unmapped": [], "annotations": [],
+                    },
+                    {
+                        "index": 2, "kind": "paragraph", "nodeType": "paragraph",
+                        "text": "[[em:未閉", "range": [2, 1, 2, 8],
+                        "synthetic": [], "unmapped": [], "annotations": [],
+                    },
+                    {
+                        "index": 3, "kind": "paragraph", "nodeType": "paragraph",
+                        "text": "<custom>literal</custom>", "range": [3, 1, 3, 25],
+                        "synthetic": [], "unmapped": [], "annotations": [],
+                    },
+                ],
+                "diagnostics": [],
+            }),
+        ),
+        (
+            "Unicode stress",
+            "e\u{301} é 👩🏽‍💻 ✈️ 🇯🇵 1️⃣ क्‍ष",
+            json!({
+                "projectionVersion": "1.0",
+                "positionEncoding": "unicode-grapheme-cluster-1-based",
+                "irVersion": "1.0", "syntaxVersion": "2.0", "documentSpan": [0, 59],
+                "blocks": [{
+                    "index": 1, "kind": "paragraph", "nodeType": "paragraph",
+                    "text": "e\u{301} é 👩🏽‍💻 ✈️ 🇯🇵 1️⃣ क्‍ष", "range": [1, 1, 1, 14],
+                    "synthetic": [], "unmapped": [], "annotations": [],
+                }],
+                "diagnostics": [],
+            }),
+        ),
+        (
+            "nested blocks",
+            "> quote one\n>\n> - quoted item\n>   - quoted nested\n>\n> quote two\n\n- first\n\n  second\n\n  > inside quote\n\n  - nested item",
+            json!({
+                "projectionVersion": "1.0",
+                "positionEncoding": "unicode-grapheme-cluster-1-based",
+                "irVersion": "1.0", "syntaxVersion": "2.0", "documentSpan": [0, 117],
+                "blocks": [
+                    {"index": 1, "kind": "blockquote", "nodeType": "paragraph", "text": "quote one", "range": [1, 1, 1, 10], "synthetic": [], "unmapped": [], "annotations": []},
+                    {"index": 2, "kind": "listItem", "nodeType": "listItem", "text": "quoted item", "range": [2, 1, 2, 12], "synthetic": [], "unmapped": [], "annotations": []},
+                    {"index": 3, "kind": "listItem", "nodeType": "listItem", "text": "quoted nested", "range": [3, 1, 3, 14], "synthetic": [], "unmapped": [], "annotations": []},
+                    {"index": 4, "kind": "blockquote", "nodeType": "paragraph", "text": "quote two", "range": [4, 1, 4, 10], "synthetic": [], "unmapped": [], "annotations": []},
+                    {"index": 5, "kind": "listItem", "nodeType": "listItem", "text": "first\n\nsecond", "range": [5, 1, 5, 14], "synthetic": [[5, 6, 5, 8]], "unmapped": [], "annotations": []},
+                    {"index": 6, "kind": "blockquote", "nodeType": "paragraph", "text": "inside quote", "range": [6, 1, 6, 13], "synthetic": [], "unmapped": [], "annotations": []},
+                    {"index": 7, "kind": "listItem", "nodeType": "listItem", "text": "nested item", "range": [7, 1, 7, 12], "synthetic": [], "unmapped": [], "annotations": []},
+                ],
+                "diagnostics": [],
+            }),
+        ),
+    ];
+
+    for (name, source, expected) in cases {
+        assert_eq!(stable_projection(source), expected, "{name}");
+    }
+}
+
+#[test]
+fn complex_containers_emit_each_searchable_leaf_once_in_source_order() {
+    let source = concat!(
+        "# top\n\n",
+        "> quote one\n>\n> quote two\n>\n> - quoted item\n>   - quoted nested\n\n",
+        "- first\n\n  second\n\n  > inside quote\n\n  - nested item\n\n",
+        "| h1 | h2 |\n| -- | -- |\n| c1 | c2 |\n\n",
+        "```rust\ncode line\n```\n\n",
+        "<section>literal html</section>\n\n",
+        "body[^note]\n\n",
+        "[^note]: footnote one\n\n    footnote two",
+    );
+    assert_eq!(
+        block_summaries(source),
+        vec![
+            (MdiTextBlockKind::Heading, "top".to_owned()),
+            (MdiTextBlockKind::Blockquote, "quote one".to_owned()),
+            (MdiTextBlockKind::Blockquote, "quote two".to_owned()),
+            (MdiTextBlockKind::ListItem, "quoted item".to_owned()),
+            (MdiTextBlockKind::ListItem, "quoted nested".to_owned()),
+            (MdiTextBlockKind::ListItem, "first\n\nsecond".to_owned()),
+            (MdiTextBlockKind::Blockquote, "inside quote".to_owned()),
+            (MdiTextBlockKind::ListItem, "nested item".to_owned()),
+            (MdiTextBlockKind::Table, "h1\th2\nc1\tc2".to_owned()),
+            (MdiTextBlockKind::Code, "code line".to_owned()),
+            (
+                MdiTextBlockKind::Html,
+                "<section>literal html</section>".to_owned(),
+            ),
+            (MdiTextBlockKind::Paragraph, "body".to_owned()),
+            (
+                MdiTextBlockKind::Footnote,
+                "footnote one\n\nfootnote two".to_owned(),
+            ),
+        ]
+    );
+
+    let result = get_mdi_text_blocks(source);
+    assert_eq!(
+        result
+            .blocks
+            .iter()
+            .map(|block| block.index)
+            .collect::<Vec<_>>(),
+        (1..=result.blocks.len() as u32).collect::<Vec<_>>()
+    );
+    for needle in [
+        "quote one",
+        "quoted item",
+        "first",
+        "inside quote",
+        "footnote one",
+    ] {
+        assert_eq!(
+            result
+                .blocks
+                .iter()
+                .filter(|block| block.text.contains(needle))
+                .count(),
+            1,
+            "{needle:?} was duplicated or omitted",
+        );
+    }
+}
+
+#[test]
+fn synthetic_separators_have_exact_ranges_and_never_claim_source_bytes() {
+    let source = concat!(
+        "- one\n\n  two\n\n",
+        "| a | b |\n| - | - |\n| c | d |\n\n",
+        "body[^n]\n\n[^n]: alpha\n\n    beta",
+    );
+    let result = get_mdi_text_blocks(source);
+    let list = &result.blocks[0];
+    let table = &result.blocks[1];
+    let footnote = &result.blocks[3];
+
+    assert_eq!(list.text, "one\n\ntwo");
+    assert_eq!(
+        list.source_map
+            .synthetic
+            .iter()
+            .map(range_tuple)
+            .collect::<Vec<_>>(),
+        vec![(1, 4, 1, 6)]
+    );
+    assert_eq!(table.text, "a\tb\nc\td");
+    assert_eq!(
+        table
+            .source_map
+            .synthetic
+            .iter()
+            .map(range_tuple)
+            .collect::<Vec<_>>(),
+        vec![(2, 2, 2, 3), (2, 4, 2, 5), (2, 6, 2, 7)]
+    );
+    assert_eq!(footnote.text, "alpha\n\nbeta");
+    assert_eq!(
+        footnote
+            .source_map
+            .synthetic
+            .iter()
+            .map(range_tuple)
+            .collect::<Vec<_>>(),
+        vec![(4, 6, 4, 8)]
+    );
+
+    for block in [list, table, footnote] {
+        for synthetic in &block.source_map.synthetic {
+            for character in synthetic.start.character..synthetic.end.character {
+                assert_eq!(source_span_for_character(block, source, character), None);
+            }
+        }
+    }
+}
+
+#[test]
+fn repeated_visible_text_maps_to_content_not_wrappers_urls_or_fence_info() {
+    let source = concat!(
+        "# \\#\n\n",
+        "[rust](https://example.test/rust) rust\n\n",
+        "![rust](rust.png) rust\n\n",
+        "```rust\nrust\n```",
+    );
+    let result = get_mdi_text_blocks(source);
+    assert_eq!(
+        result
+            .blocks
+            .iter()
+            .map(|block| block.text.as_str())
+            .collect::<Vec<_>>(),
+        vec!["#", "rust rust", "rust rust", "rust"]
+    );
+
+    let heading = source_span_for_character(&result.blocks[0], source, 1).unwrap();
+    assert_eq!(heading.2, r"\#");
+
+    let link_label = source.find("[rust]").unwrap() as u32 + 1;
+    let link_first = source_span_for_character(&result.blocks[1], source, 1).unwrap();
+    assert_eq!(link_first.0, link_label);
+    let plain_after_link = source.find(") rust").unwrap() as u32 + 2;
+    let link_plain_first = source_span_for_character(&result.blocks[1], source, 6).unwrap();
+    assert_eq!(link_plain_first.0, plain_after_link);
+
+    let image_label = source.find("![rust]").unwrap() as u32 + 2;
+    let image_first = source_span_for_character(&result.blocks[2], source, 1).unwrap();
+    assert_eq!(image_first.0, image_label);
+    let plain_after_image = source.find(") rust\n\n```").unwrap() as u32 + 2;
+    let image_plain_first = source_span_for_character(&result.blocks[2], source, 6).unwrap();
+    assert_eq!(image_plain_first.0, plain_after_image);
+
+    let code_content = source.rfind("\nrust\n```").unwrap() as u32 + 1;
+    let code_first = source_span_for_character(&result.blocks[3], source, 1).unwrap();
+    assert_eq!(code_first.0, code_content);
+    assert_ne!(code_first.0, source.find("```rust").unwrap() as u32 + 3);
+}
+
+#[test]
+fn empty_document_markup_and_normal_whitespace_emit_no_blocks_but_code_whitespace_is_literal() {
+    for source in [
+        "",
+        " ",
+        "\t",
+        "\n\n",
+        "   \n\t\n",
+        "---",
+        "***",
+        "---\ntitle: hidden\n---",
+        "[[pagebreak]]",
+    ] {
+        assert!(
+            get_mdi_text_blocks(source).blocks.is_empty(),
+            "unexpected block for {source:?}",
+        );
+    }
+
+    let code = get_mdi_text_blocks("```text\n \t\n\n```");
+    assert_eq!(code.blocks.len(), 1);
+    assert_eq!(code.blocks[0].kind, MdiTextBlockKind::Code);
+    assert_eq!(code.blocks[0].text, " \t\n");
+    assert!(code.blocks[0].source_map.synthetic.is_empty());
+    assert!(code.blocks[0].source_map.unmapped.is_empty());
+
+    let significant_unicode_space = get_mdi_text_blocks("　");
+    assert_eq!(significant_unicode_space.blocks[0].text, "　");
+}
+
+#[test]
+fn large_and_deep_supported_documents_avoid_catastrophic_slowdowns() {
+    const BLOCKS: usize = 2_000;
+    let mut source = String::new();
+    for index in 0..BLOCKS {
+        source.push_str(&format!("paragraph {index} {{東京|とうきょう}} 👩🏽‍💻\n\n"));
+    }
+    source.push_str(&(0..128).map(|_| "> ").collect::<String>());
+    source.push_str("deep leaf\n\n");
+    source.push_str("| h0 | h1 | h2 | h3 | h4 | h5 | h6 | h7 |\n");
+    source.push_str("| -- | -- | -- | -- | -- | -- | -- | -- |\n");
+    for row in 0..200 {
+        source.push_str(&format!(
+            "| {row}-0 | {row}-1 | {row}-2 | {row}-3 | {row}-4 | {row}-5 | {row}-6 | {row}-7 |\n"
+        ));
+    }
+
+    let started = Instant::now();
+    let result = get_mdi_text_blocks(&source);
+    let elapsed = started.elapsed();
+    assert!(
+        elapsed < Duration::from_secs(30),
+        "projection took {elapsed:?}; likely catastrophic complexity regression",
+    );
+    assert_eq!(result.blocks.len(), BLOCKS + 2);
+    assert_eq!(result.blocks[0].text, "paragraph 0 東京 👩🏽‍💻");
+    assert_eq!(result.blocks[BLOCKS - 1].text, "paragraph 1999 東京 👩🏽‍💻");
+    assert_eq!(result.blocks[BLOCKS].text, "deep leaf");
+    assert_eq!(result.blocks[BLOCKS].kind, MdiTextBlockKind::Blockquote);
+    assert_eq!(result.blocks[BLOCKS + 1].kind, MdiTextBlockKind::Table);
+    assert_eq!(result.blocks[BLOCKS + 1].text.lines().count(), 201);
+    assert_eq!(
+        result.blocks[BLOCKS + 1]
+            .text
+            .graphemes(true)
+            .filter(|value| *value == "\t")
+            .count(),
+        201 * 7,
+    );
+
+    // Include serialization in the scale contract because JSON is the binding
+    // boundary and can regress independently from projection construction.
+    let json = get_mdi_text_blocks_json(&source);
+    assert!(json.starts_with(r#"{"projectionVersion":"1.0""#));
+    assert!(json.contains("deep leaf"));
+}

--- a/mdi-core/tests/text_projection_invariants.rs
+++ b/mdi-core/tests/text_projection_invariants.rs
@@ -1,0 +1,549 @@
+use mdi_core::{
+    MdiTextBlock, MdiTextBlockKind, MdiTextRange, MdiTextSourceMap, SourceSpan,
+    get_mdi_text_blocks, get_mdi_text_blocks_json,
+};
+use unicode_segmentation::UnicodeSegmentation;
+
+fn range_indices(
+    range: &MdiTextRange,
+    block: u32,
+    unit_count: usize,
+    context: &str,
+) -> (usize, usize) {
+    assert_eq!(range.start.block, block, "wrong start block in {context}");
+    assert_eq!(range.end.block, block, "wrong end block in {context}");
+    assert!(
+        range.start.character >= 1,
+        "zero start position in {context}"
+    );
+    assert!(
+        range.end.character >= range.start.character,
+        "reversed range in {context}"
+    );
+    let start = range.start.character as usize - 1;
+    let end = range.end.character as usize - 1;
+    assert!(
+        end <= unit_count,
+        "out-of-bounds range in {context}: {start}..{end}/{unit_count}"
+    );
+    (start, end)
+}
+
+fn assert_source_map_partition(
+    map: &MdiTextSourceMap,
+    block: u32,
+    unit_count: usize,
+    source: &str,
+    document_span: SourceSpan,
+    context: &str,
+) {
+    let mut coverage = vec![0_u8; unit_count];
+
+    for (run_index, run) in map.runs.iter().enumerate() {
+        let run_context = format!("{context} run {run_index}");
+        let (start, end) = range_indices(&run.range, block, unit_count, &run_context);
+        assert!(start < end, "empty source run in {run_context}");
+        assert_eq!(
+            run.source_boundaries.len(),
+            end - start + 1,
+            "one source span must be supplied for every grapheme in {run_context}"
+        );
+        for boundary in &run.source_boundaries {
+            let boundary = *boundary as usize;
+            assert!(
+                boundary <= source.len(),
+                "source boundary past EOF in {run_context}"
+            );
+            assert!(
+                source.is_char_boundary(boundary),
+                "source boundary splits UTF-8 in {run_context}"
+            );
+            assert!(
+                boundary >= document_span.start_byte as usize
+                    && boundary <= document_span.end_byte as usize,
+                "source boundary outside document span in {run_context}"
+            );
+        }
+        for pair in run.source_boundaries.windows(2) {
+            assert!(
+                pair[0] < pair[1],
+                "empty or reversed grapheme source span in {run_context}"
+            );
+        }
+        for covered in &mut coverage[start..end] {
+            *covered += 1;
+        }
+    }
+
+    for (kind, ranges) in [("synthetic", &map.synthetic), ("unmapped", &map.unmapped)] {
+        for (range_index, range) in ranges.iter().enumerate() {
+            let range_context = format!("{context} {kind} range {range_index}");
+            let (start, end) = range_indices(range, block, unit_count, &range_context);
+            assert!(start < end, "empty {kind} range in {range_context}");
+            for covered in &mut coverage[start..end] {
+                *covered += 1;
+            }
+        }
+    }
+
+    assert!(
+        coverage.iter().all(|count| *count == 1),
+        "source-map categories must exactly partition {context}; coverage={coverage:?}"
+    );
+}
+
+fn assert_span(source: &str, document_span: SourceSpan, span: SourceSpan, context: &str) {
+    assert!(
+        span.start_byte <= span.end_byte,
+        "reversed span in {context}"
+    );
+    assert!(
+        span.start_byte >= document_span.start_byte,
+        "span starts before document in {context}"
+    );
+    assert!(
+        span.end_byte <= document_span.end_byte,
+        "span ends after document in {context}"
+    );
+    assert!(
+        source.is_char_boundary(span.start_byte as usize),
+        "span starts inside UTF-8 in {context}"
+    );
+    assert!(
+        source.is_char_boundary(span.end_byte as usize),
+        "span ends inside UTF-8 in {context}"
+    );
+}
+
+fn assert_projection_invariants(source: &str, require_fully_mapped: bool) {
+    let result = get_mdi_text_blocks(source);
+    let document_span = result.document.span;
+    assert_eq!(document_span.start_byte, 0);
+    assert_eq!(document_span.end_byte as usize, source.len());
+
+    for (offset, block) in result.blocks.iter().enumerate() {
+        let context = format!("block {} ({:?}) for {source:?}", block.index, block.kind);
+        assert_eq!(
+            block.index as usize,
+            offset + 1,
+            "non-contiguous block indexes"
+        );
+        let grapheme_count = block.text.graphemes(true).count();
+        assert!(
+            grapheme_count > 0,
+            "empty text block was emitted in {context}"
+        );
+        assert_eq!(
+            range_indices(&block.range, block.index, grapheme_count, &context),
+            (0, grapheme_count),
+            "block range must cover the complete text"
+        );
+        if let Some(span) = block.span {
+            assert_span(source, document_span, span, &context);
+        }
+        assert_source_map_partition(
+            &block.source_map,
+            block.index,
+            grapheme_count,
+            source,
+            document_span,
+            &context,
+        );
+        if require_fully_mapped {
+            assert!(
+                block.source_map.unmapped.is_empty(),
+                "supported syntax is unmapped: {context}"
+            );
+        }
+
+        for (annotation_index, annotation) in block.annotations.iter().enumerate() {
+            let annotation_context = format!("{context}, annotation {annotation_index}");
+            assert_eq!(annotation.kind, "rubyReading");
+            let annotation_count = annotation.text.graphemes(true).count();
+            assert!(
+                annotation_count > 0,
+                "empty annotation in {annotation_context}"
+            );
+            let (anchor_start, anchor_end) = range_indices(
+                &annotation.anchor,
+                block.index,
+                grapheme_count,
+                &annotation_context,
+            );
+            assert!(
+                anchor_start < anchor_end,
+                "empty annotation anchor in {annotation_context}"
+            );
+            if let Some(span) = annotation.span {
+                assert_span(source, document_span, span, &annotation_context);
+            }
+            assert_source_map_partition(
+                &annotation.source_map,
+                block.index,
+                annotation_count,
+                source,
+                document_span,
+                &annotation_context,
+            );
+            if require_fully_mapped {
+                assert!(
+                    annotation.source_map.unmapped.is_empty(),
+                    "supported annotation is unmapped: {annotation_context}"
+                );
+            }
+        }
+    }
+
+    for (index, diagnostic) in result.diagnostics.iter().enumerate() {
+        if let Some(span) = diagnostic.span {
+            assert_span(source, document_span, span, &format!("diagnostic {index}"));
+        }
+    }
+}
+
+fn mapped_slices<'a>(block: &'a MdiTextBlock, source: &'a str) -> Vec<&'a str> {
+    block
+        .source_map
+        .runs
+        .iter()
+        .flat_map(|run| run.source_boundaries.windows(2))
+        .map(|pair| &source[pair[0] as usize..pair[1] as usize])
+        .collect()
+}
+
+#[test]
+fn supported_corpus_has_an_exact_fully_mapped_partition() {
+    let corpus = [
+        "# 序章\n\n本文 &amp; \\* 終了",
+        "**強調** _斜体_ ~~削除~~ [表示](https://example.test) ![代替](image.png) `code`",
+        "{東京|とうきょう} {東京|とう.きょう} ^12^ [[br]] [[no-break:禁則]][[warichu:割注]][[kern:-0.1em:詰め]][[em:傍点]]",
+        "- first\n\n  second\n  - nested\n\n> quote one\n>\n> quote two",
+        "| a | b |\n| - | - |\n| c | d |\n\n```mdi\ncode\nline\n```",
+        "body[^n]\n\n[^n]: note one\n\n    note two",
+        "---\nmdi: '2.0'\ntitle: hidden\n---\n\nvisible\n\n<div>literal</div>",
+        "{東京|とうきょう\n\n[[em:未閉\n\n^1234567^\n\n<custom>literal</custom>",
+        "e\u{301} 👩🏽‍💻 ✈️ 🇯🇵 1️⃣ क्ष",
+        "# \\#\n\n- \\-\n\n> \\>",
+    ];
+
+    for source in corpus {
+        assert_projection_invariants(source, true);
+    }
+}
+
+#[test]
+fn maps_decoded_and_generated_characters_to_the_right_channels() {
+    let source = r"&amp; \* {東京|とうきょう} 前[[br]]次";
+    let result = get_mdi_text_blocks(source);
+    let block = &result.blocks[0];
+    assert_eq!(block.text, "& * 東京 前\n次");
+    let slices = mapped_slices(block, source);
+    assert!(slices.contains(&"&amp;"));
+    assert!(slices.contains(&r"\*"));
+    assert!(slices.contains(&"[[br]]"));
+    assert!(!slices.iter().any(|slice| slice.contains("とうきょう")));
+
+    let table = get_mdi_text_blocks("| a | b |\n| - | - |\n| c | d |");
+    let table = &table.blocks[0];
+    assert_eq!(table.kind, MdiTextBlockKind::Table);
+    assert_eq!(table.text, "a\tb\nc\td");
+    assert_eq!(
+        table
+            .source_map
+            .synthetic
+            .iter()
+            .map(|range| (range.start.character, range.end.character))
+            .collect::<Vec<_>>(),
+        vec![(2, 3), (4, 5), (6, 7)]
+    );
+}
+
+#[test]
+fn lf_and_crlf_keep_text_coordinates_but_use_real_byte_widths() {
+    let lf = "alpha  \nbeta\n\n```\nx\ny\n```";
+    let crlf = lf.replace('\n', "\r\n");
+    let lf_result = get_mdi_text_blocks(lf);
+    let crlf_result = get_mdi_text_blocks(&crlf);
+
+    assert_eq!(lf_result.blocks.len(), crlf_result.blocks.len());
+    for (lf_block, crlf_block) in lf_result.blocks.iter().zip(&crlf_result.blocks) {
+        assert_eq!(lf_block.index, crlf_block.index);
+        assert_eq!(lf_block.kind, crlf_block.kind);
+        assert_eq!(lf_block.text, crlf_block.text);
+        assert_eq!(lf_block.range, crlf_block.range);
+        assert_eq!(lf_block.annotations, crlf_block.annotations);
+    }
+    assert_eq!(lf_result.blocks[0].text, "alpha\nbeta");
+    assert_eq!(lf_result.blocks[1].text, "x\ny");
+
+    let lf_newlines: Vec<_> = mapped_slices(&lf_result.blocks[0], lf)
+        .into_iter()
+        .filter(|slice| slice.ends_with('\n'))
+        .collect();
+    let crlf_newlines: Vec<_> = mapped_slices(&crlf_result.blocks[0], &crlf)
+        .into_iter()
+        .filter(|slice| slice.ends_with('\n'))
+        .collect();
+    assert_eq!(lf_newlines, vec!["  \n"]);
+    assert_eq!(crlf_newlines, vec!["  \r\n"]);
+
+    let lf_code_newline = mapped_slices(&lf_result.blocks[1], lf)
+        .into_iter()
+        .find(|slice| slice.ends_with('\n'))
+        .expect("mapped LF in code");
+    let crlf_code_newline = mapped_slices(&crlf_result.blocks[1], &crlf)
+        .into_iter()
+        .find(|slice| slice.ends_with('\n'))
+        .expect("mapped CRLF in code");
+    assert_eq!(lf_code_newline, "\n");
+    assert_eq!(crlf_code_newline, "\r\n");
+    assert_eq!(crlf_code_newline.len(), lf_code_newline.len() + 1);
+
+    assert_projection_invariants(lf, true);
+    assert_projection_invariants(&crlf, true);
+}
+
+#[test]
+fn unicode_grapheme_matrix_uses_one_based_extended_grapheme_positions() {
+    let cases = [
+        ("é", 1, "NFC"),
+        ("e\u{301}", 1, "NFD"),
+        ("a\u{301}\u{327}", 1, "multiple combining marks"),
+        ("✈️", 1, "variation selector"),
+        ("🇯🇵", 1, "regional-indicator flag"),
+        ("👍🏽", 1, "emoji modifier"),
+        ("👩🏽‍💻", 1, "ZWJ emoji"),
+        ("1️⃣", 1, "keycap"),
+        ("क्ष", 1, "Indic conjunct"),
+        ("日👩🏽‍💻e\u{301}", 3, "mixed graphemes"),
+        ("e*\u{301}*", 1, "grapheme crossing Markdown nodes"),
+    ];
+
+    for (source, expected_count, label) in cases {
+        let result = get_mdi_text_blocks(source);
+        assert_eq!(result.blocks.len(), 1, "{label}");
+        let block = &result.blocks[0];
+        assert_eq!(
+            block.text.graphemes(true).count(),
+            expected_count,
+            "{label}"
+        );
+        assert_eq!(block.range.start.character, 1, "{label}");
+        assert_eq!(
+            block.range.end.character,
+            expected_count as u32 + 1,
+            "{label}"
+        );
+        assert_projection_invariants(source, true);
+    }
+}
+
+fn positions(range: &MdiTextRange) -> (u32, u32, u32, u32) {
+    (
+        range.start.block,
+        range.start.character,
+        range.end.block,
+        range.end.character,
+    )
+}
+
+#[test]
+fn ruby_group_split_and_mismatch_anchors_are_stable() {
+    let group = get_mdi_text_blocks("前{東京|とうきょう}後");
+    assert_eq!(group.blocks[0].text, "前東京後");
+    let annotation = &group.blocks[0].annotations[0];
+    assert_eq!(annotation.text, "とうきょう");
+    assert_eq!(positions(&annotation.anchor), (1, 2, 1, 4));
+
+    let split = get_mdi_text_blocks("{東京|とう.きょう}");
+    assert_eq!(split.blocks[0].annotations.len(), 2);
+    assert_eq!(split.blocks[0].annotations[0].text, "とう");
+    assert_eq!(
+        positions(&split.blocks[0].annotations[0].anchor),
+        (1, 1, 1, 2)
+    );
+    assert_eq!(split.blocks[0].annotations[1].text, "きょう");
+    assert_eq!(
+        positions(&split.blocks[0].annotations[1].anchor),
+        (1, 2, 1, 3)
+    );
+
+    for source in ["{東京|とう.}", "{東京|と.う.き}"] {
+        let result = get_mdi_text_blocks(source);
+        assert_eq!(result.blocks[0].annotations.len(), 1, "{source}");
+        assert_eq!(
+            positions(&result.blocks[0].annotations[0].anchor),
+            (1, 1, 1, 3)
+        );
+        let warnings: Vec<_> = result
+            .diagnostics
+            .iter()
+            .filter(|diagnostic| diagnostic.code == "mdi.textProjection.rubySplitMismatch")
+            .collect();
+        assert_eq!(warnings.len(), 1, "{source}");
+        assert_eq!(
+            warnings[0].span,
+            Some(SourceSpan {
+                start_byte: 0,
+                end_byte: source.len() as u32
+            })
+        );
+        assert_projection_invariants(source, true);
+    }
+}
+
+#[test]
+fn ruby_escapes_survive_the_document_parser_and_map_complete_escape_tokens() {
+    let escaped = r"{A\|B|えー.ぱいぷ.びー} {点|てん\.読み} {A|えー\|びー}";
+    let escaped_result = get_mdi_text_blocks(escaped);
+    assert_eq!(escaped_result.blocks[0].text, "A|B 点 A");
+    let escaped_annotations = &escaped_result.blocks[0].annotations;
+    assert_eq!(
+        escaped_annotations
+            .iter()
+            .map(|annotation| annotation.text.as_str())
+            .collect::<Vec<_>>(),
+        vec!["えー", "ぱいぷ", "びー", "てん.読み", "えー|びー"]
+    );
+    assert_eq!(positions(&escaped_annotations[0].anchor), (1, 1, 1, 2));
+    assert_eq!(positions(&escaped_annotations[1].anchor), (1, 2, 1, 3));
+    assert_eq!(positions(&escaped_annotations[2].anchor), (1, 3, 1, 4));
+    assert_eq!(positions(&escaped_annotations[3].anchor), (1, 5, 1, 6));
+    assert_eq!(positions(&escaped_annotations[4].anchor), (1, 7, 1, 8));
+    let reading_slices: Vec<_> = escaped_annotations[3]
+        .source_map
+        .runs
+        .iter()
+        .flat_map(|run| run.source_boundaries.windows(2))
+        .map(|pair| &escaped[pair[0] as usize..pair[1] as usize])
+        .collect();
+    assert!(
+        reading_slices.contains(&r"\."),
+        "escaped dot must map to the complete token"
+    );
+    assert_projection_invariants(escaped, true);
+}
+
+#[test]
+fn multiple_ruby_annotations_keep_independent_source_order_anchors() {
+    let multiple = "{東|とう}と{京|きょう}";
+    let multiple_result = get_mdi_text_blocks(multiple);
+    assert_eq!(multiple_result.blocks[0].text, "東と京");
+    assert_eq!(multiple_result.blocks[0].annotations.len(), 2);
+    assert_eq!(
+        positions(&multiple_result.blocks[0].annotations[0].anchor),
+        (1, 1, 1, 2)
+    );
+    assert_eq!(
+        positions(&multiple_result.blocks[0].annotations[1].anchor),
+        (1, 3, 1, 4)
+    );
+    assert_projection_invariants(multiple, true);
+}
+
+fn generated_source(mut state: u64) -> String {
+    const FRAGMENTS: &[&str] = &[
+        "東京",
+        "👩🏽‍💻",
+        "e\u{301}",
+        " ",
+        "\t",
+        "\r",
+        "\n",
+        "\\",
+        "{",
+        "}",
+        "|",
+        ".",
+        "^12^",
+        "^_^",
+        "{東京|とう.きょう}",
+        "{A\\|B|a.b.c}",
+        "[[br]]",
+        "[[em:強調]]",
+        "[[no-break:^12^]]",
+        "[[kern:wide:x]]",
+        "[[indent:2]]",
+        "[[pagebreak:left]]",
+        "《《傍点》》",
+        "**strong**",
+        "`^12^`",
+        "[^n]",
+        "\n\n",
+        "| a | b |\n| - | - |\n| 1 | 2 |\n",
+        "[link](https://example.test/?a=1&b=2)",
+        "![alt](image.png)",
+        "<script>x</script>",
+        "&amp;",
+        "&#x1f469;",
+        "\\{",
+        "\\[",
+        "---\nmdi: '3.0'\ntitle: adversarial\n---\n",
+    ];
+    let mut source = String::new();
+    for _ in 0..24 {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        source.push_str(FRAGMENTS[(state as usize) % FRAGMENTS.len()]);
+    }
+    source
+}
+
+#[test]
+fn parser_recovery_never_panics_on_known_adversarial_combinations() {
+    let mut panic_seeds = Vec::new();
+    for seed in [10_u64, 14, 83] {
+        let source = generated_source(seed);
+        match std::panic::catch_unwind(|| get_mdi_text_blocks(&source)) {
+            Ok(result) => {
+                assert_eq!(
+                    result
+                        .diagnostics
+                        .first()
+                        .map(|diagnostic| diagnostic.code.as_str()),
+                    Some("mdi.parser.recovered"),
+                    "seed {seed} must take the pre-parser recovery path used by Wasm"
+                );
+                assert_eq!(result.blocks.len(), 1, "seed {seed}");
+                assert_eq!(result.blocks[0].text, source, "seed {seed}");
+            }
+            Err(_) => panic_seeds.push((seed, source)),
+        }
+    }
+    assert!(
+        panic_seeds.is_empty(),
+        "projection panicked for deterministic regression cases: {panic_seeds:#?}"
+    );
+}
+
+#[test]
+fn deterministic_adversarial_corpus_serializes_stably() {
+    for seed in 0..96_u64 {
+        if [10, 14, 83].contains(&seed) {
+            continue;
+        }
+        let source = generated_source(seed);
+        let result = std::panic::catch_unwind(|| get_mdi_text_blocks(&source))
+            .unwrap_or_else(|_| panic!("projection panicked for seed {seed}: {source:?}"));
+        let second = get_mdi_text_blocks(&source);
+        assert_eq!(result, second, "non-deterministic result for seed {seed}");
+
+        let json = std::panic::catch_unwind(|| get_mdi_text_blocks_json(&source))
+            .unwrap_or_else(|_| panic!("JSON projection panicked for seed {seed}: {source:?}"));
+        assert_eq!(
+            json,
+            get_mdi_text_blocks_json(&source),
+            "non-deterministic JSON for seed {seed}"
+        );
+        let decoded: serde_json::Value = serde_json::from_str(&json)
+            .unwrap_or_else(|error| panic!("invalid JSON for seed {seed}: {error}"));
+        assert_eq!(decoded["projectionVersion"], "1.0");
+        assert_eq!(
+            decoded["positionEncoding"],
+            "unicode-grapheme-cluster-1-based"
+        );
+
+        assert_projection_invariants(&source, false);
+    }
+}

--- a/mdi-core/tests/text_projection_property.rs
+++ b/mdi-core/tests/text_projection_property.rs
@@ -1,0 +1,102 @@
+use mdi_core::{MdiTextBlock, get_mdi_text_blocks, get_mdi_text_blocks_json};
+use proptest::prelude::*;
+use unicode_segmentation::UnicodeSegmentation;
+
+fn assert_total_partition(block: &MdiTextBlock, source: &str) {
+    let graphemes = block.text.graphemes(true).count();
+    assert_eq!(block.index, block.range.start.block);
+    assert_eq!(block.index, block.range.end.block);
+    assert_eq!(block.range.start.character, 1);
+    assert_eq!(block.range.end.character as usize, graphemes + 1);
+
+    let mut coverage = vec![0_u8; graphemes];
+    for run in &block.source_map.runs {
+        let start = run.range.start.character as usize - 1;
+        let end = run.range.end.character as usize - 1;
+        assert!(start <= end && end <= graphemes);
+        assert_eq!(run.source_boundaries.len(), end - start + 1);
+        for boundary in &run.source_boundaries {
+            assert!((*boundary as usize) <= source.len());
+            assert!(source.is_char_boundary(*boundary as usize));
+        }
+        for pair in run.source_boundaries.windows(2) {
+            assert!(pair[0] <= pair[1]);
+        }
+        for item in &mut coverage[start..end] {
+            *item += 1;
+        }
+    }
+    for range in block
+        .source_map
+        .synthetic
+        .iter()
+        .chain(&block.source_map.unmapped)
+    {
+        let start = range.start.character as usize - 1;
+        let end = range.end.character as usize - 1;
+        assert!(start <= end && end <= graphemes);
+        for item in &mut coverage[start..end] {
+            *item += 1;
+        }
+    }
+    assert!(coverage.iter().all(|count| *count == 1));
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        cases: 96,
+        failure_persistence: None,
+        ..ProptestConfig::default()
+    })]
+
+    #[test]
+    fn arbitrary_unicode_is_total_deterministic_and_well_formed(
+        characters in prop::collection::vec(any::<char>(), 0..160),
+    ) {
+        let source: String = characters.into_iter().collect();
+        let first = get_mdi_text_blocks(&source);
+        let second = get_mdi_text_blocks(&source);
+        prop_assert_eq!(&first, &second);
+        prop_assert_eq!(first.document.span.start_byte, 0);
+        prop_assert_eq!(first.document.span.end_byte as usize, source.len());
+        prop_assert_eq!(get_mdi_text_blocks_json(&source), get_mdi_text_blocks_json(&source));
+        for (index, block) in first.blocks.iter().enumerate() {
+            prop_assert_eq!(block.index as usize, index + 1);
+            assert_total_partition(block, &source);
+        }
+    }
+
+    #[test]
+    fn generated_supported_inline_corpus_has_no_unmapped_text(
+        pieces in prop::collection::vec(
+            prop_oneof![
+                Just("日本語"),
+                Just("e\u{301}"),
+                Just("👩🏽‍💻"),
+                Just("{東京|とうきょう}"),
+                Just("{東京|とう.きょう}"),
+                Just("^12^"),
+                Just("**strong**"),
+                Just("[label](https://example.test)"),
+                Just("![alt](image.png)"),
+                Just("`code`"),
+                Just(r"\*"),
+                Just("&amp;"),
+                Just("[[no-break:禁則]]"),
+                Just("[[warichu:割注]]"),
+                Just("[[kern:-0.1em:詰め]]"),
+                Just("[[em:傍点]]"),
+                Just("before[[br]]after"),
+            ],
+            1..48,
+        ),
+    ) {
+        let source = pieces.join(" ");
+        let result = get_mdi_text_blocks(&source);
+        prop_assert!(!result.blocks.is_empty());
+        for block in &result.blocks {
+            assert_total_partition(block, &source);
+            prop_assert!(block.source_map.unmapped.is_empty(), "{block:#?}");
+        }
+    }
+}

--- a/mdi-core/tests/text_projection_render_parity.rs
+++ b/mdi-core/tests/text_projection_render_parity.rs
@@ -1,0 +1,57 @@
+use mdi_core::{get_mdi_text_blocks, render_text};
+
+#[test]
+fn render_text_and_projection_share_every_inline_plaintext_rule() {
+    let cases = [
+        ("plain", "plain"),
+        ("{東京|とうきょう}", "東京"),
+        ("{東京|とう.きょう}", "東京"),
+        ("^12^", "12"),
+        ("**strong**", "strong"),
+        ("*emphasis*", "emphasis"),
+        ("~~deleted~~", "deleted"),
+        ("[[em:傍点]]", "傍点"),
+        ("[[no-break:禁則]]", "禁則"),
+        ("[[warichu:割注]]", "割注"),
+        ("[[kern:-0.1em:詰め]]", "詰め"),
+        ("[label](https://example.test/url)", "label"),
+        ("![alternative](image.png)", "alternative"),
+        ("`inline code`", "inline code"),
+        ("before[[br]]after", "before\nafter"),
+        (
+            "reference[^note]\n\n[^note]: definition",
+            "reference\ndefinition",
+        ),
+        (r"\* &amp;", "* &"),
+        ("{broken", "{broken"),
+    ];
+
+    for (source, expected) in cases {
+        let projection = get_mdi_text_blocks(source);
+        let projected = projection
+            .blocks
+            .iter()
+            .map(|block| block.text.as_str())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert_eq!(projected, expected, "projection differs for {source:?}");
+        assert_eq!(
+            render_text(source).trim_end_matches('\n'),
+            expected,
+            "render_text differs for {source:?}"
+        );
+    }
+}
+
+#[test]
+fn footnote_reference_never_leaks_its_identifier_into_body_text() {
+    let result = get_mdi_text_blocks("body[^private-id]\n\n[^private-id]: searchable note");
+    assert_eq!(result.blocks[0].text, "body");
+    assert_eq!(result.blocks[1].text, "searchable note");
+    assert!(
+        result
+            .blocks
+            .iter()
+            .all(|block| !block.text.contains("private-id"))
+    );
+}

--- a/nodejs/browser-test/src.ts
+++ b/nodejs/browser-test/src.ts
@@ -1,4 +1,4 @@
-import { initializeMdi, parse, serializeMdi } from "@illusions-lab/mdi";
+import { getMdiTextBlocks, initializeMdi, parse, serializeMdi } from "@illusions-lab/mdi";
 import remarkMdi from "@illusions-lab/mdi-remark";
 import remarkParse from "remark-parse";
 import remarkStringify from "remark-stringify";
@@ -16,6 +16,15 @@ title: ブラウザ 😀
 | nested | [[em:MDI]] |
 `;
 const largeSource = `${source}\n\n${"段落 {東京|とうきょう} 😀\n\n".repeat(256)}`;
+const recoverySource = `[[no-break:^12^]]---
+mdi: '3.0'
+title: adversarial
+---
+---
+mdi: '3.0'
+title: adversarial
+---
+`;
 
 void run().catch((error: unknown) => {
   document.querySelector("#result")!.textContent = JSON.stringify({
@@ -38,6 +47,8 @@ async function run(): Promise<void> {
   }
 
   const parsed = parse(source);
+  const projection = getMdiTextBlocks(source);
+  const recoveryProjection = getMdiTextBlocks(recoverySource);
   const canonical = serializeMdi(source);
   const large = parse(largeSource);
   const unsupportedVersion = parse("---\nmdi: '3.0'\n---\n\nmalformed-version corpus");
@@ -48,6 +59,13 @@ async function run(): Promise<void> {
 
   document.querySelector("#result")!.textContent = JSON.stringify({
     irVersion: parsed.irVersion,
+    projectionVersion: projection.projectionVersion,
+    projectionSource: source,
+    projectionJson: JSON.stringify(projection),
+    recoverySource,
+    recoveryProjectionJson: JSON.stringify(recoveryProjection),
+    recoveryDiagnostic: recoveryProjection.diagnostics[0],
+    projectedBlocks: projection.blocks.map(({ kind, text, range }) => ({ kind, text, range })),
     firstNode: parsed.document.children[0]?.type,
     canonical,
     remarkOutput,

--- a/nodejs/packages/mdi-core/src/browser.d.ts
+++ b/nodejs/packages/mdi-core/src/browser.d.ts
@@ -1,6 +1,6 @@
 export {
   applyPdfProfileJson, blockMacroAmount, blockMacroKind, blockMacroVariant,
-  pageSizeCatalogJson, parseMdiSyntaxJson, prepareChromiumPrintProfileJson,
+  getMdiTextBlocksJson, pageSizeCatalogJson, parseMdiSyntaxJson, prepareChromiumPrintProfileJson,
   renderDocx, renderDocxWithProfile, renderEpub, renderEpubWithProfile,
   renderHtml, renderText, renderTextFormat, resolveExportProfileJson,
   resolveRuby, serializeMdi, unescapeMdi, unescapeRubyText,

--- a/nodejs/packages/mdi-core/src/browser.js
+++ b/nodejs/packages/mdi-core/src/browser.js
@@ -20,6 +20,7 @@ export const blockMacroAmount = (...args) => (requireInitialized(), bindings.blo
 export const blockMacroKind = (...args) => (requireInitialized(), bindings.blockMacroKind(...args));
 export const blockMacroVariant = (...args) => (requireInitialized(), bindings.blockMacroVariant(...args));
 export const pageSizeCatalogJson = (...args) => (requireInitialized(), bindings.pageSizeCatalogJson(...args));
+export const getMdiTextBlocksJson = (...args) => (requireInitialized(), bindings.getMdiTextBlocksJson(...args));
 export const parseMdiSyntaxJson = (...args) => (requireInitialized(), bindings.parseMdiSyntaxJson(...args));
 export const prepareChromiumPrintProfileJson = (...args) => (requireInitialized(), bindings.prepareChromiumPrintProfileJson(...args));
 export const renderDocx = (...args) => (requireInitialized(), bindings.renderDocx(...args));

--- a/nodejs/packages/mdi-core/src/node.cjs
+++ b/nodejs/packages/mdi-core/src/node.cjs
@@ -13,6 +13,7 @@ exports.blockMacroAmount = bindings.blockMacroAmount;
 exports.blockMacroKind = bindings.blockMacroKind;
 exports.blockMacroVariant = bindings.blockMacroVariant;
 exports.pageSizeCatalogJson = bindings.pageSizeCatalogJson;
+exports.getMdiTextBlocksJson = bindings.getMdiTextBlocksJson;
 exports.parseMdiSyntaxJson = bindings.parseMdiSyntaxJson;
 exports.prepareChromiumPrintProfileJson = bindings.prepareChromiumPrintProfileJson;
 exports.renderDocx = bindings.renderDocx;

--- a/nodejs/packages/mdi/README.md
+++ b/nodejs/packages/mdi/README.md
@@ -79,6 +79,29 @@ Applications should treat the IR version as a wire-protocol version. They
 must not infer grammar rules from object shapes or silently accept an
 unsupported version.
 
+## Searchable text blocks
+
+`getMdiTextBlocks(source)` returns Rust-projected heading, paragraph, list,
+blockquote, code, table, footnote, and HTML text in source order. Positions
+such as `3:18` count one-based Unicode grapheme clusters; ruby readings are a
+separate annotation channel anchored to the base-text range.
+
+```ts
+import { getMdiTextBlocks, sourceSpansForTextRange } from "@illusions-lab/mdi";
+
+const result = getMdiTextBlocks("{東京|とうきょう}");
+const block = result.blocks[0];
+console.log(block.text); // 東京
+console.log(block.annotations[0].anchor); // { start: "1:1", end: "1:3" }
+console.log(sourceSpansForTextRange(block, { start: "1:1", end: "1:3" }));
+```
+
+Each source-derived grapheme is represented by a `sourceMap.runs` boundary;
+table tabs/newlines and multi-paragraph joiners appear in `synthetic` and do
+not receive invented source spans. `parseMdiTextPosition`,
+`formatMdiTextPosition`, and `formatMdiTextRange` provide stateless coordinate
+helpers.
+
 ## Rendering
 
 Rendering starts from the same Rust IR. Canonical MDI, plain text, HTML, EPUB,

--- a/nodejs/packages/mdi/src/index.test.ts
+++ b/nodejs/packages/mdi/src/index.test.ts
@@ -1,6 +1,6 @@
 import JSZip from "jszip";
 import { describe, expect, it } from "vitest";
-import { MDI_IR_VERSION, MDI_SPEC_VERSION, initializeMdi, parse, prepareRender, renderDocx, renderDocxWithDiagnostics, renderDocxWithProfile, renderEpub, renderEpubWithDiagnostics, renderEpubWithProfile, renderHtml, renderHtmlWithDiagnostics, renderText, renderTextFormat, renderTextFormatWithDiagnostics, renderTextWithDiagnostics, serializeMdi, toPublicationMdast } from "./index.js";
+import { MDI_IR_VERSION, MDI_SPEC_VERSION, formatMdiTextPosition, formatMdiTextRange, getMdiTextBlocks, initializeMdi, parse, parseMdiTextPosition, prepareRender, renderDocx, renderDocxWithDiagnostics, renderDocxWithProfile, renderEpub, renderEpubWithDiagnostics, renderEpubWithProfile, renderHtml, renderHtmlWithDiagnostics, renderText, renderTextFormat, renderTextFormatWithDiagnostics, renderTextWithDiagnostics, serializeMdi, sourceSpansForTextRange, toPublicationMdast } from "./index.js";
 
 function assertValidSpans(node: { span?: { startByte: number; endByte: number }; children?: unknown[] }, source: string): void {
 	if (node.span) {
@@ -35,6 +35,45 @@ describe("Rust MDI JavaScript binding", () => {
 		expect(result.document.children[0]).toMatchObject({ type: "paragraph", span: { startByte: 0, endByte: 10 } });
 	});
 
+	it("returns Rust-owned grapheme text blocks, ruby annotations, and source maps", () => {
+		const source = "# 序章\n\n我喜歡{東京|とうきょう}。\n\né 👩🏽‍💻";
+		const result = getMdiTextBlocks(source);
+
+		expect(result).toMatchObject({
+			projectionVersion: "1.0",
+			positionEncoding: "unicode-grapheme-cluster-1-based",
+			irVersion: MDI_IR_VERSION,
+			syntaxVersion: MDI_SPEC_VERSION,
+		});
+		expect(result.blocks.map(({ kind, text, range }) => ({ kind, text, range }))).toEqual([
+			{ kind: "heading", text: "序章", range: { start: "1:1", end: "1:3" } },
+			{ kind: "paragraph", text: "我喜歡東京。", range: { start: "2:1", end: "2:7" } },
+			{ kind: "paragraph", text: "é 👩🏽‍💻", range: { start: "3:1", end: "3:4" } },
+		]);
+		expect(result.blocks[1]!.annotations[0]).toMatchObject({
+			kind: "rubyReading",
+			text: "とうきょう",
+			anchor: { start: "2:4", end: "2:6" },
+		});
+		expect(sourceSpansForTextRange(result.blocks[1]!, { start: "2:4", end: "2:6" })).toEqual([
+			{
+				startByte: Buffer.byteLength("# 序章\n\n我喜歡{"),
+				endByte: Buffer.byteLength("# 序章\n\n我喜歡{東京"),
+			},
+		]);
+	});
+
+	it("formats positions and omits synthetic separators from source span lookup", () => {
+		expect(parseMdiTextPosition("3:18")).toEqual({ block: 3, character: 18 });
+		expect(formatMdiTextPosition({ block: 3, character: 18 })).toBe("3:18");
+		expect(formatMdiTextRange({ start: "3:18", end: "3:24" })).toBe("3:18-3:24");
+		expect(() => parseMdiTextPosition("3:0")).toThrow("Invalid MDI text position");
+
+		const table = getMdiTextBlocks("| a | b |\n| - | - |\n| c | d |").blocks[0]!;
+		expect(table.text).toBe("a\tb\nc\td");
+		expect(sourceSpansForTextRange(table, { start: "1:2", end: "1:3" })).toEqual([]);
+	});
+
 	it("exposes nested syntax decisions made by Rust", () => {
 		const result = parse("**第^12^話**\n\n| a | b |\n| - | - |\n| 1 | 2 |");
 		expect(result.document.children.map((node) => node.type)).toEqual(["paragraph", "table"]);
@@ -47,6 +86,7 @@ describe("Rust MDI JavaScript binding", () => {
 
 	it("rejects non-string input at the host boundary", () => {
 		expect(() => parse(null as never)).toThrow("source must be a string");
+		expect(() => getMdiTextBlocks(null as never)).toThrow("source must be a string");
 		expect(() => renderHtml({} as never)).toThrow("source must be a string");
 		expect(() => renderEpub(null as never)).toThrow("source must be a string");
 		expect(() => renderDocx(null as never)).toThrow("source must be a string");

--- a/nodejs/packages/mdi/src/index.ts
+++ b/nodejs/packages/mdi/src/index.ts
@@ -5,6 +5,7 @@ import type { Root } from "mdast";
 import { parse as parseYaml } from "yaml";
 
 const {
+	getMdiTextBlocksJson,
 	parseMdiSyntaxJson,
 	renderHtml: renderHtmlFromRust,
 	renderEpub: renderEpubFromRust,
@@ -104,6 +105,9 @@ export const MDI_SPEC_VERSION = "2.0" as const;
 /** Version of the complete Rust-owned document IR. */
 export const MDI_IR_VERSION = "1.0" as const;
 
+/** Version of the Rust-owned searchable text projection. */
+export const MDI_TEXT_PROJECTION_VERSION = "1.0" as const;
+
 export interface MdiParserCapabilities {
 	mdi: boolean;
 	commonMark: boolean;
@@ -117,6 +121,66 @@ export interface MdiSourceSpan {
 	startByte: number;
 	/** Exclusive UTF-8 byte offset. */
 	endByte: number;
+}
+
+/** A canonical one-based `block:grapheme` text position. */
+export type MdiTextPosition = `${number}:${number}`;
+
+export interface MdiTextPositionValue {
+	block: number;
+	character: number;
+}
+
+export interface MdiTextRange {
+	/** Inclusive. */
+	start: MdiTextPosition;
+	/** Exclusive. */
+	end: MdiTextPosition;
+}
+
+export interface MdiTextSourceRun {
+	range: MdiTextRange;
+	/** One UTF-8 source boundary per grapheme, plus the final boundary. */
+	sourceBoundaries: number[];
+}
+
+export interface MdiTextSourceMap {
+	runs: MdiTextSourceRun[];
+	synthetic: MdiTextRange[];
+	unmapped: MdiTextRange[];
+}
+
+export type MdiAnnotationSourceMap = MdiTextSourceMap;
+
+export interface MdiTextAnnotation {
+	kind: "rubyReading";
+	text: string;
+	anchor: MdiTextRange;
+	span?: MdiSourceSpan;
+	sourceMap: MdiAnnotationSourceMap;
+}
+
+export interface MdiTextBlock {
+	/** One-based source-order block number. */
+	index: number;
+	kind: "heading" | "paragraph" | "listItem" | "blockquote" | "code" | "table" | "footnote" | "html" | "other";
+	text: string;
+	range: MdiTextRange;
+	span?: MdiSourceSpan;
+	sourceMap: MdiTextSourceMap;
+	annotations: MdiTextAnnotation[];
+	node: MdiNode;
+}
+
+export interface MdiTextBlocksResult {
+	projectionVersion: "1.0";
+	positionEncoding: "unicode-grapheme-cluster-1-based";
+	irVersion: typeof MDI_IR_VERSION;
+	syntaxVersion: typeof MDI_SPEC_VERSION;
+	capabilities: MdiParserCapabilities;
+	blocks: MdiTextBlock[];
+	document: MdiDocument;
+	diagnostics: MdiDiagnostic[];
 }
 
 export interface MdiDiagnostic {
@@ -217,6 +281,121 @@ export function parse(source: string): MdiSyntaxParseResult {
 		throw new Error(`Unsupported MDI IR version: ${String(result.irVersion)}`);
 	}
 	return result;
+}
+
+/**
+ * Parse once in Rust and return source-order plaintext blocks, annotations,
+ * and grapheme-precise UTF-8 source maps alongside the complete document IR.
+ */
+export function getMdiTextBlocks(source: string): MdiTextBlocksResult {
+	if (typeof source !== "string") throw new TypeError("source must be a string");
+	const result = JSON.parse(getMdiTextBlocksJson(source)) as MdiTextBlocksResult;
+	if (result.projectionVersion !== MDI_TEXT_PROJECTION_VERSION) {
+		throw new Error(`Unsupported MDI text projection version: ${String(result.projectionVersion)}`);
+	}
+	return result;
+}
+
+/** Parse and validate a canonical one-based `block:character` position. */
+export function parseMdiTextPosition(position: string): MdiTextPositionValue {
+	if (typeof position !== "string") throw new TypeError("position must be a string");
+	const match = /^([1-9]\d*):([1-9]\d*)$/.exec(position);
+	if (!match) throw new RangeError(`Invalid MDI text position: ${position}`);
+	const block = Number(match[1]);
+	const character = Number(match[2]);
+	if (!Number.isSafeInteger(block) || !Number.isSafeInteger(character)) {
+		throw new RangeError(`Invalid MDI text position: ${position}`);
+	}
+	return { block, character };
+}
+
+/** Format a validated one-based text position. */
+export function formatMdiTextPosition(position: MdiTextPositionValue): MdiTextPosition {
+	if (!position || typeof position !== "object") {
+		throw new TypeError("position must be an object");
+	}
+	if (!isPositiveSafeInteger(position.block) || !isPositiveSafeInteger(position.character)) {
+		throw new RangeError("position.block and position.character must be positive safe integers");
+	}
+	return `${position.block}:${position.character}`;
+}
+
+/** Format a canonical full `start-end` range such as `3:18-3:24`. */
+export function formatMdiTextRange(range: MdiTextRange): string {
+	if (!range || typeof range !== "object") throw new TypeError("range must be an object");
+	const start = parseMdiTextPosition(range.start);
+	const end = parseMdiTextPosition(range.end);
+	if (start.block !== end.block || end.character < start.character) {
+		throw new RangeError("range must be ordered within one text block");
+	}
+	return `${range.start}-${range.end}`;
+}
+
+/**
+ * Resolve a text range to its source-derived UTF-8 spans. Synthetic table or
+ * paragraph separators are deliberately omitted.
+ */
+export function sourceSpansForTextRange(
+	block: MdiTextBlock,
+	range: MdiTextRange,
+): MdiSourceSpan[] {
+	if (!block || typeof block !== "object") throw new TypeError("block must be an object");
+	const start = parseMdiTextPosition(range.start);
+	const end = parseMdiTextPosition(range.end);
+	if (start.block !== block.index || end.block !== block.index) {
+		throw new RangeError("range must belong to the supplied text block");
+	}
+	const blockEnd = parseMdiTextPosition(block.range.end).character;
+	if (end.character < start.character || start.character < 1 || end.character > blockEnd) {
+		throw new RangeError("range falls outside the supplied text block");
+	}
+
+	const spans: MdiSourceSpan[] = [];
+	let previousRunEnd = 1;
+	for (const run of block.sourceMap.runs) {
+		const runStartPosition = parseMdiTextPosition(run.range.start);
+		const runEndPosition = parseMdiTextPosition(run.range.end);
+		const runStart = runStartPosition.character;
+		const runEnd = runEndPosition.character;
+		const invalidRange = runStartPosition.block !== block.index
+			|| runEndPosition.block !== block.index
+			|| runEnd < runStart
+			|| runStart < previousRunEnd
+			|| runEnd > blockEnd;
+		const invalidBoundaries = run.sourceBoundaries.length !== runEnd - runStart + 1
+			|| run.sourceBoundaries.some((boundary) => !Number.isSafeInteger(boundary) || boundary < 0)
+			|| run.sourceBoundaries.some((boundary, index) => index > 0 && boundary < run.sourceBoundaries[index - 1]!)
+			|| (block.span !== undefined && run.sourceBoundaries.some(
+				(boundary) => boundary < block.span!.startByte || boundary > block.span!.endByte,
+			));
+		if (invalidRange || invalidBoundaries) {
+			throw new Error("Invalid MDI text source run");
+		}
+		previousRunEnd = runEnd;
+		const overlapStart = Math.max(start.character, runStart);
+		const overlapEnd = Math.min(end.character, runEnd);
+		for (let character = overlapStart; character < overlapEnd; character += 1) {
+			const offset = character - runStart;
+			appendMergedSourceSpan(spans, {
+				startByte: run.sourceBoundaries[offset]!,
+				endByte: run.sourceBoundaries[offset + 1]!,
+			});
+		}
+	}
+	return spans;
+}
+
+function appendMergedSourceSpan(spans: MdiSourceSpan[], next: MdiSourceSpan): void {
+	const previous = spans.at(-1);
+	if (previous?.endByte === next.startByte) {
+		previous.endByte = next.endByte;
+	} else {
+		spans.push(next);
+	}
+}
+
+function isPositiveSafeInteger(value: unknown): value is number {
+	return typeof value === "number" && Number.isSafeInteger(value) && value >= 1;
 }
 
 /** Render complete `.mdi` source to standalone semantic HTML in Rust. */

--- a/nodejs/packages/mdi/src/text-projection-utils.test.ts
+++ b/nodejs/packages/mdi/src/text-projection-utils.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, it } from "vitest";
+import {
+	formatMdiTextPosition,
+	formatMdiTextRange,
+	parseMdiTextPosition,
+	sourceSpansForTextRange,
+	type MdiTextBlock,
+	type MdiTextSourceRun,
+} from "./index.js";
+
+function blockWithRuns(
+	runs: MdiTextSourceRun[],
+	overrides: Partial<MdiTextBlock> = {},
+): MdiTextBlock {
+	return {
+		index: 1,
+		kind: "paragraph",
+		text: "abcdef",
+		range: { start: "1:1", end: "1:7" },
+		span: { startByte: 0, endByte: 100 },
+		sourceMap: { runs, synthetic: [], unmapped: [] },
+		annotations: [],
+		node: { type: "paragraph" },
+		...overrides,
+	};
+}
+
+describe("MDI text position utilities", () => {
+	it("parses canonical one-based positions through the safe-integer limit", () => {
+		expect(parseMdiTextPosition("1:1")).toEqual({ block: 1, character: 1 });
+		expect(parseMdiTextPosition("3:18")).toEqual({ block: 3, character: 18 });
+		expect(parseMdiTextPosition(`${Number.MAX_SAFE_INTEGER}:${Number.MAX_SAFE_INTEGER}`)).toEqual({
+			block: Number.MAX_SAFE_INTEGER,
+			character: Number.MAX_SAFE_INTEGER,
+		});
+	});
+
+	it.each([
+		"0:1",
+		"1:0",
+		"-1:1",
+		"1:-1",
+		"1.5:2",
+		"1:2.5",
+		"NaN:1",
+		"1:NaN",
+		"Infinity:1",
+		"1:Infinity",
+		"01:1",
+		"1:01",
+		"+1:1",
+		"1e2:1",
+		"1",
+		"1:2:3",
+		" 1:2",
+		"1:2 ",
+		"1 : 2",
+		`${Number.MAX_SAFE_INTEGER + 1}:1`,
+		`1:${Number.MAX_SAFE_INTEGER + 1}`,
+	])("rejects non-canonical position %j", (position) => {
+		expect(() => parseMdiTextPosition(position)).toThrow("Invalid MDI text position");
+	});
+
+	it("rejects non-string parse input", () => {
+		expect(() => parseMdiTextPosition(Number.NaN as never)).toThrow(TypeError);
+		expect(() => parseMdiTextPosition(null as never)).toThrow(TypeError);
+	});
+
+	it("formats only positive safe-integer values", () => {
+		expect(formatMdiTextPosition({ block: 3, character: 18 })).toBe("3:18");
+		expect(formatMdiTextPosition({
+			block: Number.MAX_SAFE_INTEGER,
+			character: Number.MAX_SAFE_INTEGER,
+		})).toBe(`${Number.MAX_SAFE_INTEGER}:${Number.MAX_SAFE_INTEGER}`);
+
+		for (const invalid of [0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY, Number.MAX_SAFE_INTEGER + 1]) {
+			expect(() => formatMdiTextPosition({ block: invalid, character: 1 })).toThrow(RangeError);
+			expect(() => formatMdiTextPosition({ block: 1, character: invalid })).toThrow(RangeError);
+		}
+		expect(() => formatMdiTextPosition(null as never)).toThrow(TypeError);
+		expect(() => formatMdiTextPosition("1:1" as never)).toThrow(TypeError);
+	});
+
+	it("formats ordered same-block ranges, including empty ranges", () => {
+		expect(formatMdiTextRange({ start: "3:18", end: "3:24" })).toBe("3:18-3:24");
+		expect(formatMdiTextRange({ start: "3:18", end: "3:18" })).toBe("3:18-3:18");
+	});
+
+	it("rejects cross-block, reversed, non-canonical, and non-object ranges", () => {
+		expect(() => formatMdiTextRange({ start: "3:18", end: "4:18" })).toThrow(RangeError);
+		expect(() => formatMdiTextRange({ start: "3:19", end: "3:18" })).toThrow(RangeError);
+		expect(() => formatMdiTextRange({ start: "3:18", end: "3:018" as never })).toThrow(RangeError);
+		expect(() => formatMdiTextRange(null as never)).toThrow(TypeError);
+	});
+});
+
+describe("sourceSpansForTextRange", () => {
+	it("merges adjacent grapheme spans within and across runs", () => {
+		const block = blockWithRuns([
+			{ range: { start: "1:1", end: "1:3" }, sourceBoundaries: [10, 11, 13] },
+			{ range: { start: "1:3", end: "1:5" }, sourceBoundaries: [13, 17, 20] },
+		]);
+
+		expect(sourceSpansForTextRange(block, { start: "1:1", end: "1:5" })).toEqual([
+			{ startByte: 10, endByte: 20 },
+		]);
+	});
+
+	it("keeps source-discontinuous runs separate", () => {
+		const block = blockWithRuns([
+			{ range: { start: "1:1", end: "1:3" }, sourceBoundaries: [10, 11, 13] },
+			{ range: { start: "1:3", end: "1:5" }, sourceBoundaries: [30, 34, 40] },
+		]);
+
+		expect(sourceSpansForTextRange(block, { start: "1:2", end: "1:4" })).toEqual([
+			{ startByte: 11, endByte: 13 },
+			{ startByte: 30, endByte: 34 },
+		]);
+	});
+
+	it("omits synthetic and unmapped text without manufacturing source spans", () => {
+		const block = blockWithRuns(
+			[
+				{ range: { start: "1:1", end: "1:3" }, sourceBoundaries: [0, 1, 2] },
+				{ range: { start: "1:4", end: "1:6" }, sourceBoundaries: [10, 11, 12] },
+			],
+			{
+				sourceMap: {
+					runs: [
+						{ range: { start: "1:1", end: "1:3" }, sourceBoundaries: [0, 1, 2] },
+						{ range: { start: "1:4", end: "1:6" }, sourceBoundaries: [10, 11, 12] },
+					],
+					synthetic: [{ start: "1:3", end: "1:4" }],
+					unmapped: [{ start: "1:6", end: "1:7" }],
+				},
+			},
+		);
+
+		expect(sourceSpansForTextRange(block, { start: "1:3", end: "1:4" })).toEqual([]);
+		expect(sourceSpansForTextRange(block, { start: "1:6", end: "1:7" })).toEqual([]);
+		expect(sourceSpansForTextRange(block, { start: "1:2", end: "1:7" })).toEqual([
+			{ startByte: 1, endByte: 2 },
+			{ startByte: 10, endByte: 12 },
+		]);
+	});
+
+	it("supports empty ranges at the beginning, middle, and exclusive block end", () => {
+		const block = blockWithRuns([
+			{ range: { start: "1:1", end: "1:7" }, sourceBoundaries: [0, 1, 2, 3, 4, 5, 6] },
+		]);
+
+		for (const position of ["1:1", "1:4", "1:7"] as const) {
+			expect(sourceSpansForTextRange(block, { start: position, end: position })).toEqual([]);
+		}
+	});
+
+	it("rejects ranges for another block, reversed ranges, and ranges outside the block", () => {
+		const block = blockWithRuns([
+			{ range: { start: "1:1", end: "1:7" }, sourceBoundaries: [0, 1, 2, 3, 4, 5, 6] },
+		]);
+
+		expect(() => sourceSpansForTextRange(block, { start: "2:1", end: "2:2" })).toThrow(
+			"range must belong to the supplied text block",
+		);
+		expect(() => sourceSpansForTextRange(block, { start: "1:4", end: "2:5" })).toThrow(
+			"range must belong to the supplied text block",
+		);
+		expect(() => sourceSpansForTextRange(block, { start: "1:5", end: "1:4" })).toThrow(
+			"range falls outside the supplied text block",
+		);
+		expect(() => sourceSpansForTextRange(block, { start: "1:1", end: "1:8" })).toThrow(
+			"range falls outside the supplied text block",
+		);
+		expect(() => sourceSpansForTextRange(null as never, { start: "1:1", end: "1:2" })).toThrow(TypeError);
+	});
+
+	it("rejects malformed source-boundary cardinality instead of returning a partial mapping", () => {
+		const tooFew = blockWithRuns([
+			{ range: { start: "1:1", end: "1:4" }, sourceBoundaries: [0, 1, 2] },
+		]);
+		const tooMany = blockWithRuns([
+			{ range: { start: "1:1", end: "1:3" }, sourceBoundaries: [0, 1, 2, 3] },
+		]);
+
+		expect(() => sourceSpansForTextRange(tooFew, { start: "1:1", end: "1:2" })).toThrow(
+			"Invalid MDI text source run",
+		);
+		expect(() => sourceSpansForTextRange(tooMany, { start: "1:1", end: "1:2" })).toThrow(
+			"Invalid MDI text source run",
+		);
+	});
+
+	it.each([
+		{
+			name: "a run from another block",
+			runs: [{ range: { start: "2:1", end: "2:3" }, sourceBoundaries: [0, 1, 2] }],
+		},
+		{
+			name: "overlapping runs",
+			runs: [
+				{ range: { start: "1:1", end: "1:4" }, sourceBoundaries: [0, 1, 2, 3] },
+				{ range: { start: "1:3", end: "1:5" }, sourceBoundaries: [10, 11, 12] },
+			],
+		},
+		{
+			name: "a reversed run",
+			runs: [{ range: { start: "1:4", end: "1:3" }, sourceBoundaries: [] }],
+		},
+		{
+			name: "a run beyond the block text range",
+			runs: [{ range: { start: "1:6", end: "1:8" }, sourceBoundaries: [0, 1, 2] }],
+		},
+	] satisfies Array<{ name: string; runs: MdiTextSourceRun[] }>)
+		("rejects $name", ({ runs }) => {
+			expect(() => sourceSpansForTextRange(blockWithRuns(runs), { start: "1:1", end: "1:2" }))
+				.toThrow("Invalid MDI text source run");
+		});
+
+	it.each([
+		{ name: "negative", boundaries: [-1, 0, 1] },
+		{ name: "fractional", boundaries: [0, 0.5, 1] },
+		{ name: "NaN", boundaries: [0, Number.NaN, 1] },
+		{ name: "infinite", boundaries: [0, Number.POSITIVE_INFINITY, 1] },
+		{ name: "unsafe-integer", boundaries: [0, Number.MAX_SAFE_INTEGER + 1, Number.MAX_SAFE_INTEGER + 1] },
+		{ name: "descending", boundaries: [2, 1, 3] },
+	])("rejects $name source boundaries", ({ boundaries }) => {
+		const block = blockWithRuns([
+			{ range: { start: "1:1", end: "1:3" }, sourceBoundaries: boundaries },
+		]);
+		expect(() => sourceSpansForTextRange(block, { start: "1:1", end: "1:2" }))
+			.toThrow("Invalid MDI text source run");
+	});
+
+	it.each([
+		{ name: "before", boundaries: [9, 10, 11] },
+		{ name: "after", boundaries: [49, 50, 51] },
+	])("rejects source boundaries $name the block source span", ({ boundaries }) => {
+		const block = blockWithRuns(
+			[{ range: { start: "1:1", end: "1:3" }, sourceBoundaries: boundaries }],
+			{ span: { startByte: 10, endByte: 50 } },
+		);
+		expect(() => sourceSpansForTextRange(block, { start: "1:1", end: "1:2" }))
+			.toThrow("Invalid MDI text source run");
+	});
+});

--- a/nodejs/scripts/test-browser-wasm.mjs
+++ b/nodejs/scripts/test-browser-wasm.mjs
@@ -3,8 +3,10 @@ import { createServer } from "node:http";
 import { execFileSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { mkdtemp, mkdir, readFile, readdir, rm, stat, writeFile } from "node:fs/promises";
+import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { extname, join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
 import { chromium, firefox, webkit } from "playwright";
 import { build } from "vite";
 import { packPublishablePackage } from "./pack-publishable-package.mjs";
@@ -41,6 +43,8 @@ try {
   await mkdir(fixtureRoot, { recursive: true });
   await writeFile(join(consumerDirectory, "package.json"), JSON.stringify({ name: "mdi-packed-browser-consumer", private: true, type: "module" }));
   execFileSync("npm", ["install", "--ignore-scripts", "--no-audit", "--no-fund", ...tarballs], { cwd: consumerDirectory, stdio: "inherit" });
+  const consumerRequire = createRequire(join(consumerDirectory, "package.json"));
+  const packedMdi = await import(pathToFileURL(consumerRequire.resolve("@illusions-lab/mdi")).href);
   await writeFile(join(fixtureRoot, "index.html"), await readFile(resolve(repositoryRoot, "nodejs/browser-test/index.html")));
   await writeFile(join(fixtureRoot, "src.ts"), await readFile(resolve(repositoryRoot, "nodejs/browser-test/src.ts")));
 
@@ -102,7 +106,7 @@ try {
     const url = `http://127.0.0.1:${address.port}/mdi-editor/`;
     console.log("Running packed browser WASM contract in Chromium, Firefox, and WebKit");
     for (const [browserName, browserType] of browserTypes) {
-      await testBrowser(browserName, browserType, url, runRetry && browserName === "Chromium" ? `${url}?retry=1` : undefined);
+      await testBrowser(browserName, browserType, url, packedMdi.getMdiTextBlocks, runRetry && browserName === "Chromium" ? `${url}?retry=1` : undefined);
     }
     assert.equal(wasmRequests.length, browserTypes.length + (runRetry ? 2 : 0), "failed initialization must retry exactly once without duplicate concurrent loads");
     assert(wasmRequests.every(({ contentType }) => contentType === "application/wasm"), "WASM must be served with application/wasm");
@@ -114,21 +118,21 @@ try {
   await rm(outputDirectory, { recursive: true, force: true });
 }
 
-async function testBrowser(browserName, browserType, url, retryUrl) {
+async function testBrowser(browserName, browserType, url, getNodeProjection, retryUrl) {
   console.log(`Launching ${browserName}`);
   const browser = await browserType.launch({ headless: true });
   try {
-    await testPage(browserName, await browser.newPage(), url);
+    await testPage(browserName, await browser.newPage(), url, getNodeProjection);
     if (retryUrl) {
       retryFailureRemaining = 1;
-      await testPage(`${browserName} retry`, await browser.newPage(), retryUrl);
+      await testPage(`${browserName} retry`, await browser.newPage(), retryUrl, getNodeProjection);
     }
   } finally {
     await browser.close();
   }
 }
 
-async function testPage(browserName, page, url) {
+async function testPage(browserName, page, url, getNodeProjection) {
   const pageErrors = [];
   page.on("pageerror", (error) => pageErrors.push(error));
   await page.goto(url, { waitUntil: "networkidle" });
@@ -142,6 +146,20 @@ async function testPage(browserName, page, url) {
   const result = JSON.parse(await page.locator("#result").textContent());
   assert.equal(result.error, undefined, `${browserName}: ${result.error}`);
   assert.equal(result.irVersion, "1.0", browserName);
+  assert.equal(result.projectionVersion, "1.0", browserName);
+  assert.equal(
+    result.projectionJson,
+    JSON.stringify(getNodeProjection(result.projectionSource)),
+    `${browserName}: Node and browser must return byte-for-byte identical projection JSON`,
+  );
+  assert.equal(
+    result.recoveryProjectionJson,
+    JSON.stringify(getNodeProjection(result.recoverySource)),
+    `${browserName}: malformed recovery must match Node without trapping Wasm`,
+  );
+  assert.equal(result.recoveryDiagnostic?.code, "mdi.parser.recovered", browserName);
+  assert.equal(result.projectedBlocks[0]?.kind, "heading", browserName);
+  assert.equal(result.projectedBlocks[0]?.range?.start, "1:1", browserName);
   assert.equal(result.firstNode, "heading", browserName);
   assert.equal(result.hasFrontmatter, true, browserName);
   assert.equal(result.tableType, "table", browserName);


### PR DESCRIPTION
## Summary

- add the Rust-owned `getMdiTextBlocks` projection with one-based grapheme coordinates, UTF-8 source maps, and ruby-reading annotations
- expose the versioned JSON contract through Node.js and browser WASM, including safe source-range utilities
- recover malformed parser edge cases as literal text instead of trapping WebAssembly, and release `mdi-core` 2.0.6
- document the search-index API and diagnostics in English, Japanese, and Traditional Chinese

## Why

Hosts need a stable searchable plaintext projection without rebuilding text from IR in JavaScript. The new API preserves exact source provenance while keeping parsing and inline semantics in Rust.

## Validation

- `cargo test --manifest-path mdi-core/Cargo.toml`
- `cargo package --manifest-path mdi-core/Cargo.toml --allow-dirty`
- `pnpm build`
- `pnpm test:browser` (Chromium, Firefox, WebKit)
- `pnpm typecheck`

Fixes #71.

After merge, the protected-main release workflows publish the next npm patch versions and `mdi-core` 2.0.6 through trusted publishing.
