### PR TITLE
feat: batch source span resolution

### DIFF
--- a/docs/src/content/docs/bindings/javascript.md
+++ b/docs/src/content/docs/bindings/javascript.md
@@ -60,7 +60,7 @@ Ruby readings remain searchable annotations whose `anchor` points back to the
 base-text range.
 
 ```ts
-import { getMdiTextBlocks, resolveMdiSourceSpan, sourceSpansForTextRange } from "@illusions-lab/mdi";
+import { getMdiTextBlocks, resolveMdiSourceSpan, resolveMdiSourceSpans, sourceSpansForTextRange } from "@illusions-lab/mdi";
 
 const result = getMdiTextBlocks("# 題\n\n{東京|とうきょう}");
 const paragraph = result.blocks[1];
@@ -70,6 +70,7 @@ console.log(paragraph.text); // 東京
 console.log(paragraph.annotations[0].text); // とうきょう
 console.log(sourceSpansForTextRange(paragraph, match)); // UTF-8 source spans
 console.log(resolveMdiSourceSpan("# 題\n\n{東京|とうきょう}", { startByte: 8, endByte: 14 }));
+console.log(resolveMdiSourceSpans("same same", [{ startByte: 0, endByte: 4 }, { startByte: 5, endByte: 9 }]));
 ```
 
 `sourceMap.synthetic` identifies separators added by the projection, such as
@@ -87,6 +88,11 @@ within the source, and end on code-point boundaries. It returns ordered
 synthetic separators, and unmapped text produce no invented canonical range,
 so forward/reverse mapping is not promised to be bijective across annotations,
 multi-to-one tokens, partial graphemes, discontinuities, or unmapped text.
+
+Use `resolveMdiSourceSpans(source, spans)` for diagnostics or decoration
+batches. Rust validates all spans, parses/projects the document once, and
+returns one resolution per input span in the same order. Each separate call to
+the singular convenience API performs its own parse.
 
 ## Choose the export level
 

--- a/docs/src/content/docs/bindings/rust.md
+++ b/docs/src/content/docs/bindings/rust.md
@@ -72,6 +72,10 @@ structural, synthetic, or unmapped bytes do not gain invented ranges. Ruby's
 separate channels and multi-to-one/discontinuous mappings mean round trips are
 not generally bijective.
 
+For a diagnostics or decoration batch, use `resolve_mdi_source_spans(source,
+spans)`. It validates the full slice, parses/projects once, and returns the
+resolutions in input order.
+
 ## Current implementation status
 
 Parsing (`parse_document`/`parse_output`), serialization (`serialize_mdi`), and every renderer (`render_html`, `render_text_format`, `render_epub`, `render_docx`, `render_pdf`) are implemented today, at the "baseline" level described on [Rust Core API status](/core/rust-api/#not-yet-implemented). There is no separate `validate`/`normalize` API distinct from `parse_output`/`serialize_mdi` — see that same page for exactly what's missing.

--- a/docs/src/content/docs/core/rust-api.md
+++ b/docs/src/content/docs/core/rust-api.md
@@ -64,6 +64,11 @@ bytes do not create ranges. Ruby's two channels, multi-to-one tokens, partial
 graphemes, discontinuous mappings, and unmapped text mean this is not a general
 inverse of every forward lookup.
 
+Use `resolve_mdi_source_spans(source, spans)` for batch work. It validates the
+whole slice before parsing, creates one projection, and resolves every span in
+input order against that shared projection. The matching JSON boundary is
+`resolve_mdi_source_spans_json`.
+
 ## Not yet implemented
 
 These exist as concepts in `ARCHITECTURE.md`/`SYNTAX.md` but have **no corresponding function in `mdi-core` today** — don't assume they exist because the architecture diagram mentions the concept:

--- a/docs/src/content/docs/ja/bindings/javascript.md
+++ b/docs/src/content/docs/ja/bindings/javascript.md
@@ -58,7 +58,7 @@ block、完全な document IR、diagnostics を返します。`3:18` は三つ�
 annotation として検索でき、`anchor` は base text の range を指します。
 
 ```ts
-import { getMdiTextBlocks, resolveMdiSourceSpan, sourceSpansForTextRange } from "@illusions-lab/mdi";
+import { getMdiTextBlocks, resolveMdiSourceSpan, resolveMdiSourceSpans, sourceSpansForTextRange } from "@illusions-lab/mdi";
 
 const result = getMdiTextBlocks("# 題\n\n{東京|とうきょう}");
 const paragraph = result.blocks[1];
@@ -68,6 +68,7 @@ console.log(paragraph.text); // 東京
 console.log(paragraph.annotations[0].text); // とうきょう
 console.log(sourceSpansForTextRange(paragraph, match)); // UTF-8 source span
 console.log(resolveMdiSourceSpan("# 題\n\n{東京|とうきょう}", { startByte: 8, endByte: 14 }));
+console.log(resolveMdiSourceSpans("same same", [{ startByte: 0, endByte: 4 }, { startByte: 5, endByte: 9 }]));
 ```
 
 `sourceMap.synthetic` は table の tab や row newline など projection が追加した
@@ -84,6 +85,11 @@ range と `complete | partial | none` coverage です。forward coverage 全体�
 delimiter、synthetic、unmapped byte に range は作られないため、annotation、
 multi-to-one token、partial grapheme、discontinuous mapping を含む round trip は
 一般には bijection ではありません。
+
+同じ文書に対する diagnostics や decoration の一括処理には
+`resolveMdiSourceSpans(source, spans)` を使います。全 span を検証した後、Rust
+で parse/projection を一度だけ行い、入力順に結果を返します。単数 API を個別に
+呼ぶ場合は、呼び出しごとに parse されます。
 
 ## baseline と設定付き EPUB/DOCX
 

--- a/docs/src/content/docs/ja/bindings/rust.md
+++ b/docs/src/content/docs/ja/bindings/rust.md
@@ -57,6 +57,10 @@ boundary を検証し、本文と annotation の maximal grapheme range、
 Ruby の別 channel や multi-to-one/discontinuous mapping により、round trip は
 一般に bijection ではありません。
 
+diagnostics や decoration の一括処理には `resolve_mdi_source_spans(source,
+spans)` を使います。slice 全体を検証してから一度だけ parse/projection を行い、
+入力順に結果を返します。
+
 ## 現在の実装状況
 
 parse、`serialize_mdi`、HTML/TXT/EPUB/DOCX/PDF renderer はすべて実装済みです。baseline の正確な範囲は [Rust Core API](/ja/core/rust-api/#not-yet-implemented) を参照してください。

--- a/docs/src/content/docs/ja/core/rust-api.md
+++ b/docs/src/content/docs/ja/core/rust-api.md
@@ -50,6 +50,7 @@ current-generation API は `ParseOutput`、`ParserCapabilities`、`Diagnostic`�
 `resolve_mdi_source_span(source, span)` は half-open UTF-8 source span を本文と ruby
 annotation の range に逆引きします。coverage、relation、boundary、delimiter、
 synthetic/unmapped、round-trip の制約は [Rust binding](/ja/bindings/rust/) を参照してください。
+複数 span は `resolve_mdi_source_spans(source, spans)` で一度の parse/projection にまとめられます。
 
 ## Not yet implemented
 

--- a/docs/src/content/docs/zh-tw/bindings/javascript.md
+++ b/docs/src/content/docs/zh-tw/bindings/javascript.md
@@ -56,7 +56,7 @@ Unicode grapheme。Ruby 讀音會作為可搜尋的獨立 annotation channel，�
 仍指回正文 base text 的 range。
 
 ```ts
-import { getMdiTextBlocks, resolveMdiSourceSpan, sourceSpansForTextRange } from "@illusions-lab/mdi";
+import { getMdiTextBlocks, resolveMdiSourceSpan, resolveMdiSourceSpans, sourceSpansForTextRange } from "@illusions-lab/mdi";
 
 const result = getMdiTextBlocks("# 題\n\n{東京|とうきょう}");
 const paragraph = result.blocks[1];
@@ -66,6 +66,7 @@ console.log(paragraph.text); // 東京
 console.log(paragraph.annotations[0].text); // とうきょう
 console.log(sourceSpansForTextRange(paragraph, match)); // UTF-8 source spans
 console.log(resolveMdiSourceSpan("# 題\n\n{東京|とうきょう}", { startByte: 8, endByte: 14 }));
+console.log(resolveMdiSourceSpans("same same", [{ startByte: 0, endByte: 4 }, { startByte: 5, endByte: 9 }]));
 ```
 
 `sourceMap.synthetic` 指出 projection 額外加入的 separator，例如 table 的 tab 與
@@ -80,6 +81,10 @@ block、正文優先、零基底 annotation index 排序，coverage 為
 span 不視為 caret，也不回傳鄰近 range。純結構 delimiter、synthetic 與 unmapped
 byte 不會取得虛構 range，因此 annotation、多對一 token、partial grapheme、
 discontinuous mapping 等情況不保證 round trip 是雙射。
+
+同一文件有多個 diagnostics 或 decorations 時，請使用
+`resolveMdiSourceSpans(source, spans)`。它先驗證全部 span，再由 Rust 只做一次
+parse/projection，並依輸入順序回傳結果；分別呼叫單筆 API 則每次都會重新 parse。
 
 ## baseline 與可設定 EPUB/DOCX
 

--- a/docs/src/content/docs/zh-tw/bindings/rust.md
+++ b/docs/src/content/docs/zh-tw/bindings/rust.md
@@ -57,6 +57,9 @@ coverage 和 `Exact | Overlap` relation。空 span、純結構 delimiter、synth
 unmapped source 都不會產生 range。Ruby 雙 channel 與多對一／不連續 mapping
 代表 round trip 通常不是雙射。
 
+diagnostics 或 decorations 的批次處理請使用 `resolve_mdi_source_spans(source,
+spans)`；它先驗證整個 slice，只做一次 parse/projection，再依輸入順序回傳結果。
+
 ## 目前實作狀態
 
 Parsing、`serialize_mdi` 及所有 renderer（`render_html`、`render_text_format`、`render_epub`、`render_docx`、`render_pdf`）皆已實作，限制見 [Rust Core API 尚未實作項目](/zh-tw/core/rust-api/#尚未實作)。沒有獨立 `validate`/`normalize` API，分別由 `parse_output`/`serialize_mdi` 擔任。

--- a/docs/src/content/docs/zh-tw/core/rust-api.md
+++ b/docs/src/content/docs/zh-tw/core/rust-api.md
@@ -52,6 +52,7 @@ description: "`mdi-core/src/lib.rs` 現在實際公開的所有 symbol，包含 
 `resolve_mdi_source_span(source, span)` 把 half-open UTF-8 source span 反解為正文與
 ruby annotation ranges。Coverage、relation、boundary、delimiter、synthetic/unmapped
 及 round-trip 限制請參閱 [Rust 綁定](/zh-tw/bindings/rust/)。
+多個 span 可使用 `resolve_mdi_source_spans(source, spans)`，以單次 parse/projection 批量解析。
 
 ## 尚未實作
 

--- a/mdi-core/README.md
+++ b/mdi-core/README.md
@@ -35,6 +35,9 @@ UTF-8 source span becomes ordered canonical block-text and ruby-annotation
 ranges. Its `complete`, `partial`, or `none` coverage reports whether every
 requested source byte belongs to at least one mapped grapheme; synthetic and
 unmapped projection text never creates a match.
+For diagnostics or decoration batches, use `resolve_mdi_source_spans`; it
+validates every span first, then parses and projects the source exactly once
+and returns resolutions in input order.
 When rendering one parsed document in multiple formats, use the
 `*_document` functions, such as `render_html_document`, to avoid parsing it
 again.

--- a/mdi-core/src/lib.rs
+++ b/mdi-core/src/lib.rs
@@ -4,7 +4,7 @@
 //! parses CommonMark, GFM, YAML front matter, and MDI into one portable wire
 //! tree; language bindings only adapt that tree to their host APIs.
 
-use serde::{Serialize, Serializer, ser::SerializeStruct};
+use serde::{Deserialize, Serialize, Serializer, ser::SerializeStruct};
 use std::fs;
 use std::io::{Cursor, Seek, Write};
 use std::path::{Path, PathBuf};
@@ -31,7 +31,7 @@ pub use text_projection::{
     MdiSourceSpanTextResolution, MdiTextAnnotation, MdiTextBlock, MdiTextBlockKind,
     MdiTextBlocksResult, MdiTextPosition, MdiTextRange, MdiTextSourceMap, MdiTextSourceRun,
     get_mdi_text_blocks, get_mdi_text_blocks_json, resolve_mdi_source_span,
-    resolve_mdi_source_span_json,
+    resolve_mdi_source_span_json, resolve_mdi_source_spans, resolve_mdi_source_spans_json,
 };
 
 /// MDI syntax version implemented by this crate.
@@ -87,7 +87,7 @@ pub enum DiagnosticSeverity {
 }
 
 /// Half-open UTF-8 byte range in the original source.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SourceSpan {
     pub start_byte: u32,
@@ -3992,7 +3992,7 @@ mod wasm {
         page_size_catalog_json, parse_json, prepare_chromium_print_profile_json, render_docx,
         render_docx_with_profile, render_epub, render_epub_with_profile, render_html, render_text,
         render_text_format, resolve_export_profile_json, resolve_mdi_source_span_json,
-        serialize_mdi, split_ruby, unescape_mdi, unescape_ruby,
+        resolve_mdi_source_spans_json, serialize_mdi, split_ruby, unescape_mdi, unescape_ruby,
     };
     use wasm_bindgen::prelude::*;
 
@@ -4025,6 +4025,18 @@ mod wasm {
             },
         )
         .map_err(|error| JsValue::from_str(&error.to_string()))
+    }
+
+    /// Resolve many half-open UTF-8 source spans after one Rust parse.
+    #[wasm_bindgen(js_name = resolveMdiSourceSpansJson)]
+    pub fn wasm_resolve_mdi_source_spans_json(
+        source: &str,
+        spans_json: &str,
+    ) -> Result<String, JsValue> {
+        let spans: Vec<SourceSpan> = serde_json::from_str(spans_json)
+            .map_err(|error| JsValue::from_str(&format!("invalid source spans JSON: {error}")))?;
+        resolve_mdi_source_spans_json(source, &spans)
+            .map_err(|error| JsValue::from_str(&error.to_string()))
     }
 
     /// Render source through the Rust parser and Rust HTML renderer.

--- a/mdi-core/src/text_projection.rs
+++ b/mdi-core/src/text_projection.rs
@@ -340,16 +340,42 @@ pub fn resolve_mdi_source_span(
     span: SourceSpan,
 ) -> Result<MdiSourceSpanTextResolution, MdiSourceSpanResolutionError> {
     validate_source_span(source, span)?;
+    let projection = get_mdi_text_blocks(source);
+    Ok(resolve_mdi_source_span_in_projection(&projection, span))
+}
+
+/// Resolve many source spans after parsing and projecting `source` exactly
+/// once. Input order is preserved in the returned resolutions.
+pub fn resolve_mdi_source_spans(
+    source: &str,
+    spans: &[SourceSpan],
+) -> Result<Vec<MdiSourceSpanTextResolution>, MdiSourceSpanResolutionError> {
+    for &span in spans {
+        validate_source_span(source, span)?;
+    }
+    if spans.is_empty() {
+        return Ok(Vec::new());
+    }
+    let projection = get_mdi_text_blocks(source);
+    Ok(spans
+        .iter()
+        .map(|&span| resolve_mdi_source_span_in_projection(&projection, span))
+        .collect())
+}
+
+fn resolve_mdi_source_span_in_projection(
+    projection: &MdiTextBlocksResult,
+    span: SourceSpan,
+) -> MdiSourceSpanTextResolution {
     if span.start_byte == span.end_byte {
-        return Ok(MdiSourceSpanTextResolution {
+        return MdiSourceSpanTextResolution {
             projection_version: MDI_TEXT_PROJECTION_VERSION,
             source_span: span,
             coverage: MdiSourceSpanCoverage::None,
             matches: Vec::new(),
-        });
+        };
     }
 
-    let projection = get_mdi_text_blocks(source);
     let mut matches = Vec::new();
     let mut covered = Vec::new();
     for block in &projection.blocks {
@@ -384,12 +410,12 @@ pub fn resolve_mdi_source_span(
     } else {
         MdiSourceSpanCoverage::Partial
     };
-    Ok(MdiSourceSpanTextResolution {
+    MdiSourceSpanTextResolution {
         projection_version: MDI_TEXT_PROJECTION_VERSION,
         source_span: span,
         coverage,
         matches,
-    })
+    }
 }
 
 /// JSON boundary for language bindings.
@@ -400,6 +426,17 @@ pub fn resolve_mdi_source_span_json(
     let resolution = resolve_mdi_source_span(source, span)?;
     Ok(serde_json::to_string(&resolution)
         .expect("serializing an MDI source-span resolution cannot fail"))
+}
+
+/// Batched JSON boundary for language bindings. The source is parsed once for
+/// all spans, and the returned array follows input order.
+pub fn resolve_mdi_source_spans_json(
+    source: &str,
+    spans: &[SourceSpan],
+) -> Result<String, MdiSourceSpanResolutionError> {
+    let resolutions = resolve_mdi_source_spans(source, spans)?;
+    Ok(serde_json::to_string(&resolutions)
+        .expect("serializing MDI source-span resolutions cannot fail"))
 }
 
 fn validate_source_span(

--- a/mdi-core/tests/source_span_resolution.rs
+++ b/mdi-core/tests/source_span_resolution.rs
@@ -1,7 +1,8 @@
 use mdi_core::{
     MdiSourceSpanCoverage, MdiSourceSpanRelation, MdiSourceSpanResolutionError,
-    MdiSourceSpanTextMatch, SourceSpan, get_mdi_text_blocks, resolve_mdi_source_span,
-    resolve_mdi_source_span_json,
+    MdiSourceSpanTextMatch, MdiTextBlockKind, SourceSpan, get_mdi_text_blocks,
+    resolve_mdi_source_span, resolve_mdi_source_span_json, resolve_mdi_source_spans,
+    resolve_mdi_source_spans_json,
 };
 
 fn span(start_byte: u32, end_byte: u32) -> SourceSpan {
@@ -146,6 +147,96 @@ fn validates_order_bounds_and_utf8_boundaries() {
         resolve_mdi_source_span("東京", span(1, 3)),
         Err(MdiSourceSpanResolutionError::NotUtf8Boundary)
     );
+}
+
+#[test]
+fn batch_resolution_preserves_order_and_matches_single_queries() {
+    let source = "前{東京|とうきょう}後\n\nsame same";
+    let tokyo_start = byte_offset(source, "東京");
+    let spans = [
+        span(0, 3),
+        span(tokyo_start, tokyo_start + 6),
+        span(source.len() as u32, source.len() as u32),
+    ];
+    let batch = resolve_mdi_source_spans(source, &spans).unwrap();
+    assert_eq!(batch.len(), spans.len());
+    for (resolution, requested) in batch.iter().zip(spans) {
+        assert_eq!(resolution.source_span, requested);
+        assert_eq!(
+            resolution,
+            &resolve_mdi_source_span(source, requested).unwrap()
+        );
+    }
+    assert_eq!(resolve_mdi_source_spans(source, &[]).unwrap(), Vec::new());
+    assert_eq!(
+        resolve_mdi_source_spans(source, &[spans[0], span(2, 1)]),
+        Err(MdiSourceSpanResolutionError::Reversed)
+    );
+
+    let json = resolve_mdi_source_spans_json(source, &spans).unwrap();
+    assert_eq!(json, resolve_mdi_source_spans_json(source, &spans).unwrap());
+    let wire: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(wire.as_array().unwrap().len(), spans.len());
+}
+
+#[test]
+fn repeated_identical_text_resolves_to_distinct_canonical_ranges() {
+    let source = "same same same";
+    for (start_byte, expected_start) in [(0, 1), (5, 6), (10, 11)] {
+        let resolution = resolve_mdi_source_span(source, span(start_byte, start_byte + 4)).unwrap();
+        assert!(matches!(
+            resolution.matches.as_slice(),
+            [MdiSourceSpanTextMatch::BlockText {
+                range,
+                relation: MdiSourceSpanRelation::Exact,
+                ..
+            }] if range.start.character == expected_start
+                && range.end.character == expected_start + 4
+        ));
+    }
+}
+
+#[test]
+fn resolves_every_searchable_block_family_including_footnotes() {
+    let source = concat!(
+        "# headingword\n\n",
+        "paragraphword\n\n",
+        "> quoteword\n\n",
+        "- listword\n\n",
+        "| tableword | x |\n| - | - |\n| y | z |\n\n",
+        "```text\ncodeword\n```\n\n",
+        "<section>htmlword</section>\n\n",
+        "body[^note]\n\n",
+        "[^note]: footnoteword",
+    );
+    let projection = get_mdi_text_blocks(source);
+    for (needle, expected_kind) in [
+        ("headingword", MdiTextBlockKind::Heading),
+        ("paragraphword", MdiTextBlockKind::Paragraph),
+        ("quoteword", MdiTextBlockKind::Blockquote),
+        ("listword", MdiTextBlockKind::ListItem),
+        ("tableword", MdiTextBlockKind::Table),
+        ("codeword", MdiTextBlockKind::Code),
+        ("htmlword", MdiTextBlockKind::Html),
+        ("footnoteword", MdiTextBlockKind::Footnote),
+    ] {
+        let start = byte_offset(source, needle);
+        let resolution = resolve_mdi_source_span(
+            source,
+            span(start, start + u32::try_from(needle.len()).unwrap()),
+        )
+        .unwrap();
+        let [MdiSourceSpanTextMatch::BlockText { block_index, .. }] = resolution.matches.as_slice()
+        else {
+            panic!("expected one block-text match for {needle}");
+        };
+        assert_eq!(
+            projection.blocks[usize::try_from(*block_index - 1).unwrap()].kind,
+            expected_kind,
+            "wrong block family for {needle}",
+        );
+        assert_eq!(resolution.coverage, MdiSourceSpanCoverage::Complete);
+    }
 }
 
 #[test]

--- a/nodejs/browser-test/src.ts
+++ b/nodejs/browser-test/src.ts
@@ -1,4 +1,4 @@
-import { getMdiTextBlocks, initializeMdi, parse, resolveMdiSourceSpan, serializeMdi } from "@illusions-lab/mdi";
+import { getMdiTextBlocks, initializeMdi, parse, resolveMdiSourceSpan, resolveMdiSourceSpans, serializeMdi } from "@illusions-lab/mdi";
 import remarkMdi from "@illusions-lab/mdi-remark";
 import remarkParse from "remark-parse";
 import remarkStringify from "remark-stringify";
@@ -50,6 +50,7 @@ async function run(): Promise<void> {
   const projection = getMdiTextBlocks(source);
   const sourceResolutionSpan = parsed.document.children[1]!.span!;
   const sourceResolution = resolveMdiSourceSpan(source, sourceResolutionSpan);
+  const sourceResolutions = resolveMdiSourceSpans(source, [sourceResolutionSpan, { startByte: 0, endByte: 0 }]);
   const recoveryProjection = getMdiTextBlocks(recoverySource);
   const canonical = serializeMdi(source);
   const large = parse(largeSource);
@@ -66,6 +67,7 @@ async function run(): Promise<void> {
     projectionJson: JSON.stringify(projection),
     sourceResolutionSpan,
     sourceResolutionJson: JSON.stringify(sourceResolution),
+    sourceResolutionsJson: JSON.stringify(sourceResolutions),
     recoverySource,
     recoveryProjectionJson: JSON.stringify(recoveryProjection),
     recoveryDiagnostic: recoveryProjection.diagnostics[0],

--- a/nodejs/packages/mdi-core/README.md
+++ b/nodejs/packages/mdi-core/README.md
@@ -31,6 +31,9 @@ The raw text-projection boundaries are `getMdiTextBlocksJson(source)` and
 Rust-owned inverse mapping as JSON and rejects reversed, out-of-bounds, or
 non-UTF-8-boundary spans. Applications normally use the typed
 `resolveMdiSourceSpan` wrapper from `@illusions-lab/mdi`.
+`resolveMdiSourceSpansJson(source, spansJson)` accepts a JSON array and parses
+the source once for the whole batch; applications normally use the typed
+`resolveMdiSourceSpans` wrapper.
 
 Browser bundlers select the web-compatible runtime facade automatically through
 the package's `browser` export condition. The generated `.wasm` asset remains

--- a/nodejs/packages/mdi-core/src/browser.d.ts
+++ b/nodejs/packages/mdi-core/src/browser.d.ts
@@ -2,6 +2,7 @@ export {
   applyPdfProfileJson, blockMacroAmount, blockMacroKind, blockMacroVariant,
   getMdiTextBlocksJson, pageSizeCatalogJson, parseMdiSyntaxJson, prepareChromiumPrintProfileJson,
   resolveMdiSourceSpanJson,
+  resolveMdiSourceSpansJson,
   renderDocx, renderDocxWithProfile, renderEpub, renderEpubWithProfile,
   renderHtml, renderText, renderTextFormat, resolveExportProfileJson,
   resolveRuby, serializeMdi, unescapeMdi, unescapeRubyText,

--- a/nodejs/packages/mdi-core/src/browser.js
+++ b/nodejs/packages/mdi-core/src/browser.js
@@ -22,6 +22,7 @@ export const blockMacroVariant = (...args) => (requireInitialized(), bindings.bl
 export const pageSizeCatalogJson = (...args) => (requireInitialized(), bindings.pageSizeCatalogJson(...args));
 export const getMdiTextBlocksJson = (...args) => (requireInitialized(), bindings.getMdiTextBlocksJson(...args));
 export const resolveMdiSourceSpanJson = (...args) => (requireInitialized(), bindings.resolveMdiSourceSpanJson(...args));
+export const resolveMdiSourceSpansJson = (...args) => (requireInitialized(), bindings.resolveMdiSourceSpansJson(...args));
 export const parseMdiSyntaxJson = (...args) => (requireInitialized(), bindings.parseMdiSyntaxJson(...args));
 export const prepareChromiumPrintProfileJson = (...args) => (requireInitialized(), bindings.prepareChromiumPrintProfileJson(...args));
 export const renderDocx = (...args) => (requireInitialized(), bindings.renderDocx(...args));

--- a/nodejs/packages/mdi-core/src/node.cjs
+++ b/nodejs/packages/mdi-core/src/node.cjs
@@ -15,6 +15,7 @@ exports.blockMacroVariant = bindings.blockMacroVariant;
 exports.pageSizeCatalogJson = bindings.pageSizeCatalogJson;
 exports.getMdiTextBlocksJson = bindings.getMdiTextBlocksJson;
 exports.resolveMdiSourceSpanJson = bindings.resolveMdiSourceSpanJson;
+exports.resolveMdiSourceSpansJson = bindings.resolveMdiSourceSpansJson;
 exports.parseMdiSyntaxJson = bindings.parseMdiSyntaxJson;
 exports.prepareChromiumPrintProfileJson = bindings.prepareChromiumPrintProfileJson;
 exports.renderDocx = bindings.renderDocx;

--- a/nodejs/packages/mdi/README.md
+++ b/nodejs/packages/mdi/README.md
@@ -87,7 +87,7 @@ such as `3:18` count one-based Unicode grapheme clusters; ruby readings are a
 separate annotation channel anchored to the base-text range.
 
 ```ts
-import { getMdiTextBlocks, resolveMdiSourceSpan, sourceSpansForTextRange } from "@illusions-lab/mdi";
+import { getMdiTextBlocks, resolveMdiSourceSpan, resolveMdiSourceSpans, sourceSpansForTextRange } from "@illusions-lab/mdi";
 
 const result = getMdiTextBlocks("{東京|とうきょう}");
 const block = result.blocks[0];
@@ -95,6 +95,7 @@ console.log(block.text); // 東京
 console.log(block.annotations[0].anchor); // { start: "1:1", end: "1:3" }
 console.log(sourceSpansForTextRange(block, { start: "1:1", end: "1:3" }));
 console.log(resolveMdiSourceSpan("{東京|とうきょう}", { startByte: 1, endByte: 7 }));
+console.log(resolveMdiSourceSpans("same same", [{ startByte: 0, endByte: 4 }, { startByte: 5, endByte: 9 }]));
 ```
 
 `resolveMdiSourceSpan` accepts half-open UTF-8 byte offsets and returns ordered
@@ -108,6 +109,9 @@ a delimiter token already owned by one projected grapheme (such as an explicit
 break) can match. Reverse and forward mapping are therefore not generally
 bijective, especially for annotations, multi-byte token mappings, partial
 graphemes, discontinuous runs, and synthetic or unmapped text.
+For multiple lookups against one document, use `resolveMdiSourceSpans`. It
+validates the full array, performs one Rust parse/projection, and preserves
+input order; repeated calls to the singular convenience API each parse anew.
 
 Each source-derived grapheme is represented by a `sourceMap.runs` boundary;
 table tabs/newlines and multi-paragraph joiners appear in `synthetic` and do

--- a/nodejs/packages/mdi/src/index.test.ts
+++ b/nodejs/packages/mdi/src/index.test.ts
@@ -1,6 +1,6 @@
 import JSZip from "jszip";
 import { describe, expect, it } from "vitest";
-import { MDI_IR_VERSION, MDI_SPEC_VERSION, formatMdiTextPosition, formatMdiTextRange, getMdiTextBlocks, initializeMdi, parse, parseMdiTextPosition, prepareRender, renderDocx, renderDocxWithDiagnostics, renderDocxWithProfile, renderEpub, renderEpubWithDiagnostics, renderEpubWithProfile, renderHtml, renderHtmlWithDiagnostics, renderText, renderTextFormat, renderTextFormatWithDiagnostics, renderTextWithDiagnostics, resolveMdiSourceSpan, serializeMdi, sourceSpansForTextRange, toPublicationMdast } from "./index.js";
+import { MDI_IR_VERSION, MDI_SPEC_VERSION, formatMdiTextPosition, formatMdiTextRange, getMdiTextBlocks, initializeMdi, parse, parseMdiTextPosition, prepareRender, renderDocx, renderDocxWithDiagnostics, renderDocxWithProfile, renderEpub, renderEpubWithDiagnostics, renderEpubWithProfile, renderHtml, renderHtmlWithDiagnostics, renderText, renderTextFormat, renderTextFormatWithDiagnostics, renderTextWithDiagnostics, resolveMdiSourceSpan, resolveMdiSourceSpans, serializeMdi, sourceSpansForTextRange, toPublicationMdast } from "./index.js";
 
 function assertValidSpans(node: { span?: { startByte: number; endByte: number }; children?: unknown[] }, source: string): void {
 	if (node.span) {
@@ -114,6 +114,25 @@ describe("Rust MDI JavaScript binding", () => {
 		expect(() => resolveMdiSourceSpan("x", { startByte: 1, endByte: 0 })).toThrow(RangeError);
 		expect(() => resolveMdiSourceSpan("x", { startByte: 0, endByte: 2 })).toThrow(RangeError);
 		expect(() => resolveMdiSourceSpan("東京", { startByte: 1, endByte: 3 })).toThrow(RangeError);
+	});
+
+	it("resolves batches in input order through one Rust boundary", () => {
+		const source = "same same same";
+		const spans = [
+			{ startByte: 10, endByte: 14 },
+			{ startByte: 0, endByte: 4 },
+			{ startByte: 5, endByte: 9 },
+		];
+		const batch = resolveMdiSourceSpans(source, spans);
+		expect(batch.map((resolution) => resolution.sourceSpan)).toEqual(spans);
+		expect(batch.map((resolution) => resolution.matches[0]?.range)).toEqual([
+			{ start: "1:11", end: "1:15" },
+			{ start: "1:1", end: "1:5" },
+			{ start: "1:6", end: "1:10" },
+		]);
+		expect(resolveMdiSourceSpans(source, [])).toEqual([]);
+		expect(() => resolveMdiSourceSpans(source, null as never)).toThrow(TypeError);
+		expect(() => resolveMdiSourceSpans(source, [spans[0]!, { startByte: 2, endByte: 1 }])).toThrow(RangeError);
 	});
 
 	it("exposes nested syntax decisions made by Rust", () => {

--- a/nodejs/packages/mdi/src/index.ts
+++ b/nodejs/packages/mdi/src/index.ts
@@ -6,7 +6,7 @@ import { parse as parseYaml } from "yaml";
 
 const {
 	getMdiTextBlocksJson,
-	resolveMdiSourceSpanJson,
+	resolveMdiSourceSpansJson,
 	parseMdiSyntaxJson,
 	renderHtml: renderHtmlFromRust,
 	renderEpub: renderEpubFromRust,
@@ -335,37 +335,54 @@ export function resolveMdiSourceSpan(
 	source: string,
 	span: MdiSourceSpan,
 ): MdiSourceSpanTextResolution {
-	if (typeof source !== "string") throw new TypeError("source must be a string");
-	assertSourceSpanInput(span);
-	const utf8 = utf8SourceBoundaries(source);
-	if (span.startByte > span.endByte) {
-		throw new RangeError("span.startByte must not exceed span.endByte");
-	}
-	if (span.endByte > utf8.length) {
-		throw new RangeError("span falls outside the UTF-8 source length");
-	}
-	if (!utf8.boundaries.has(span.startByte) || !utf8.boundaries.has(span.endByte)) {
-		throw new RangeError("span endpoints must be UTF-8 code-point boundaries");
-	}
-	const result = JSON.parse(
-		resolveMdiSourceSpanJson(source, span.startByte, span.endByte),
-	) as MdiSourceSpanTextResolution;
-	if (result.projectionVersion !== MDI_TEXT_PROJECTION_VERSION) {
-		throw new Error(`Unsupported MDI text projection version: ${String(result.projectionVersion)}`);
-	}
-	return result;
+	return resolveMdiSourceSpans(source, [span])[0]!;
 }
 
-function assertSourceSpanInput(span: MdiSourceSpan): void {
+/**
+ * Resolve many half-open UTF-8 source spans with one Rust parse/projection.
+ * The returned resolutions preserve input order.
+ */
+export function resolveMdiSourceSpans(
+	source: string,
+	spans: readonly MdiSourceSpan[],
+): MdiSourceSpanTextResolution[] {
+	if (typeof source !== "string") throw new TypeError("source must be a string");
+	if (!Array.isArray(spans)) throw new TypeError("spans must be an array");
+	if (spans.length === 0) return [];
+	const utf8 = utf8SourceBoundaries(source);
+	for (const [index, span] of spans.entries()) {
+		assertSourceSpanInput(span, `spans[${index}]`);
+		if (span.startByte > span.endByte) {
+			throw new RangeError(`spans[${index}].startByte must not exceed endByte`);
+		}
+		if (span.endByte > utf8.length) {
+			throw new RangeError(`spans[${index}] falls outside the UTF-8 source length`);
+		}
+		if (!utf8.boundaries.has(span.startByte) || !utf8.boundaries.has(span.endByte)) {
+			throw new RangeError(`spans[${index}] endpoints must be UTF-8 code-point boundaries`);
+		}
+	}
+	const results = JSON.parse(
+		resolveMdiSourceSpansJson(source, JSON.stringify(spans)),
+	) as MdiSourceSpanTextResolution[];
+	for (const result of results) {
+		if (result.projectionVersion !== MDI_TEXT_PROJECTION_VERSION) {
+			throw new Error(`Unsupported MDI text projection version: ${String(result.projectionVersion)}`);
+		}
+	}
+	return results;
+}
+
+function assertSourceSpanInput(span: MdiSourceSpan, name = "span"): void {
 	if (!span || typeof span !== "object" || Array.isArray(span)) {
-		throw new TypeError("span must be an object");
+		throw new TypeError(`${name} must be an object`);
 	}
 	if (typeof span.startByte !== "number" || typeof span.endByte !== "number") {
-		throw new TypeError("span.startByte and span.endByte must be numbers");
+		throw new TypeError(`${name}.startByte and ${name}.endByte must be numbers`);
 	}
 	const isUint32 = (value: number): boolean => Number.isInteger(value) && value >= 0 && value <= 0xffff_ffff;
 	if (!isUint32(span.startByte) || !isUint32(span.endByte)) {
-		throw new RangeError("span.startByte and span.endByte must be uint32 values");
+		throw new RangeError(`${name}.startByte and ${name}.endByte must be uint32 values`);
 	}
 }
 

--- a/nodejs/packages/mdi/src/source-span-version.test.ts
+++ b/nodejs/packages/mdi/src/source-span-version.test.ts
@@ -4,12 +4,12 @@ vi.mock("@illusions-lab/mdi-core", async (importOriginal) => {
 	const original = await importOriginal<typeof import("@illusions-lab/mdi-core")>();
 	return {
 		...original,
-		resolveMdiSourceSpanJson: () => JSON.stringify({
+		resolveMdiSourceSpansJson: () => JSON.stringify([{
 			projectionVersion: "9.9",
 			sourceSpan: { startByte: 0, endByte: 0 },
 			coverage: "none",
 			matches: [],
-		}),
+		}]),
 	};
 });
 

--- a/nodejs/scripts/test-browser-wasm.mjs
+++ b/nodejs/scripts/test-browser-wasm.mjs
@@ -106,7 +106,7 @@ try {
     const url = `http://127.0.0.1:${address.port}/mdi-editor/`;
     console.log("Running packed browser WASM contract in Chromium, Firefox, and WebKit");
     for (const [browserName, browserType] of browserTypes) {
-      await testBrowser(browserName, browserType, url, packedMdi.getMdiTextBlocks, packedMdi.resolveMdiSourceSpan, runRetry && browserName === "Chromium" ? `${url}?retry=1` : undefined);
+      await testBrowser(browserName, browserType, url, packedMdi.getMdiTextBlocks, packedMdi.resolveMdiSourceSpan, packedMdi.resolveMdiSourceSpans, runRetry && browserName === "Chromium" ? `${url}?retry=1` : undefined);
     }
     assert.equal(wasmRequests.length, browserTypes.length + (runRetry ? 2 : 0), "failed initialization must retry exactly once without duplicate concurrent loads");
     assert(wasmRequests.every(({ contentType }) => contentType === "application/wasm"), "WASM must be served with application/wasm");
@@ -118,21 +118,21 @@ try {
   await rm(outputDirectory, { recursive: true, force: true });
 }
 
-async function testBrowser(browserName, browserType, url, getNodeProjection, resolveNodeSourceSpan, retryUrl) {
+async function testBrowser(browserName, browserType, url, getNodeProjection, resolveNodeSourceSpan, resolveNodeSourceSpans, retryUrl) {
   console.log(`Launching ${browserName}`);
   const browser = await browserType.launch({ headless: true });
   try {
-    await testPage(browserName, await browser.newPage(), url, getNodeProjection, resolveNodeSourceSpan);
+    await testPage(browserName, await browser.newPage(), url, getNodeProjection, resolveNodeSourceSpan, resolveNodeSourceSpans);
     if (retryUrl) {
       retryFailureRemaining = 1;
-      await testPage(`${browserName} retry`, await browser.newPage(), retryUrl, getNodeProjection, resolveNodeSourceSpan);
+      await testPage(`${browserName} retry`, await browser.newPage(), retryUrl, getNodeProjection, resolveNodeSourceSpan, resolveNodeSourceSpans);
     }
   } finally {
     await browser.close();
   }
 }
 
-async function testPage(browserName, page, url, getNodeProjection, resolveNodeSourceSpan) {
+async function testPage(browserName, page, url, getNodeProjection, resolveNodeSourceSpan, resolveNodeSourceSpans) {
   const pageErrors = [];
   page.on("pageerror", (error) => pageErrors.push(error));
   await page.goto(url, { waitUntil: "networkidle" });
@@ -161,6 +161,11 @@ async function testPage(browserName, page, url, getNodeProjection, resolveNodeSo
     result.sourceResolutionJson,
     JSON.stringify(resolveNodeSourceSpan(result.projectionSource, result.sourceResolutionSpan)),
     `${browserName}: Node and browser must return byte-for-byte identical source resolution JSON`,
+  );
+  assert.equal(
+    result.sourceResolutionsJson,
+    JSON.stringify(resolveNodeSourceSpans(result.projectionSource, [result.sourceResolutionSpan, { startByte: 0, endByte: 0 }])),
+    `${browserName}: Node and browser must return byte-for-byte identical batched source resolution JSON`,
   );
   assert.equal(result.recoveryDiagnostic?.code, "mdi.parser.recovered", browserName);
   assert.equal(result.projectedBlocks[0]?.kind, "heading", browserName);

--- a/nodejs/scripts/test-safari-wasm.mjs
+++ b/nodejs/scripts/test-safari-wasm.mjs
@@ -63,6 +63,7 @@ try {
   assert.equal(result.irVersion, "1.0");
   assert.equal(JSON.parse(result.sourceResolutionJson).projectionVersion, "1.0");
   assert(JSON.parse(result.sourceResolutionJson).matches.length > 0);
+  assert.equal(JSON.parse(result.sourceResolutionsJson).length, 2);
   assert.equal(result.hasFrontmatter, true);
   assert.equal(result.tableType, "table");
   assert(result.utf8Span?.endByte > result.utf8Span?.startByte);


### PR DESCRIPTION
## Summary

- add Rust-backed `resolveMdiSourceSpans(source, spans)` with one parse/projection per batch
- keep singular resolution as a convenience wrapper with identical mapping semantics
- cover repeated identical text and every searchable block family, including footnotes
- expose the batched JSON/WASM boundary in Node and browsers and document it in English, Japanese, and Traditional Chinese

## Why

PR #75 established the source-span inverse mapping contract, but repeated singular calls reparsed a full document. This follow-up provides the batch path needed by diagnostics and decoration consumers while preserving input order and all validation/coverage/relation rules.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- Rust llvm-cov thresholds: lines 96.94%, functions 93.33%, regions 95.54%
- `pnpm typecheck`
- `pnpm build` (including docs)
- `pnpm --filter @illusions-lab/mdi test` (83 tests)
- `pnpm test:browser` (packed Chromium, Firefox, WebKit)
- publishable-package contract tests
- `pnpm test:coverage`

## Release safety

The earlier `main` CI run was cancelled after the performance gap was identified, and its release workflow skipped. This PR must pass PR and post-merge `main` CI before automatic publication.
