### PR TITLE
fix: harden mdast provenance boundary

### DIFF
--- a/CODE_HEALTH.md
+++ b/CODE_HEALTH.md
@@ -1,0 +1,161 @@
+# Code-health backlog
+
+This backlog records issues observed while hardening the internal mdast
+provenance transport. They are deliberately out of scope for that change, but
+the evidence and completion conditions below make each item independently
+actionable.
+
+## P1 — MDI version declarations are compared as strings
+
+**Evidence.** `mdi-core/src/lib.rs::diagnostics` decides whether a declared
+frontmatter `mdi` version is newer with `declared > MDI_SPEC_VERSION`. This is
+lexicographic ordering, so versions such as `10.0` and `2.10` do not follow
+numeric major/minor ordering. Existing tests cover only `3.0` versus `2.0`.
+
+**Repair direction.** Parse the MDI declaration into a deliberately small,
+documented numeric version type (including a policy for malformed values) and
+compare numeric components. Keep package SemVer and MDI language-version
+semantics separate.
+
+**Acceptance criteria.** Table-driven tests cover equal, older, newer, multi-
+digit major/minor, missing components, whitespace, and malformed declarations;
+only genuinely newer supported-shape declarations emit
+`mdi.version.unsupported`, with the existing frontmatter byte span.
+
+## P1 — PDF rendering permits remote-resource SSRF and has no hard timeout
+
+**Evidence.** `mdi-core/src/lib.rs::render_html_node` copies an image node's URL
+into `<img src="...">`. `nodejs/packages/to-pdf/src/index.ts::renderHtmlToPdf`
+passes that HTML to Playwright `page.setContent` without request interception,
+URL allow-listing, or an offline context. The same function launches Chromium,
+renders, and closes it without an operation deadline or forced process cleanup.
+An attacker-controlled document can therefore make the browser request loopback
+or private-network URLs, and a stalled launch/navigation/PDF/close can occupy a
+worker indefinitely.
+
+**Repair direction.** Make PDF rendering offline by default. Intercept all
+requests and allow only explicitly supported embedded schemes/resources; if
+remote resources are an opt-in feature, resolve and validate every redirect
+against a public-network policy. Wrap the complete Chromium lifecycle in a
+deadline and ensure timeout/error paths terminate the browser process.
+
+**Acceptance criteria.** Integration tests prove HTTP(S), loopback, link-local,
+private-network, `file:`, and redirect-based fetches are blocked by default;
+approved embedded assets still render; a deliberately hung adapter rejects
+within the configured deadline and leaves no Chromium child process behind.
+
+## P1 — Python and Android JNI lockfiles reject `--locked` builds
+
+**Evidence.** `mdi-core/Cargo.toml` is version `2.0.6`, while both
+`python/Cargo.lock` and `mdi-android-jni/Cargo.lock` still record `mdi-core`
+version `2.0.5`. Running `cargo check --locked` from either `python/` or
+`mdi-android-jni/` fails with “cannot update the lock file … because --locked
+was passed”. Android's `android/scripts/build-native.sh` does not pass
+`--locked`, so ordinary CI can silently rewrite dependency resolution.
+
+**Repair direction.** Regenerate and commit both leaf lockfiles whenever the
+path dependency changes, and make native build/test/release entry points use
+`--locked`. Add a cheap CI lockfile validation step for every Rust manifest.
+
+**Acceptance criteria.** `cargo check --locked --manifest-path
+python/Cargo.toml` and `cargo check --locked --manifest-path
+mdi-android-jni/Cargo.toml` pass in a clean checkout; Android native builds also
+invoke Cargo with `--locked`; CI fails on either stale lockfile.
+
+## P1 — JavaScript reinterprets frontmatter and publication defaults
+
+**Evidence.** `nodejs/packages/mdi/src/index.ts::toPublicationMdast` receives
+Rust's parsed `Frontmatter`, but calls the local `publicationFrontmatter(raw)`.
+That helper reparses YAML with `parseYaml`, then independently defaults `mdi` to
+`2.0`, `lang` to `ja`, `writingMode` to `horizontal`, and derives
+`pageProgression`. `nodejs/packages/mdast-util-mdi/src/source.ts` separately
+maps the camelCase publication object back to YAML keys. These host-side rules
+can drift from Rust parsing and default semantics.
+
+**Repair direction.** Define the normalized publication metadata/defaults once
+in Rust's versioned transport (or a single generated contract) and make JS a
+shape-only adapter. Preserve raw YAML for round trips without using it as a
+second semantic parser.
+
+**Acceptance criteria.** Cross-runtime fixtures for absent, explicit, invalid,
+and future frontmatter values produce identical normalized metadata; deleting
+the JS YAML parser/default logic does not change adapter output; round-tripping
+still preserves the Rust-owned raw frontmatter.
+
+## P1 — Diagnostics and PDF/export helpers parse the same source twice
+
+**Evidence.** `nodejs/packages/mdi/src/index.ts::renderWithDiagnostics` and
+`renderWithDiagnosticsAsync` call `parse(source)` and then invoke a renderer
+closure. The public `renderHtmlWithDiagnostics`, `renderEpubWithDiagnostics`,
+`renderDocxWithDiagnostics`, `renderTextWithDiagnostics`, and
+`renderTextFormatWithDiagnostics` closures call Rust APIs that parse the same
+source again. The PDF path builds on rendered HTML and retains the separately
+parsed result, so large-document editor/export workflows pay duplicate parser
+cost and can only assume the two passes stay semantically identical.
+
+**Repair direction.** Add an internal Rust parse-once operation/handle or
+combined result that derives diagnostics, headings, and requested output from
+one document. Keep lifetime/ownership explicit at each FFI boundary.
+
+**Acceptance criteria.** An instrumented parser counter is exactly one for
+every `*WithDiagnostics` and PDF preparation operation; returned diagnostics,
+headings, spans, and output all derive from the same parse; behavior and error
+mapping remain compatible.
+
+## P2 — Performance CI reports results but cannot catch regressions
+
+**Evidence.** `.github/workflows/ci.yml` runs four ignored release benchmarks,
+uploads JSONL, and makes `large-document-performance-report` a dependency of
+publication checks. `scripts/write-large-document-performance-report.mjs`
+validates only that the four input sizes exist, then states that throughput is
+“reported rather than hard-gated”. No ratio, baseline, complexity, or maximum
+duration can fail the workflow.
+
+**Repair direction.** Gate deterministic structural work counters and scaling
+ratios, while retaining wall-clock measurements as reports or using a generous
+runner-normalized threshold. Store an explicit reviewed baseline with bounded
+update procedure.
+
+**Acceptance criteria.** A synthetic super-linear implementation makes CI
+fail; expected variance on hosted runners does not; the report identifies the
+baseline, observed ratio, allowed threshold, and failing case.
+
+## P2 — `mdi-core/src/lib.rs` is monolithic and retains two parser tracks
+
+**Evidence.** `mdi-core/src/lib.rs` is roughly 5,900 lines and contains public
+wire types, the complete parser/lowering path, renderers, FFI, Wasm bindings,
+and most tests. It also retains the deprecated compatibility model
+`MdiSyntaxDocument`/`MdiBlock` and `parse_mdi_syntax`, whose line-oriented parser
+is separate from the canonical `parse_document`/markdown-rs path. The root
+module therefore mixes unrelated ownership boundaries and exposes two syntax
+decision paths.
+
+**Repair direction.** Split document IR, parsing/lowering, diagnostics,
+serialization, renderers, and host boundaries into focused modules. Replace
+the deprecated parser implementation with an adapter over the canonical tree,
+then remove it after the documented compatibility window.
+
+**Acceptance criteria.** All syntax decisions flow through one canonical
+parser; compatibility output is projection-only; module/API tests prevent host
+bindings from reaching parser internals; public compatibility and serialized
+fixtures remain stable through the migration.
+
+## P2 — JNI exception, panic, and allocation-failure paths lack coverage
+
+**Evidence.** `mdi-android-jni/src/lib.rs` exports JNI functions directly as
+`extern "system"`. It maps JNI string/allocation errors to Java exceptions and
+null pointers, but does not put `catch_unwind` at the JNI boundary. Its two unit
+tests call `mdi_core` helpers directly and never exercise `JNIEnv`, exception
+classes, null inputs, allocation failures, or panic containment. Android's
+Jacoco configuration explicitly excludes `MdiNative`/`NativeMdiBridge`, so the
+90% Kotlin line gate cannot detect this gap.
+
+**Repair direction.** Centralize every JNI entry through a panic-safe boundary
+and a tested error mapper. Add JVM/emulator tests for invalid/null strings,
+Rust errors, pending exceptions, and returned null/byte arrays; use a controlled
+test hook or abstraction for otherwise impractical allocation failures.
+
+**Acceptance criteria.** No Rust panic can unwind across JNI; every failure
+produces the documented Java exception with no leaked local/native resources;
+tests execute each exception/null branch, and CI reports native-boundary
+coverage separately from the Kotlin Jacoco gate.

--- a/android/mdi-android/src/androidTest/kotlin/app/illusions/mdi/MdiInstrumentedTest.kt
+++ b/android/mdi-android/src/androidTest/kotlin/app/illusions/mdi/MdiInstrumentedTest.kt
@@ -23,6 +23,22 @@ class MdiInstrumentedTest {
     }
 
     @Test
+    fun general_parse_wire_tree_never_exposes_mdast_provenance() {
+        val source = """---
+title: provenance isolation
+---
+
+> - {東京|とうきょう} ^12^
+
+| image | empty |
+| - | - |
+| ![alt](cover.png) | ![](empty.png) |"""
+        val result = Mdi.parse(source)
+
+        assertTrue(!result.document.toString().contains("\"mdiProvenance\""))
+    }
+
+    @Test
     fun native_library_delegates_renderers_to_rust() {
         assertTrue(Mdi.renderHtml("{東京|とうきょう}").contains("mdi-ruby"))
         assertEquals("東京 12\n", Mdi.renderText("{東京|とうきょう} ^12^"))

--- a/mdi-core/src/lib.rs
+++ b/mdi-core/src/lib.rs
@@ -16,6 +16,8 @@ use unicode_segmentation::UnicodeSegmentation;
 use zip::{CompressionMethod, ZipWriter, write::SimpleFileOptions};
 
 mod docx;
+#[cfg(test)]
+mod provenance_tests;
 mod publication_profile;
 mod text_projection;
 pub use publication_profile::{
@@ -46,7 +48,8 @@ pub const MDI_IR_VERSION: &str = "1.0";
 ///
 /// The record is attached to IR nodes only so host adapters can carry it into
 /// their own transient metadata. It is never part of MDI serialization.
-pub const MDI_MDAST_PROVENANCE_VERSION: &str = "1.0";
+#[cfg(any(test, feature = "wasm"))]
+pub(crate) const MDI_MDAST_PROVENANCE_VERSION: &str = "1.0";
 
 /// A binding-friendly parse envelope.
 ///
@@ -296,7 +299,8 @@ pub fn parse_document(source: &str) -> Document {
 
 /// Parse a document for the Rust-to-mdast adapter boundary. The adapter-only
 /// provenance is deliberately absent from the normal language-binding IR.
-pub fn parse_document_for_mdast(source: &str) -> Document {
+#[cfg(any(test, feature = "wasm"))]
+pub(crate) fn parse_document_for_mdast(source: &str) -> Document {
     let mut document = parse_document_without_provenance(source);
     text_projection::attach_mdast_provenance(&mut document, source);
     document
@@ -1103,8 +1107,13 @@ pub fn parse_json(source: &str) -> String {
 
 /// Serialize the Rust-owned IR plus transient mdast provenance. This narrow
 /// boundary exists solely for `@illusions-lab/mdi-remark`.
-pub fn parse_mdast_json(source: &str) -> String {
+#[cfg(any(test, feature = "wasm"))]
+pub(crate) fn parse_mdast_json(source: &str) -> String {
     let document = parse_document_for_mdast(source);
+    let frontmatter_span = document
+        .frontmatter
+        .as_ref()
+        .map(|frontmatter| frontmatter.span);
     let output = ParseOutput {
         ir_version: MDI_IR_VERSION,
         syntax_version: MDI_SPEC_VERSION,
@@ -1118,6 +1127,17 @@ pub fn parse_mdast_json(source: &str) -> String {
         diagnostics: diagnostics(&document),
         document,
     };
+    let mut output = serde_json::to_value(output).expect("mdast parse output is serializable");
+    if let Some(span) = frontmatter_span {
+        output["document"]["frontmatter"]["mdiProvenance"] = serde_json::json!({
+            "version": MDI_MDAST_PROVENANCE_VERSION,
+            "construct": { "path": "frontmatter", "type": "yaml" },
+            "span": span,
+            "role": "container",
+            "status": "sourceBacked",
+            "targets": [],
+        });
+    }
     serde_json::to_string(&output).expect("serializing mdast provenance cannot fail")
 }
 
@@ -4657,14 +4677,32 @@ mod tests {
 
     #[test]
     fn keeps_mdast_provenance_out_of_the_standard_binding_contract() {
-        let standard = parse_document("text");
-        assert!(standard.children[0].get("mdiProvenance").is_none());
+        fn contains_provenance(value: &serde_json::Value) -> bool {
+            match value {
+                serde_json::Value::Object(object) => {
+                    object.contains_key("mdiProvenance") || object.values().any(contains_provenance)
+                }
+                serde_json::Value::Array(values) => values.iter().any(contains_provenance),
+                _ => false,
+            }
+        }
 
-        let mdast: serde_json::Value = serde_json::from_str(&parse_mdast_json("text"))
+        let source = "---\ntitle: boundary\n---\n\n> - nested {東京|とうきょう}";
+        let standard: serde_json::Value = serde_json::from_str(&parse_json(source)).unwrap();
+        assert!(!contains_provenance(&standard));
+        let projection: serde_json::Value =
+            serde_json::from_str(&get_mdi_text_blocks_json(source)).unwrap();
+        assert!(!contains_provenance(&projection));
+
+        let mdast: serde_json::Value = serde_json::from_str(&parse_mdast_json(source))
             .expect("mdast parse output is valid JSON");
         assert_eq!(
             mdast["document"]["children"][0]["mdiProvenance"]["version"],
             MDI_MDAST_PROVENANCE_VERSION
+        );
+        assert_eq!(
+            mdast["document"]["frontmatter"]["mdiProvenance"]["construct"],
+            serde_json::json!({ "path": "frontmatter", "type": "yaml" })
         );
     }
 

--- a/mdi-core/src/provenance_tests.rs
+++ b/mdi-core/src/provenance_tests.rs
@@ -1,0 +1,399 @@
+use super::{parse_document_for_mdast, parse_document_without_provenance, parse_mdast_json};
+use crate::text_projection::{
+    get_mdi_text_blocks, provenance_query_visits, reset_provenance_query_visits,
+};
+use serde_json::{Value, json};
+use std::hint::black_box;
+use std::time::{Duration, Instant};
+use unicode_segmentation::UnicodeSegmentation;
+
+#[derive(Clone, Copy)]
+struct Selector {
+    node_type: &'static str,
+    value_field: Option<(&'static str, &'static str)>,
+    occurrence: usize,
+}
+
+impl Selector {
+    const fn first(node_type: &'static str) -> Self {
+        Self {
+            node_type,
+            value_field: None,
+            occurrence: 0,
+        }
+    }
+
+    const fn value(node_type: &'static str, field: &'static str, value: &'static str) -> Self {
+        Self {
+            node_type,
+            value_field: Some((field, value)),
+            occurrence: 0,
+        }
+    }
+
+    const fn nth(node_type: &'static str, occurrence: usize) -> Self {
+        Self {
+            node_type,
+            value_field: None,
+            occurrence,
+        }
+    }
+}
+
+struct AcceptanceCase {
+    name: &'static str,
+    source: &'static str,
+    selector: Selector,
+    role: &'static str,
+    status: &'static str,
+    targets: Value,
+}
+
+fn matching_nodes<'a>(value: &'a Value, selector: Selector, matches: &mut Vec<&'a Value>) {
+    if value.get("type").and_then(Value::as_str) == Some(selector.node_type)
+        && selector.value_field.is_none_or(|(field, expected)| {
+            value.get(field).and_then(Value::as_str) == Some(expected)
+        })
+    {
+        matches.push(value);
+    }
+    if let Some(children) = value.get("children").and_then(Value::as_array) {
+        for child in children {
+            matching_nodes(child, selector, matches);
+        }
+    }
+}
+
+fn selected_node(document: &super::Document, selector: Selector) -> &Value {
+    let mut matches = Vec::new();
+    for child in &document.children {
+        matching_nodes(child, selector, &mut matches);
+    }
+    matches
+        .get(selector.occurrence)
+        .copied()
+        .unwrap_or_else(|| {
+            panic!(
+                "missing occurrence {} of node type {:?}",
+                selector.occurrence, selector.node_type
+            )
+        })
+}
+
+fn block_target(block: u32, start: u32, end: u32) -> Value {
+    json!({
+        "blockIndex": block,
+        "channel": "blockText",
+        "range": {"start": format!("{block}:{start}"), "end": format!("{block}:{end}")},
+    })
+}
+
+fn annotation_target(block: u32, annotation: u32, start: u32, end: u32) -> Value {
+    json!({
+        "blockIndex": block,
+        "channel": "annotation",
+        "annotationIndex": annotation,
+        "range": {"start": format!("{block}:{start}"), "end": format!("{block}:{end}")},
+    })
+}
+
+#[test]
+fn provenance_acceptance_matrix_has_exact_roles_statuses_and_targets() {
+    let cases = vec![
+        AcceptanceCase {
+            name: "nested list container",
+            source: "- outer\n  - inner\n",
+            selector: Selector::nth("listItem", 1),
+            role: "container",
+            status: "sourceBacked",
+            targets: json!([]),
+        },
+        AcceptanceCase {
+            name: "nested list text",
+            source: "- outer\n  - inner\n",
+            selector: Selector::value("text", "value", "inner"),
+            role: "textBearing",
+            status: "sourceBacked",
+            targets: json!([block_target(2, 1, 6)]),
+        },
+        AcceptanceCase {
+            name: "blockquote container",
+            source: "> quote\n",
+            selector: Selector::first("blockquote"),
+            role: "container",
+            status: "sourceBacked",
+            targets: json!([]),
+        },
+        AcceptanceCase {
+            name: "blockquote text",
+            source: "> quote\n",
+            selector: Selector::value("text", "value", "quote"),
+            role: "textBearing",
+            status: "sourceBacked",
+            targets: json!([block_target(1, 1, 6)]),
+        },
+        AcceptanceCase {
+            name: "table cell container",
+            source: "| a | b |\n| - | - |\n| c | d |\n",
+            selector: Selector::nth("tableCell", 3),
+            role: "container",
+            status: "sourceBacked",
+            targets: json!([]),
+        },
+        AcceptanceCase {
+            name: "table cell text",
+            source: "| a | b |\n| - | - |\n| c | d |\n",
+            selector: Selector::value("text", "value", "d"),
+            role: "textBearing",
+            status: "sourceBacked",
+            targets: json!([block_target(1, 7, 8)]),
+        },
+        AcceptanceCase {
+            name: "ruby base and reading",
+            source: "{東京|とうきょう}",
+            selector: Selector::first("ruby"),
+            role: "textBearing",
+            status: "sourceBacked",
+            targets: json!([block_target(1, 1, 3), annotation_target(1, 0, 1, 6),]),
+        },
+        AcceptanceCase {
+            name: "html",
+            source: "<i>x</i>\n",
+            selector: Selector::first("html"),
+            role: "textBearing",
+            status: "sourceBacked",
+            targets: json!([block_target(1, 1, 4)]),
+        },
+        AcceptanceCase {
+            name: "blank",
+            source: "\\\n",
+            selector: Selector::first("blank"),
+            role: "container",
+            status: "sourceBacked",
+            targets: json!([]),
+        },
+        AcceptanceCase {
+            name: "pagebreak",
+            source: "[[pagebreak:right]]\n",
+            selector: Selector::first("pagebreak"),
+            role: "container",
+            status: "sourceBacked",
+            targets: json!([]),
+        },
+        AcceptanceCase {
+            name: "indent paragraph",
+            source: "[[indent:2]]\nindented\n",
+            selector: Selector::first("paragraph"),
+            role: "container",
+            status: "sourceBacked",
+            targets: json!([]),
+        },
+        AcceptanceCase {
+            name: "bottom paragraph",
+            source: "[[bottom:3]]\nbottom\n",
+            selector: Selector::first("paragraph"),
+            role: "container",
+            status: "sourceBacked",
+            targets: json!([]),
+        },
+        AcceptanceCase {
+            name: "explicit break",
+            source: "a[[br]]b\n",
+            selector: Selector::first("break"),
+            role: "textBearing",
+            status: "sourceBacked",
+            targets: json!([block_target(1, 2, 3)]),
+        },
+        AcceptanceCase {
+            name: "image alt text",
+            source: "![alt](image.png)\n",
+            selector: Selector::value("image", "alt", "alt"),
+            role: "textBearing",
+            status: "sourceBacked",
+            targets: json!([block_target(1, 1, 4)]),
+        },
+        AcceptanceCase {
+            name: "empty image alt",
+            source: "![](image.png)\n",
+            selector: Selector::value("image", "alt", ""),
+            role: "textBearing",
+            status: "unmapped",
+            targets: json!([]),
+        },
+        AcceptanceCase {
+            name: "malformed literal fallback",
+            source: "[[em:open\n",
+            selector: Selector::value("text", "value", "[[em:open"),
+            role: "textBearing",
+            status: "sourceBacked",
+            targets: json!([block_target(1, 1, 10)]),
+        },
+    ];
+
+    for case in cases {
+        let document = parse_document_for_mdast(case.source);
+        let node = selected_node(&document, case.selector);
+        let provenance = node
+            .get("mdiProvenance")
+            .unwrap_or_else(|| panic!("{}: selected node lacks provenance: {node:#}", case.name));
+        assert_eq!(
+            provenance["construct"]["type"], case.selector.node_type,
+            "{}: construct type",
+            case.name
+        );
+        assert_eq!(provenance["role"], case.role, "{}: role", case.name);
+        assert_eq!(provenance["status"], case.status, "{}: status", case.name);
+        assert_eq!(
+            provenance["targets"], case.targets,
+            "{}: targets",
+            case.name
+        );
+        assert!(
+            provenance["construct"]["path"].as_str().is_some(),
+            "{}: parse-local path",
+            case.name
+        );
+    }
+}
+
+#[test]
+fn frontmatter_provenance_is_rust_owned_and_has_no_projection_targets() {
+    let output: Value = serde_json::from_str(&parse_mdast_json("---\ntitle: Test\n---\n\nbody\n"))
+        .expect("mdast envelope");
+    let provenance = &output["document"]["frontmatter"]["mdiProvenance"];
+    assert_eq!(
+        provenance["construct"],
+        json!({"path": "frontmatter", "type": "yaml"})
+    );
+    assert_eq!(provenance["role"], "container");
+    assert_eq!(provenance["status"], "sourceBacked");
+    assert_eq!(provenance["span"], json!({"startByte": 0, "endByte": 19}));
+    assert_eq!(provenance["targets"], json!([]));
+}
+
+fn repeated_projection_source(paragraphs: usize) -> String {
+    let mut source = String::with_capacity(paragraphs * 32);
+    for index in 0..paragraphs {
+        source.push_str(&format!("unit-{index} {{東|とう}} ![a](x)\n\n"));
+    }
+    source
+}
+
+fn projection_unit_count(source: &str) -> usize {
+    let projection = get_mdi_text_blocks(source);
+    projection
+        .blocks
+        .iter()
+        .map(|block| {
+            block.text.graphemes(true).count()
+                + block
+                    .annotations
+                    .iter()
+                    .map(|annotation| annotation.text.graphemes(true).count())
+                    .sum::<usize>()
+        })
+        .sum()
+}
+
+#[test]
+fn provenance_interval_queries_visit_only_a_linear_number_of_candidates() {
+    fn measured(paragraphs: usize) -> (usize, usize) {
+        let source = repeated_projection_source(paragraphs);
+        let units = projection_unit_count(&source);
+        reset_provenance_query_visits();
+        black_box(parse_document_for_mdast(black_box(&source)));
+        (units, provenance_query_visits())
+    }
+
+    let (small_units, small_visits) = measured(200);
+    let (large_units, large_visits) = measured(400);
+    assert!(
+        small_visits > 0,
+        "query instrumentation did not record visits"
+    );
+    assert!(
+        small_visits <= small_units * 4,
+        "candidate visits must be bounded by projection units and actual matches: visits={small_visits}, units={small_units}"
+    );
+    assert!(
+        large_visits <= large_units * 4,
+        "candidate visits must be bounded by projection units and actual matches: visits={large_visits}, units={large_units}"
+    );
+    assert!(
+        large_visits <= small_visits * 3,
+        "doubling the tree approached quadratic candidate scanning: {small_visits} -> {large_visits}"
+    );
+}
+
+fn bounded_nested_list(items: usize) -> String {
+    let mut source = String::with_capacity(items * 32);
+    for index in 0..items {
+        let depth = index % 4;
+        source.push_str(&"  ".repeat(depth));
+        source.push_str("- item ");
+        source.push_str(&index.to_string());
+        source.push_str(" {東|とう}\n");
+    }
+    source
+}
+
+fn median_duration(mut samples: Vec<Duration>) -> Duration {
+    samples.sort_unstable();
+    samples[samples.len() / 2]
+}
+
+#[test]
+#[ignore = "release-only provenance scaling benchmark"]
+fn release_nested_list_scaling_is_not_near_quadratic() {
+    let mut normal = Vec::new();
+    let mut mdast = Vec::new();
+    let mut projection = Vec::new();
+    for size in [800, 1600, 3200] {
+        let source = bounded_nested_list(size);
+        let measure = |operation: &mut dyn FnMut()| {
+            median_duration(
+                (0..3)
+                    .map(|_| {
+                        let started = Instant::now();
+                        operation();
+                        started.elapsed()
+                    })
+                    .collect(),
+            )
+        };
+        let normal_elapsed = measure(&mut || {
+            black_box(parse_document_without_provenance(black_box(&source)));
+        });
+        let mdast_elapsed = measure(&mut || {
+            black_box(parse_document_for_mdast(black_box(&source)));
+        });
+        let projection_elapsed = measure(&mut || {
+            black_box(get_mdi_text_blocks(black_box(&source)));
+        });
+        eprintln!(
+            "nested-list {size}: normal={normal_elapsed:?} mdast={mdast_elapsed:?} projection={projection_elapsed:?}"
+        );
+        normal.push(normal_elapsed);
+        mdast.push(mdast_elapsed);
+        projection.push(projection_elapsed);
+    }
+
+    for (label, timings) in [
+        ("normal parse", normal),
+        ("mdast parse", mdast),
+        ("projection", projection),
+    ] {
+        for pair in timings.windows(2) {
+            // A true quadratic doubling is approximately 4x. Allow ordinary
+            // runner noise, but fail well before that shape is reached.
+            let allowed = pair[0].mul_f64(3.25) + Duration::from_millis(10);
+            assert!(
+                pair[1] <= allowed,
+                "{label} approached quadratic growth: {:?} -> {:?} (limit {:?})",
+                pair[0],
+                pair[1],
+                allowed
+            );
+        }
+    }
+}

--- a/mdi-core/src/text_projection.rs
+++ b/mdi-core/src/text_projection.rs
@@ -1,11 +1,19 @@
+#[cfg(any(test, feature = "wasm"))]
+use crate::MDI_MDAST_PROVENANCE_VERSION;
 use crate::{
-    Diagnostic, DiagnosticSeverity, Document, MDI_IR_VERSION, MDI_MDAST_PROVENANCE_VERSION,
-    MDI_SPEC_VERSION, ParserCapabilities, SourceSpan, diagnostics,
-    parse_document_without_provenance,
+    Diagnostic, DiagnosticSeverity, Document, MDI_IR_VERSION, MDI_SPEC_VERSION, ParserCapabilities,
+    SourceSpan, diagnostics, parse_document_without_provenance,
 };
 use serde::Serialize;
+#[cfg(test)]
+use std::cell::Cell;
 use std::fmt;
 use unicode_segmentation::UnicodeSegmentation;
+
+#[cfg(test)]
+thread_local! {
+    static PROVENANCE_QUERY_VISITS: Cell<usize> = const { Cell::new(0) };
+}
 
 pub(crate) enum PlainInline<'a> {
     Value(&'a str),
@@ -332,6 +340,7 @@ pub fn get_mdi_text_blocks(source: &str) -> MdiTextBlocksResult {
 /// Attach adapter-only provenance to every Rust IR construct.  The mdast
 /// adapter transports this exact record; it must not reconstruct projection
 /// ranges, source maps, or identities in JavaScript.
+#[cfg(any(test, feature = "wasm"))]
 pub(crate) fn attach_mdast_provenance(document: &mut Document, source: &str) {
     let mut collector = Collector {
         source,
@@ -341,12 +350,14 @@ pub(crate) fn attach_mdast_provenance(document: &mut Document, source: &str) {
     for node in &document.children {
         collector.collect(node, false);
     }
-    for (index, node) in document.children.iter_mut().enumerate() {
-        attach_node_provenance(node, &collector.blocks, &index.to_string());
+    let provenance_index = ProvenanceIndex::new(&collector.blocks);
+    for (node_index, node) in document.children.iter_mut().enumerate() {
+        attach_node_provenance(node, &provenance_index, &node_index.to_string());
     }
 }
 
-fn attach_node_provenance(node: &mut serde_json::Value, blocks: &[MdiTextBlock], path: &str) {
+#[cfg(any(test, feature = "wasm"))]
+fn attach_node_provenance(node: &mut serde_json::Value, index: &ProvenanceIndex, path: &str) {
     let Some(object) = node.as_object_mut() else {
         return;
     };
@@ -357,17 +368,19 @@ fn attach_node_provenance(node: &mut serde_json::Value, blocks: &[MdiTextBlock],
     let span = object
         .get("span")
         .and_then(|value| serde_json::from_value::<SourceSpan>(value.clone()).ok());
-    let targets = span
-        .map(|span| provenance_targets(blocks, span))
-        .unwrap_or_default();
     let role = if is_text_bearing(node_type) {
         "textBearing"
     } else {
         "container"
     };
+    let targets = if role == "textBearing" {
+        span.map(|span| index.targets(span)).unwrap_or_default()
+    } else {
+        Vec::new()
+    };
     let status = if span.is_none() {
         "synthetic"
-    } else if targets.is_empty() {
+    } else if role == "textBearing" && targets.is_empty() {
         "unmapped"
     } else {
         "sourceBacked"
@@ -387,12 +400,13 @@ fn attach_node_provenance(node: &mut serde_json::Value, blocks: &[MdiTextBlock],
         .get_mut("children")
         .and_then(serde_json::Value::as_array_mut)
     {
-        for (index, child) in children.iter_mut().enumerate() {
-            attach_node_provenance(child, blocks, &format!("{path}.{index}"));
+        for (child_index, child) in children.iter_mut().enumerate() {
+            attach_node_provenance(child, index, &format!("{path}.{child_index}"));
         }
     }
 }
 
+#[cfg(any(test, feature = "wasm"))]
 fn is_text_bearing(node_type: &str) -> bool {
     matches!(
         node_type,
@@ -400,40 +414,166 @@ fn is_text_bearing(node_type: &str) -> bool {
     )
 }
 
-fn provenance_targets(blocks: &[MdiTextBlock], span: SourceSpan) -> Vec<serde_json::Value> {
-    if span.start_byte == span.end_byte {
-        return Vec::new();
-    }
-    let mut matches = Vec::new();
-    let mut covered = Vec::new();
-    for block in blocks {
-        resolve_source_map_channel(
-            block.index,
-            None,
-            &block.source_map,
-            span,
-            &mut matches,
-            &mut covered,
-        );
-        for (annotation_index, annotation) in block.annotations.iter().enumerate() {
-            resolve_source_map_channel(
+#[cfg(any(test, feature = "wasm"))]
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ProvenanceChannel {
+    BlockText,
+    Annotation(u32),
+}
+
+#[cfg(any(test, feature = "wasm"))]
+struct ProvenanceUnit {
+    span: SourceSpan,
+    block_index: u32,
+    channel: ProvenanceChannel,
+    character: u32,
+    ordinal: usize,
+}
+
+/// An immutable interval index built once for one mdast parse. `prefix_max_end`
+/// makes the first possible overlap a binary search even when source intervals
+/// nest or share their starting byte.
+#[cfg(any(test, feature = "wasm"))]
+struct ProvenanceIndex {
+    units: Vec<ProvenanceUnit>,
+    prefix_max_end: Vec<u32>,
+}
+
+#[cfg(any(test, feature = "wasm"))]
+impl ProvenanceIndex {
+    fn new(blocks: &[MdiTextBlock]) -> Self {
+        let mut units = Vec::new();
+        for block in blocks {
+            Self::push_channel(
+                &mut units,
                 block.index,
-                Some(annotation_index as u32),
-                &annotation.source_map,
-                span,
-                &mut matches,
-                &mut covered,
+                ProvenanceChannel::BlockText,
+                &block.source_map,
             );
+            for (annotation_index, annotation) in block.annotations.iter().enumerate() {
+                Self::push_channel(
+                    &mut units,
+                    block.index,
+                    ProvenanceChannel::Annotation(annotation_index as u32),
+                    &annotation.source_map,
+                );
+            }
+        }
+        units.sort_by_key(|unit| (unit.span.start_byte, unit.span.end_byte, unit.ordinal));
+        let mut maximum = 0;
+        let prefix_max_end = units
+            .iter()
+            .map(|unit| {
+                maximum = maximum.max(unit.span.end_byte);
+                maximum
+            })
+            .collect();
+        Self {
+            units,
+            prefix_max_end,
         }
     }
-    matches.into_iter().map(|matched| match matched {
-        MdiSourceSpanTextMatch::BlockText { block_index, range, .. } => serde_json::json!({
+
+    fn push_channel(
+        units: &mut Vec<ProvenanceUnit>,
+        block_index: u32,
+        channel: ProvenanceChannel,
+        map: &MdiTextSourceMap,
+    ) {
+        for run in &map.runs {
+            for (offset, boundaries) in run.source_boundaries.windows(2).enumerate() {
+                units.push(ProvenanceUnit {
+                    span: SourceSpan {
+                        start_byte: boundaries[0],
+                        end_byte: boundaries[1],
+                    },
+                    block_index,
+                    channel,
+                    character: run.range.start.character + offset as u32,
+                    ordinal: units.len(),
+                });
+            }
+        }
+    }
+
+    fn targets(&self, span: SourceSpan) -> Vec<serde_json::Value> {
+        if span.start_byte == span.end_byte || self.units.is_empty() {
+            return Vec::new();
+        }
+        let first = self
+            .prefix_max_end
+            .partition_point(|&end| end <= span.start_byte);
+        let after_last = self
+            .units
+            .partition_point(|unit| unit.span.start_byte < span.end_byte);
+        let mut targets = Vec::new();
+        let mut pending: Option<(u32, ProvenanceChannel, u32, u32)> = None;
+        for unit in self.units.get(first..after_last).unwrap_or_default() {
+            #[cfg(test)]
+            PROVENANCE_QUERY_VISITS.with(|visits| visits.set(visits.get() + 1));
+            if unit.span.end_byte <= span.start_byte {
+                continue;
+            }
+            match pending.as_mut() {
+                Some((block, channel, _, end))
+                    if *block == unit.block_index
+                        && *channel == unit.channel
+                        && *end == unit.character =>
+                {
+                    *end = unit.character + 1;
+                }
+                _ => {
+                    if let Some(target) = pending.take() {
+                        targets.push(provenance_target(target));
+                    }
+                    pending = Some((
+                        unit.block_index,
+                        unit.channel,
+                        unit.character,
+                        unit.character + 1,
+                    ));
+                }
+            }
+        }
+        if let Some(target) = pending {
+            targets.push(provenance_target(target));
+        }
+        targets
+    }
+}
+
+#[cfg(any(test, feature = "wasm"))]
+fn provenance_target(
+    (block_index, channel, start, end): (u32, ProvenanceChannel, u32, u32),
+) -> serde_json::Value {
+    let range = MdiTextRange {
+        start: MdiTextPosition {
+            block: block_index,
+            character: start,
+        },
+        end: MdiTextPosition {
+            block: block_index,
+            character: end,
+        },
+    };
+    match channel {
+        ProvenanceChannel::BlockText => serde_json::json!({
             "blockIndex": block_index, "channel": "blockText", "range": range,
         }),
-        MdiSourceSpanTextMatch::Annotation { block_index, annotation_index, range, .. } => serde_json::json!({
+        ProvenanceChannel::Annotation(annotation_index) => serde_json::json!({
             "blockIndex": block_index, "channel": "annotation", "annotationIndex": annotation_index, "range": range,
         }),
-    }).collect()
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn reset_provenance_query_visits() {
+    PROVENANCE_QUERY_VISITS.with(|visits| visits.set(0));
+}
+
+#[cfg(test)]
+pub(crate) fn provenance_query_visits() -> usize {
+    PROVENANCE_QUERY_VISITS.with(Cell::get)
 }
 
 pub fn get_mdi_text_blocks_json(source: &str) -> String {

--- a/nodejs/browser-test/src.ts
+++ b/nodejs/browser-test/src.ts
@@ -1,4 +1,5 @@
-import { getMdiTextBlocks, initializeMdi, parse, parseForMdast, resolveMdiSourceSpan, resolveMdiSourceSpans, serializeMdi } from "@illusions-lab/mdi";
+import { getMdiTextBlocks, initializeMdi, parse, resolveMdiSourceSpan, resolveMdiSourceSpans, serializeMdi } from "@illusions-lab/mdi";
+import { parseForMdast, type MdiMdastDocument, type MdiMdastNode } from "@illusions-lab/mdi/internal/mdast";
 import remarkMdi from "@illusions-lab/mdi-remark";
 import remarkParse from "remark-parse";
 import remarkStringify from "remark-stringify";
@@ -63,7 +64,7 @@ async function run(): Promise<void> {
   document.querySelector("#result")!.textContent = JSON.stringify({
     irVersion: parsed.irVersion,
     projectionVersion: projection.projectionVersion,
-    provenanceJson: JSON.stringify(parseForMdast(source).document.children.map((node) => node.mdiProvenance)),
+    provenanceJson: JSON.stringify(canonicalProvenance(parseForMdast(source).document)),
     projectionSource: source,
     projectionJson: JSON.stringify(projection),
     sourceResolutionSpan,
@@ -82,4 +83,18 @@ async function run(): Promise<void> {
     largeNodeCount: large.document.children.length,
     diagnostic: unsupportedVersion.diagnostics[0],
   });
+}
+
+function canonicalProvenance(document: MdiMdastDocument): unknown {
+  return {
+    frontmatter: document.frontmatter?.mdiProvenance ?? null,
+    children: document.children.map(canonicalNodeProvenance),
+  };
+}
+
+function canonicalNodeProvenance(node: MdiMdastNode): unknown {
+  return {
+    provenance: node.mdiProvenance ?? null,
+    children: (node.children ?? []).map(canonicalNodeProvenance),
+  };
 }

--- a/nodejs/packages/mdi-core/CHANGELOG.md
+++ b/nodejs/packages/mdi-core/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @illusions-lab/mdi-core
 
+## 2.0.3
+
+### Patch Changes
+
+- Add the Rust-owned mdast provenance transport used by the internal remark
+  adapter without changing the general parse or text-projection contracts.
+
 ## 2.0.2
 
 ### Patch Changes

--- a/nodejs/packages/mdi-core/package.json
+++ b/nodejs/packages/mdi-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@illusions-lab/mdi-core",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "wasm bindings for mdi-core, the language-neutral MDI 2.0 syntax core",
   "license": "MIT",
   "repository": {

--- a/nodejs/packages/mdi/CHANGELOG.md
+++ b/nodejs/packages/mdi/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @illusions-lab/mdi
 
+## 2.0.3
+
+### Patch Changes
+
+- Isolate Rust-owned mdast provenance under `@illusions-lab/mdi/internal/mdast`
+  and keep it out of general parsing and text projection.
+- Updated dependencies
+  - @illusions-lab/mdi-core@2.0.3
+
 ## 2.0.2
 
 ### Patch Changes

--- a/nodejs/packages/mdi/package.json
+++ b/nodejs/packages/mdi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@illusions-lab/mdi",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Thin JavaScript binding for the Rust-authoritative MDI parser",
   "license": "MIT",
   "repository": {
@@ -21,13 +21,17 @@
     "./node": {
       "types": "./dist/node.d.ts",
       "default": "./dist/node.js"
+    },
+    "./internal/mdast": {
+      "types": "./dist/internal/mdast.d.ts",
+      "default": "./dist/internal/mdast.js"
     }
   },
   "files": [
     "dist"
   ],
   "scripts": {
-    "build": "tsup src/index.ts src/node.ts --format esm,cjs --dts",
+    "build": "tsup src/index.ts src/node.ts src/internal/mdast.ts --format esm,cjs --dts",
     "test": "vitest run --passWithNoTests",
     "typecheck": "tsc --noEmit"
   },

--- a/nodejs/packages/mdi/src/index.ts
+++ b/nodejs/packages/mdi/src/index.ts
@@ -7,7 +7,6 @@ import { parse as parseYaml } from "yaml";
 const {
 	getMdiTextBlocksJson,
 	resolveMdiSourceSpansJson,
-	parseMdiMdastJson,
 	parseMdiSyntaxJson,
 	renderHtml: renderHtmlFromRust,
 	renderEpub: renderEpubFromRust,
@@ -110,9 +109,6 @@ export const MDI_IR_VERSION = "1.0" as const;
 /** Version of the Rust-owned searchable text projection. */
 export const MDI_TEXT_PROJECTION_VERSION = "1.0" as const;
 
-/** Version of Rust-owned transient mdast provenance records. */
-export const MDI_MDAST_PROVENANCE_VERSION = "1.0" as const;
-
 export interface MdiParserCapabilities {
 	mdi: boolean;
 	commonMark: boolean;
@@ -126,25 +122,6 @@ export interface MdiSourceSpan {
 	startByte: number;
 	/** Exclusive UTF-8 byte offset. */
 	endByte: number;
-}
-
-/** A projection target assigned by Rust to a source-backed IR construct. */
-export type MdiMdastProvenanceTarget =
-	| { blockIndex: number; channel: "blockText"; range: MdiTextRange }
-	| { blockIndex: number; channel: "annotation"; annotationIndex: number; range: MdiTextRange };
-
-/**
- * Transient identity and projection metadata emitted by Rust for mdast
- * adapters. `construct.path` is a stable IR path for this parse result; it is
- * not a persisted document ID and must not be inferred from text or order.
- */
-export interface MdiMdastProvenance {
-	version: typeof MDI_MDAST_PROVENANCE_VERSION;
-	construct: { path: string; type: string };
-	span?: MdiSourceSpan;
-	role: "container" | "textBearing";
-	status: "sourceBacked" | "synthetic" | "unmapped";
-	targets: MdiMdastProvenanceTarget[];
 }
 
 /** A canonical one-based `block:grapheme` text position. */
@@ -252,8 +229,6 @@ export type MdiRubyReading =
 export interface MdiNode {
 	type: string;
 	span?: MdiSourceSpan;
-	/** Rust-owned, adapter-only metadata; omitted by canonical serialization. */
-	mdiProvenance?: MdiMdastProvenance;
 	children?: MdiNode[];
 	[key: string]: unknown;
 }
@@ -333,16 +308,6 @@ export type MdiSyntaxDocument = MdiDocument;
 export function parse(source: string): MdiSyntaxParseResult {
 	if (typeof source !== "string") throw new TypeError("source must be a string");
 	const result = JSON.parse(parseMdiSyntaxJson(source)) as MdiSyntaxParseResult;
-	if (result.irVersion !== MDI_IR_VERSION) {
-		throw new Error(`Unsupported MDI IR version: ${String(result.irVersion)}`);
-	}
-	return result;
-}
-
-/** @internal Rust-backed input for the mdast adapter; not a general IR API. */
-export function parseForMdast(source: string): MdiSyntaxParseResult {
-	if (typeof source !== "string") throw new TypeError("source must be a string");
-	const result = JSON.parse(parseMdiMdastJson(source)) as MdiSyntaxParseResult;
 	if (result.irVersion !== MDI_IR_VERSION) {
 		throw new Error(`Unsupported MDI IR version: ${String(result.irVersion)}`);
 	}

--- a/nodejs/packages/mdi/src/internal/mdast.ts
+++ b/nodejs/packages/mdi/src/internal/mdast.ts
@@ -1,0 +1,66 @@
+import { parseMdiMdastJson } from "@illusions-lab/mdi-core";
+import {
+	MDI_IR_VERSION,
+	MDI_SPEC_VERSION,
+	type MdiDiagnostic,
+	type MdiDocument,
+	type MdiFrontmatter,
+	type MdiNode,
+	type MdiParserCapabilities,
+	type MdiSourceSpan,
+	type MdiTextRange,
+} from "../index.js";
+
+/** Version of Rust-owned transient mdast provenance records. */
+export const MDI_MDAST_PROVENANCE_VERSION = "1.0" as const;
+
+/** A projection target assigned by Rust to a source-backed IR construct. */
+export type MdiMdastProvenanceTarget =
+	| { blockIndex: number; channel: "blockText"; range: MdiTextRange }
+	| { blockIndex: number; channel: "annotation"; annotationIndex: number; range: MdiTextRange };
+
+/**
+ * Transient identity and projection metadata emitted by Rust for mdast
+ * adapters. `construct.path` is valid only for this parse result; it is not a
+ * persisted document ID and must not be inferred from text or order.
+ */
+export interface MdiMdastProvenance {
+	version: typeof MDI_MDAST_PROVENANCE_VERSION;
+	construct: { path: string; type: string };
+	span: MdiSourceSpan | null;
+	role: "container" | "textBearing";
+	status: "sourceBacked" | "synthetic" | "unmapped";
+	targets: MdiMdastProvenanceTarget[];
+}
+
+export type MdiMdastNode = Omit<MdiNode, "children"> & {
+	mdiProvenance?: MdiMdastProvenance;
+	children?: MdiMdastNode[];
+};
+
+export type MdiMdastFrontmatter = MdiFrontmatter & {
+	mdiProvenance: MdiMdastProvenance;
+};
+
+export type MdiMdastDocument = Omit<MdiDocument, "frontmatter" | "children"> & {
+	frontmatter?: MdiMdastFrontmatter;
+	children: MdiMdastNode[];
+};
+
+export interface MdiMdastParseResult {
+	irVersion: typeof MDI_IR_VERSION;
+	syntaxVersion: typeof MDI_SPEC_VERSION;
+	capabilities: MdiParserCapabilities;
+	document: MdiMdastDocument;
+	diagnostics: MdiDiagnostic[];
+}
+
+/** Rust-backed transport exclusively for mdast adapters. */
+export function parseForMdast(source: string): MdiMdastParseResult {
+	if (typeof source !== "string") throw new TypeError("source must be a string");
+	const result = JSON.parse(parseMdiMdastJson(source)) as MdiMdastParseResult;
+	if (result.irVersion !== MDI_IR_VERSION) {
+		throw new Error(`Unsupported MDI IR version: ${String(result.irVersion)}`);
+	}
+	return result;
+}

--- a/nodejs/packages/mdi/src/wire-provenance-isolation.test.ts
+++ b/nodejs/packages/mdi/src/wire-provenance-isolation.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { getMdiTextBlocks, parse } from "./index.js";
+
+const source = `---
+title: provenance isolation
+---
+
+> - {東京|とうきょう} ^12^
+>   continuation
+
+| image | empty |
+| - | - |
+| ![alt](cover.png) | ![](empty.png) |`;
+
+describe("general wire provenance isolation", () => {
+	it("keeps mdast provenance out of parse and text-projection JSON", () => {
+		for (const result of [parse(source), getMdiTextBlocks(source)]) {
+			expect(JSON.stringify(result)).not.toContain('"mdiProvenance"');
+		}
+	});
+});

--- a/nodejs/packages/remark/CHANGELOG.md
+++ b/nodejs/packages/remark/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @illusions-lab/mdi-remark
 
+## 2.0.18
+
+### Patch Changes
+
+- Preserve the complete Rust-owned provenance tree, including YAML
+  frontmatter, through the internal mdast adapter.
+- Updated dependencies
+  - @illusions-lab/mdi@2.0.3
+
 ## 2.0.17
 
 ### Patch Changes

--- a/nodejs/packages/remark/README.md
+++ b/nodejs/packages/remark/README.md
@@ -23,16 +23,16 @@ normalization, serialization, and renderer semantics remain in Rust.
 
 ## Rust-owned mdast provenance
 
-Every emitted source construct carries transient metadata at
-`node.data.mdiProvenance`. Its version is `1.0`; the adapter copies the record
-from Rust without parsing or deriving it. Generic mdast consumers may ignore
-`data.mdiProvenance` safely.
+Every emitted source construct, including the YAML frontmatter node, carries
+transient metadata at `node.data.mdiProvenance`. Its version is `1.0`; the
+adapter copies the record from Rust without parsing or deriving it. Generic
+mdast consumers may ignore `data.mdiProvenance` safely.
 
 ```ts
 type MdiMdastProvenance = {
   version: "1.0";
   construct: { path: string; type: string };
-  span?: { startByte: number; endByte: number };
+  span: { startByte: number; endByte: number } | null;
   role: "container" | "textBearing";
   status: "sourceBacked" | "synthetic" | "unmapped";
   targets: Array<
@@ -49,6 +49,8 @@ metadata while building their own document model, then join source-span
 resolution through these keys. They must not rebuild provenance using text,
 source order, DOM, or editor-tree traversal. Provenance is not serialized to
 canonical MDI, Markdown, HTML, clipboard, or persisted-document semantics.
+Container records intentionally have no aggregate projection targets; only
+text-bearing nodes query the indexed projection map.
 
 ## Usage
 

--- a/nodejs/packages/remark/package.json
+++ b/nodejs/packages/remark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@illusions-lab/mdi-remark",
-  "version": "2.0.17",
+  "version": "2.0.18",
   "description": "Rust-backed remark adapter for MDI 2.0 documents",
   "license": "MIT",
   "repository": {

--- a/nodejs/packages/remark/src/index.test.ts
+++ b/nodejs/packages/remark/src/index.test.ts
@@ -4,6 +4,7 @@ import { unified } from "unified";
 import remarkParse from "remark-parse";
 import remarkStringify from "remark-stringify";
 import type { Root } from "mdast";
+import { parseForMdast } from "@illusions-lab/mdi/internal/mdast";
 import remarkMdi from "./index.js";
 
 function processor() {
@@ -182,6 +183,7 @@ same
 			expect(["container", "textBearing"]).toContain(record.role);
 			expect(["sourceBacked", "synthetic", "unmapped"]).toContain(record.status);
 			expect(Array.isArray(record.targets)).toBe(true);
+			if (record.role === "container") expect(record.targets).toEqual([]);
 		}
 		const ruby = records.find((record) => (record.construct as { type: string }).type === "ruby")!;
 		expect(ruby.targets).toEqual(expect.arrayContaining([
@@ -189,7 +191,17 @@ same
 			expect.objectContaining({ channel: "annotation", annotationIndex: 0 }),
 		]));
 		const blank = records.find((record) => (record.construct as { type: string }).type === "blank")!;
-		expect(blank).toMatchObject({ role: "container", status: "unmapped", targets: [] });
+		expect(blank).toMatchObject({ role: "container", status: "sourceBacked", targets: [] });
+	});
+
+	it("copies Rust-owned frontmatter provenance onto the YAML node unchanged", () => {
+		const source = "---\ntitle: Example\n---\n\ntext";
+		const rustProvenance = parseForMdast(source).document.frontmatter?.mdiProvenance;
+		const yaml = parse(source).children[0] as Root["children"][number];
+
+		expect(rustProvenance).toBeDefined();
+		expect(yaml.type).toBe("yaml");
+		expect((yaml.data as Record<string, unknown>).mdiProvenance).toEqual(rustProvenance);
 	});
 
 	it("does not serialize transient provenance into Markdown", () => {

--- a/nodejs/packages/remark/src/index.ts
+++ b/nodejs/packages/remark/src/index.ts
@@ -1,9 +1,8 @@
 import {
 	parseForMdast,
-	type MdiDocument,
-	type MdiMdastProvenance,
-	type MdiNode,
-} from "@illusions-lab/mdi";
+	type MdiMdastDocument,
+	type MdiMdastNode,
+} from "@illusions-lab/mdi/internal/mdast";
 import { mdiToMarkdown } from "mdast-util-mdi";
 import remarkFrontmatter from "remark-frontmatter";
 import remarkGfm from "remark-gfm";
@@ -14,8 +13,8 @@ import type { Processor } from "unified";
 import { resolveFrontmatter } from "./frontmatter.js";
 
 export const MDI_SPEC_VERSION = "2.0";
-export const MDI_MDAST_PROVENANCE_VERSION = "1.0" as const;
-export type { MdiMdastProvenance, MdiMdastProvenanceTarget } from "@illusions-lab/mdi";
+export { MDI_MDAST_PROVENANCE_VERSION } from "@illusions-lab/mdi/internal/mdast";
+export type { MdiMdastProvenance, MdiMdastProvenanceTarget } from "@illusions-lab/mdi/internal/mdast";
 export type { MdiFrontmatter } from "./frontmatter.js";
 export { initializeMdi } from "@illusions-lab/mdi";
 
@@ -41,15 +40,19 @@ export default function remarkMdi(this: Processor): void {
 	};
 }
 
-function toMdast(document: MdiDocument): Root {
+function toMdast(document: MdiMdastDocument): Root {
 	const children = document.children.map(toMdastNode) as unknown as Root["children"];
 	if (document.frontmatter) {
-		children.unshift({ type: "yaml", value: document.frontmatter.raw });
+		children.unshift({
+			type: "yaml",
+			value: document.frontmatter.raw,
+			data: { mdiProvenance: document.frontmatter.mdiProvenance },
+		} as unknown as Root["children"][number]);
 	}
 	return { type: "root", children };
 }
 
-function toMdastNode(node: MdiNode): Record<string, unknown> {
+function toMdastNode(node: MdiMdastNode): Record<string, unknown> {
 	const { span: _span, mdiProvenance, children, ...rest } = node;
 	const mapped: Record<string, unknown> = { ...rest };
 	if (children) mapped.children = children.map(toMdastNode);

--- a/nodejs/scripts/test-browser-wasm.mjs
+++ b/nodejs/scripts/test-browser-wasm.mjs
@@ -45,6 +45,7 @@ try {
   execFileSync("npm", ["install", "--ignore-scripts", "--no-audit", "--no-fund", ...tarballs], { cwd: consumerDirectory, stdio: "inherit" });
   const consumerRequire = createRequire(join(consumerDirectory, "package.json"));
   const packedMdi = await import(pathToFileURL(consumerRequire.resolve("@illusions-lab/mdi")).href);
+  const packedMdast = await import(pathToFileURL(consumerRequire.resolve("@illusions-lab/mdi/internal/mdast")).href);
   await writeFile(join(fixtureRoot, "index.html"), await readFile(resolve(repositoryRoot, "nodejs/browser-test/index.html")));
   await writeFile(join(fixtureRoot, "src.ts"), await readFile(resolve(repositoryRoot, "nodejs/browser-test/src.ts")));
 
@@ -106,7 +107,7 @@ try {
     const url = `http://127.0.0.1:${address.port}/mdi-editor/`;
     console.log("Running packed browser WASM contract in Chromium, Firefox, and WebKit");
     for (const [browserName, browserType] of browserTypes) {
-      await testBrowser(browserName, browserType, url, packedMdi.getMdiTextBlocks, packedMdi.parseForMdast, packedMdi.resolveMdiSourceSpan, packedMdi.resolveMdiSourceSpans, runRetry && browserName === "Chromium" ? `${url}?retry=1` : undefined);
+      await testBrowser(browserName, browserType, url, packedMdi.getMdiTextBlocks, packedMdast.parseForMdast, packedMdi.resolveMdiSourceSpan, packedMdi.resolveMdiSourceSpans, runRetry && browserName === "Chromium" ? `${url}?retry=1` : undefined);
     }
     assert.equal(wasmRequests.length, browserTypes.length + (runRetry ? 2 : 0), "failed initialization must retry exactly once without duplicate concurrent loads");
     assert(wasmRequests.every(({ contentType }) => contentType === "application/wasm"), "WASM must be served with application/wasm");
@@ -149,7 +150,7 @@ async function testPage(browserName, page, url, getNodeProjection, parseNodeMdas
   assert.equal(result.projectionVersion, "1.0", browserName);
   assert.equal(
     result.provenanceJson,
-    JSON.stringify(parseNodeMdast(result.projectionSource).document.children.map((node) => node.mdiProvenance)),
+    JSON.stringify(canonicalProvenance(parseNodeMdast(result.projectionSource).document)),
     `${browserName}: Node and browser provenance must be byte-for-byte identical`,
   );
   assert.equal(
@@ -185,6 +186,20 @@ async function testPage(browserName, page, url, getNodeProjection, parseNodeMdas
   assert.match(result.canonical, /\{東京\|とうきょう\}/, browserName);
   assert.match(result.remarkOutput, /\{東京\|とうきょう\}/, browserName);
   console.log(`✓ ${browserName}: initialize, parse, serialize, and remark`);
+}
+
+function canonicalProvenance(document) {
+  return {
+    frontmatter: document.frontmatter?.mdiProvenance ?? null,
+    children: document.children.map(canonicalNodeProvenance),
+  };
+}
+
+function canonicalNodeProvenance(node) {
+  return {
+    provenance: node.mdiProvenance ?? null,
+    children: (node.children ?? []).map(canonicalNodeProvenance),
+  };
 }
 
 async function listFiles(directory) {

--- a/python/tests/test_mdi.py
+++ b/python/tests/test_mdi.py
@@ -32,6 +32,16 @@ def assert_valid_spans(node: dict[str, Any], source: str) -> None:
         assert_valid_spans(child, source)
 
 
+def assert_key_absent(value: Any, forbidden: str) -> None:
+    if isinstance(value, dict):
+        assert forbidden not in value
+        for child in value.values():
+            assert_key_absent(child, forbidden)
+    elif isinstance(value, list):
+        for child in value:
+            assert_key_absent(child, forbidden)
+
+
 def test_exposes_the_complete_versioned_rust_document_contract() -> None:
     result = mdi.parse(SOURCE)
 
@@ -57,6 +67,18 @@ def test_exposes_the_complete_versioned_rust_document_contract() -> None:
     ]
     assert result["document"]["span"] == {"startByte": 0, "endByte": len(SOURCE.encode())}
     assert_valid_spans(result["document"], SOURCE)
+
+
+def test_general_parse_wire_json_never_exposes_mdast_provenance() -> None:
+    result = mdi.parse(
+        "---\ntitle: provenance isolation\n---\n\n"
+        "> - {東京|とうきょう} ^12^  \n"
+        ">   continuation\n\n"
+        "| image | empty |\n| - | - |\n| ![alt](cover.png) | ![](empty.png) |"
+    )
+
+    assert_key_absent(result, "mdiProvenance")
+    assert '"mdiProvenance"' not in json.dumps(result, ensure_ascii=False)
 
 
 def test_rust_owns_nested_syntax_decisions_and_literal_fallbacks() -> None:

--- a/swift/Tests/MDITests/MDITests.swift
+++ b/swift/Tests/MDITests/MDITests.swift
@@ -77,6 +77,25 @@ final class MDITests: XCTestCase {
         })
     }
 
+    func testGeneralParseWireTreeNeverExposesMdastProvenance() throws {
+        let source = """
+        ---
+        title: provenance isolation
+        ---
+
+        > - {東京|とうきょう} ^12^
+
+        | image | empty |
+        | - | - |
+        | ![alt](cover.png) | ![](empty.png) |
+        """
+        let result = try MDI.parse(source)
+
+        assertKeyAbsent("mdiProvenance", in: result.document)
+        let encoded = try JSONEncoder().encode(result)
+        XCTAssertFalse(String(decoding: encoded, as: UTF8.self).contains("\"mdiProvenance\""))
+    }
+
     func testRendersThroughRust() throws {
         let html = try MDI.renderHTML("{東京|とうきょう} ^12^")
         XCTAssertTrue(html.contains("<ruby class=\"mdi-ruby\">東京"))
@@ -346,6 +365,27 @@ final class MDITests: XCTestCase {
                     file: file,
                     line: line
                 )
+            }
+        case .null, .bool, .number, .string:
+            break
+        }
+    }
+
+    private func assertKeyAbsent(
+        _ forbidden: String,
+        in value: MDIJSONValue,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        switch value {
+        case let .array(values):
+            for child in values {
+                assertKeyAbsent(forbidden, in: child, file: file, line: line)
+            }
+        case let .object(object):
+            XCTAssertNil(object[forbidden], file: file, line: line)
+            for child in object.values {
+                assertKeyAbsent(forbidden, in: child, file: file, line: line)
             }
         case .null, .bool, .number, .string:
             break


### PR DESCRIPTION
## What changed

- isolate the mdast-only parser and provenance types under `@illusions-lab/mdi/internal/mdast`
- build a single prefix-max-end interval index and query it only for text-bearing nodes
- make container records structural-only with empty targets and Rust-owned source/synthetic status
- carry Rust-generated frontmatter provenance unchanged onto the remark YAML node
- compare the complete recursive provenance tree across Node, Chromium, Firefox, and WebKit
- add exact acceptance, candidate-scan complexity, release scaling, and cross-binding leakage tests
- record unrelated review findings in `CODE_HEALTH.md`

## Why

PR #78's initial implementation scanned every projection channel for every IR node, exposed an adapter transport through general JS APIs, assigned aggregate targets to containers, and omitted frontmatter from browser parity. This stacked change narrows the API boundary and makes provenance projection scale with indexed units and actual text-bearing matches.

`construct.path` remains parse-local transient identity and must not be persisted.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` (71 passed, 1 ignored)
- `cargo llvm-cov --locked` (97.07% line coverage)
- release 800/1600/3200 nested-list scaling gate (mdast: 21.8 / 45.0 / 96.2 ms)
- `pnpm typecheck`
- `pnpm build`
- `pnpm test:coverage`
- `pnpm test:browser` (Chromium + retry, Firefox, WebKit)
- Python coverage suite (26 passed, 100%)

Local Swift execution is blocked by the installed toolchain lacking XCTest; Android execution is blocked by the host having no Java runtime. The added binding contract tests compile in their normal CI environments. Publication artifact contracts additionally require the external `EPUBCHECK_JAR` fixture.

## Stack

Base: `agent/rust-mdast-provenance` (PR #78)
