### PR TITLE
Add automatic two-line warichu across renderers and bindings

### DIFF
--- a/SYNTAX.md
+++ b/SYNTAX.md
@@ -497,23 +497,13 @@ Warichu is an inline annotation set in two half-height lines within the line of 
 
 ### HTML Output / HTML 出力
 
-```html
-<span class="mdi-warichu">六曜の一つで吉日とされる</span>
-```
+Renderers may generate two-line fragments without changing the inline children
+or inserting `[[br]]` into the document. The Rust renderer uses presentation-only
+`.mdi-warichu-fragment` and `.mdi-warichu-line` spans at 50% body size.
+See [automatic layout decisions and current limitations](./WARICHU-LAYOUT.md).
 
-```css
-.mdi-warichu {
-  display: inline-block;
-  font-size: 0.5em;
-  line-height: 1.1;
-  max-inline-size: 10em;
-  vertical-align: middle;
-  text-align: start;
-}
-```
-
-CSS has no native warichu support; the inline-block approximation above wraps the note into two short lines. Renderers targeting formats with native warichu (e.g. InDesign, some EPUB readers) should map it directly.  
-CSS に割注のネイティブサポートはないため、上記の inline-block による近似で二行組を再現します。割注をネイティブに持つ出力先（InDesign 等）ではそちらへマップします。
+レンダラーは文書の内容や `[[br]]` を変更せず、表示用の二行組を生成できます。
+自動分割は保存される構文ではありません。既存の明示的な改行は保持されます。
 
 ---
 

--- a/WARICHU-LAYOUT.md
+++ b/WARICHU-LAYOUT.md
@@ -71,3 +71,16 @@ iframe ownership, resize source preservation, and repeated hard breaks.
 These are browser tests, not EPUB reading-system or native OS IME tests.
 The editor and complete release quality gates must still pass before the
 three-repository feature can be called complete.
+
+## Physical print page measurement
+
+Print hosts pass the Rust-resolved `prepared.page` to
+`settleMdiPrintLayout(evaluate, { page: prepared.page, timeoutMs, signal })`.
+The bridge constrains the temporary print body's inline extent to the printable
+paper area before reading geometry. It then measures rendered row advances and
+inherited text insets to refine the capacities supplied to Rust. Tracking and
+paragraph indentation are retained; no JavaScript splitting algorithm is added.
+This prevents screen-window dimensions from causing clipped notes or Chromium
+shrink-to-fit during printing. Long 720-character A5 notes are checked in both
+writing directions for complete PDF text and unchanged body/note glyph sizes.
+This does not promise exact proportional-font balance.

--- a/WARICHU-LAYOUT.md
+++ b/WARICHU-LAYOUT.md
@@ -1,0 +1,73 @@
+# Automatic warichu layout
+
+Status: Rust renderer and adaptive browser adapter implemented. Editor integration
+and cross-product release gates are tracked separately. Existing syntax and document IR are unchanged.
+
+## Decisions
+
+Source: [W3C JLREQ §3.4](https://www.w3.org/TR/jlreq/#inline_cutting_note).
+The renderer uses two lines with zero line gap. The 50% body size is this
+implementation's default, not a universal JLREQ requirement. Horizontal layout
+places the first line above the second; vertical-rl places it on the right.
+Authored parentheses remain authored text; none are added or removed.
+
+`layout_warichu(children, capacity)` operates on parsed inline IR and returns
+transient fragments. `layoutMdiWarichu` exposes the same calculation through
+Node/WASM. Capacity and returned widths use half-em units at the note's font size.
+ASCII and halfwidth kana graphemes count as one half-em; other graphemes count as
+two. Ruby readings and markup are excluded. Ruby, tcy, no-break, and unknown
+containers stay indivisible. Common inline formatting is carried across splits.
+Legal midpoint candidates are ranked by capacity, balance, then first-line length.
+A conservative Japanese punctuation/small-kana prohibition prevents illegal
+internal boundaries. Explicit `[[br]]` remains a hard boundary, including repeats.
+Oversized units are retained and diagnosed by `overflow` / `data-mdi-overflow`.
+
+HTML and EPUB use precomputed spans in source reading order. No script is needed.
+PDF waits for fonts and converged host-measured Rust layout before printing. Pure text and canonical MDI never receive automatic breaks.
+
+DOCX uses native `w:eastAsianLayout` with `w:combine="1"`, no added brackets, and
+one group ID per note across normal formatted runs. Word determines the split.
+See [Microsoft EastAsianLayout documentation](https://learn.microsoft.com/en-us/dotnet/api/documentformat.openxml.wordprocessing.eastasianlayout?view=openxml-3.0.1).
+This is not a claim of tested Microsoft Word rendering. Native ruby and tcy are kept in the note group; reader appearance still needs
+interoperability testing.
+
+## Limits and remaining integration
+
+Static no-script rendering uses 40 half-em units (20 note em) per line.
+The browser adapter measures remaining space and responds to resizing, fonts,
+zoom and writing mode. Indivisible contents can overflow narrow containers.
+External parentheses have headless Chromium, Firefox and WebKit geometry tests.
+Proportional font visual balance is not guaranteed by character estimates.
+Reader reflow may differ from the tested browsers.
+
+Milkdown editing, prepared-document/provenance/clipboard operations, Illusions
+entry points, and complete product release verification are separate gates.
+Do not interpret renderer tests as completion of the three-repository feature.
+
+## Verification
+
+- `cargo test --manifest-path mdi-core/Cargo.toml --test warichu_layout`
+- `pnpm --filter @illusions-lab/mdi exec vitest run src/warichu.test.ts`
+- `node nodejs/scripts/test-warichu-layout.mjs` (headless Chromium geometry)
+- Run the repository's full Rust, Node coverage, build, and publication contracts
+  before shipping. Do not lower coverage thresholds.
+
+Custom formatting and the future draft-preview window are tracked separately in
+[MDI #85](https://github.com/illusions-lab/MDI/issues/85); no private syntax or local
+metadata implements those settings.
+
+## Browser adapter implementation update
+
+The JavaScript package now exposes `attachMdiWarichuLayout` and a host-driven
+`settleMdiPrintLayout`. The adapter measures first-line remaining capacity and
+continuation capacity, asks Rust for source-mapped fragments, and writes only
+presentation spans. It observes font, resize, and style changes; local changes
+invalidate their containing paragraph. Static legacy mdast rendering now uses
+the same Rust splitter. Authored hard breaks are retained, including repeats.
+
+Packed consumers have been exercised headlessly in Chromium, Firefox, and
+WebKit for two-line horizontal/vertical geometry, multi-line wrapping,
+iframe ownership, resize source preservation, and repeated hard breaks.
+These are browser tests, not EPUB reading-system or native OS IME tests.
+The editor and complete release quality gates must still pass before the
+three-repository feature can be called complete.

--- a/android/CHANGELOG.md
+++ b/android/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 2.0.2
 
 - Add Rust-owned automatic warichu layout with first-fragment and continuation capacities.
 - Preserve graphemes across formatting boundaries, indivisible inline groups, authored hard breaks and source UTF-8 paths.

--- a/android/CHANGELOG.md
+++ b/android/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## Unreleased
+
+- Add Rust-owned automatic warichu layout with first-fragment and continuation capacities.
+- Preserve graphemes across formatting boundaries, indivisible inline groups, authored hard breaks and source UTF-8 paths.
+- Return portable per-line HTML and retain oversized content with an overflow signal.
+- Keep two lines at half body size, including nested notes, without changing syntax, document IR or canonical text.
+- Expose thin language APIs; static reader reflow and exact proportional-font balance remain outside the tested guarantees.

--- a/android/README.md
+++ b/android/README.md
@@ -58,3 +58,31 @@ val epub: ByteArray = Mdi.renderEpub("# Chapter")
 `MdiParseResult.document` is a tagged JSON object so the binding remains
 forward-compatible with new Rust node shapes. Check `irVersion` (the binding
 does this before returning from `parse`) rather than guessing schema meaning.
+
+## Automatic warichu presentation layout
+
+The Rust core supplies two lines at 50% body size with no line gap. Capacity is
+measured in half-em units at the note font size; it is a character-width estimate,
+not exact proportional-font measurement. The first fragment can use the space
+remaining on the current body line; following fragments use the full capacity.
+
+```kotlin
+val fragments = Mdi.layoutWarichuJson(
+    """[{"type":"text","value":"一二三四五六"}]""", capacity = 4, firstCapacity = 2)
+```
+
+Results contain `lines`, `html`, `widths`, `overflow`, `hardBreakAfter`, and
+`sources`. Each source has a child-index `path` relative to the input inline array,
+half-open `startUtf8` / `endUtf8` offsets into that leaf's visible text, and an
+indivisible `group` ID. A cluster crossing formatting boundaries shares a group.
+Ruby, tcy, no-break and unknown containers remain whole; their coordinates use
+projected visible text (ruby base, excluding its reading). Oversized groups remain
+available and report overflow. Author hard breaks are retained; automatic splits
+never enter canonical MDI or plain text.
+
+The C ABI provides `mdi_layout_warichu_json`, taking inline-array JSON and options
+JSON (`firstCapacity`, `continuationCapacity`) and returning the same JSON through
+`mdi_ffi_result`. Release both returned buffers with `mdi_free_buffer`.
+Static HTML/EPUB includes readable precomputed lines; reader reflow can differ.
+DOCX uses native Word combination groups; XML verification is not a Word rendering
+test. Custom sizes, line counts and manual splitting remain tracked in MDI #85.

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,3 +1,3 @@
 android.useAndroidX=true
 kotlin.code.style=official
-VERSION_NAME=2.0.1
+VERSION_NAME=2.0.2

--- a/android/mdi-android/src/androidTest/kotlin/app/illusions/mdi/MdiInstrumentedTest.kt
+++ b/android/mdi-android/src/androidTest/kotlin/app/illusions/mdi/MdiInstrumentedTest.kt
@@ -13,6 +13,14 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class MdiInstrumentedTest {
     @Test
+    fun native_warichu_layout_preserves_utf8_positions_and_two_lines() {
+        val result = Mdi.layoutWarichuJson("""[{"type":"text","value":"一二三四五六"}]""", 4, 2)
+        assertTrue(result.contains("\"html\":[\"一\",\"二\"]"))
+        assertTrue(result.contains("\"startUtf8\":6"))
+        assertTrue(result.contains("\"html\":[\"三四\",\"五六\"]"))
+    }
+
+    @Test
     fun native_library_parses_unicode_and_preserves_utf8_byte_spans() {
         val source = "第^12^話"
         val result = Mdi.parse(source)

--- a/android/mdi-android/src/main/kotlin/app/illusions/mdi/Mdi.kt
+++ b/android/mdi-android/src/main/kotlin/app/illusions/mdi/Mdi.kt
@@ -13,6 +13,13 @@ public const val MDI_IR_VERSION: String = "1.0"
 
 /** Complete Android interface to the Rust-authoritative MDI implementation. */
 public object Mdi {
+    /** Rust layout of parsed inline children; capacities use note half-em units. */
+    @JvmStatic public fun layoutWarichuJson(childrenJson: String, capacity: Int = 40, firstCapacity: Int = capacity): String {
+        require(capacity >= 0 && firstCapacity >= 0) { "Warichu capacities must be non-negative" }
+        return MdiBridgeHolder.bridge.layoutWarichuJson(childrenJson,
+            "{\"firstCapacity\":$firstCapacity,\"continuationCapacity\":$capacity}")
+    }
+
     /** Parses complete MDI source; Kotlin does not tokenize or repair syntax. */
     @JvmStatic
     public fun parse(source: String): MdiParseResult {
@@ -92,6 +99,7 @@ internal object MdiJson {
 
 /** Host boundary kept separate so unit tests can cover the public API without JNI. */
 internal interface MdiBridge {
+    fun layoutWarichuJson(nodes: String, options: String): String
     fun parseJson(source: String): String
     fun renderHtml(source: String): String
     fun serializeMdi(source: String): String
@@ -102,6 +110,7 @@ internal interface MdiBridge {
 }
 
 internal object NativeMdiBridge : MdiBridge {
+    override fun layoutWarichuJson(nodes: String, options: String): String = MdiNative.layoutWarichuJson(nodes, options)
     override fun parseJson(source: String): String = MdiNative.parseJson(source)
     override fun renderHtml(source: String): String = MdiNative.renderHtml(source)
     override fun serializeMdi(source: String): String = MdiNative.serializeMdi(source)

--- a/android/mdi-android/src/main/kotlin/app/illusions/mdi/internal/MdiNative.kt
+++ b/android/mdi-android/src/main/kotlin/app/illusions/mdi/internal/MdiNative.kt
@@ -6,6 +6,7 @@ internal object MdiNative {
         System.loadLibrary("mdi_android")
     }
 
+    external fun layoutWarichuJson(nodes: String, options: String): String
     external fun parseJson(source: String): String
     external fun renderHtml(source: String): String
     external fun serializeMdi(source: String): String

--- a/android/mdi-android/src/test/kotlin/app/illusions/mdi/MdiJsonTest.kt
+++ b/android/mdi-android/src/test/kotlin/app/illusions/mdi/MdiJsonTest.kt
@@ -111,7 +111,16 @@ class MdiJsonTest {
         assertNotNull(MdiSourceSpan.serializer())
     }
 
+    @Test
+    fun warichu_options_forward_to_rust_and_reject_negative_capacity() {
+        assertEquals("{\"firstCapacity\":2,\"continuationCapacity\":4}", Mdi.layoutWarichuJson("[]", 4, 2))
+        assertEquals("{\"firstCapacity\":40,\"continuationCapacity\":40}", Mdi.layoutWarichuJson("[]"))
+        assertFailsWith<IllegalArgumentException> { Mdi.layoutWarichuJson("[]", -1) }
+        assertFailsWith<IllegalArgumentException> { Mdi.layoutWarichuJson("[]", 1, -1) }
+    }
+
     private class FakeBridge : MdiBridge {
+        override fun layoutWarichuJson(nodes: String, options: String): String = options
         val calls = mutableListOf<String>()
         var parseJson: String = validParseJson
 

--- a/docs/src/content/docs/bindings/android.md
+++ b/docs/src/content/docs/bindings/android.md
@@ -33,3 +33,14 @@ val html = Mdi.renderHtml("# 題\n\n{東京|とうきょう}")
 See [`android/README.md`](https://github.com/illusions-lab/MDI/blob/main/android/README.md)
 for local Rust target setup, native-library generation, and the acceptance
 command.
+
+## Automatic warichu layout
+
+Rust is the only splitting implementation. Layout uses two lines at half the body font size with zero line gap. The first fragment can use remaining body-line capacity; later fragments use full capacity. Capacity and widths are half-em units at note size, using character-width estimates rather than exact proportional-font balancing.
+
+```kotlin
+val fragments = Mdi.layoutWarichuJson(
+    """[{"type":"text","value":"一二三四五六"}]""", capacity = 4, firstCapacity = 2)
+```
+
+Results include `lines`, `html`, `widths`, `overflow`, `hardBreakAfter` and `sources`. Source paths are child indices relative to the input array; `startUtf8` and `endUtf8` are half-open byte offsets in visible leaf text. Indivisible `group` IDs keep clusters across formatting boundaries together. Ruby, tcy and no-break stay whole. Hard breaks are retained; automatic splits do not change canonical MDI or plain text. Static HTML/EPUB readers may reflow differently. DOCX uses native combination groups; XML and importer checks are not a claim of Microsoft Word rendering tests.

--- a/docs/src/content/docs/bindings/javascript.md
+++ b/docs/src/content/docs/bindings/javascript.md
@@ -175,3 +175,8 @@ Install `@illusions-lab/mdi-to-pdf` alongside `@illusions-lab/mdi` for the defau
 `renderText`, `renderTextFormat`, and `serializeMdi` are synchronous Rust functions. `renderTextFormat` accepts `txt`, `txt-ruby`, `narou`, `kakuyomu`, `aozora`, or `note` plus an optional indentation prefix. `parseMdiSyntax` is a deprecated alias for `parse`; `MDI_SPEC_VERSION` is `"2.0"` and `MDI_IR_VERSION` is `"1.0"`.
 
 Non-string source is a `TypeError`; invalid option objects are also rejected with `TypeError`. Treat diagnostics as document feedback, and reserve `try`/`catch` for programming, I/O, archive, or host-renderer failures. Source spans are UTF-8 **byte** offsets, not JavaScript string indices; see [Diagnostics](/core/diagnostics/).
+
+
+### Automatic warichu layout
+
+Automatic warichu uses two lines at 50% type. Use `layoutMdiWarichu(children, { firstCapacity, continuationCapacity })` for Rust splitting, `attachMdiWarichuLayout(container)` for read-only HTML, and `settleMdiPrintLayout(evaluate, { timeoutMs, signal })` before printing. Layout is presentation-only; canonical MDI is unchanged. Static EPUB/HTML preserve readable precomputed lines; reader reflow may vary.

--- a/docs/src/content/docs/bindings/javascript.md
+++ b/docs/src/content/docs/bindings/javascript.md
@@ -179,4 +179,4 @@ Non-string source is a `TypeError`; invalid option objects are also rejected wit
 
 ### Automatic warichu layout
 
-Automatic warichu uses two lines at 50% type. Use `layoutMdiWarichu(children, { firstCapacity, continuationCapacity })` for Rust splitting, `attachMdiWarichuLayout(container)` for read-only HTML, and `settleMdiPrintLayout(evaluate, { timeoutMs, signal })` before printing. Layout is presentation-only; canonical MDI is unchanged. Static EPUB/HTML preserve readable precomputed lines; reader reflow may vary.
+Automatic warichu uses two lines at 50% type. Use `layoutMdiWarichu(children, { firstCapacity, continuationCapacity })` for Rust splitting, `attachMdiWarichuLayout(container)` for read-only HTML, and `settleMdiPrintLayout(evaluate, { timeoutMs, signal, page: prepared.page })` before printing. Layout is presentation-only; canonical MDI is unchanged. Static EPUB/HTML preserve readable precomputed lines; reader reflow may vary.

--- a/docs/src/content/docs/bindings/python.md
+++ b/docs/src/content/docs/bindings/python.md
@@ -119,3 +119,14 @@ Everything listed above is real, published, and tested — the package's own tes
 - [Rust Core API status](/core/rust-api/) — the exact Rust functions this package wraps.
 - [Document IR](/core/document-ir/) — the node catalogue for the dictionaries `mdi.parse()` returns.
 - [Bindings: CLI](/bindings/cli/) — the same functions, from the command line, including PDF.
+
+## Automatic warichu layout
+
+Rust is the only splitting implementation. Layout uses two lines at half the body font size with zero line gap. The first fragment can use remaining body-line capacity; later fragments use full capacity. Capacity and widths are half-em units at note size, using character-width estimates rather than exact proportional-font balancing.
+
+```python
+from mdi import layout_warichu
+fragments = layout_warichu([{"type": "text", "value": "一二三四五六"}], 4, first_capacity=2)
+```
+
+Results include `lines`, `html`, `widths`, `overflow`, `hardBreakAfter` and `sources`. Source paths are child indices relative to the input array; `startUtf8` and `endUtf8` are half-open byte offsets in visible leaf text. Indivisible `group` IDs keep clusters across formatting boundaries together. Ruby, tcy and no-break stay whole. Hard breaks are retained; automatic splits do not change canonical MDI or plain text. Static HTML/EPUB readers may reflow differently. DOCX uses native combination groups; XML and importer checks are not a claim of Microsoft Word rendering tests.

--- a/docs/src/content/docs/bindings/rust.md
+++ b/docs/src/content/docs/bindings/rust.md
@@ -89,3 +89,15 @@ Parsing (`parse_document`/`parse_output`), serialization (`serialize_mdi`), and 
 - [Rust Core API status](/core/rust-api/) — every function, in full.
 - [API reference on docs.rs](https://docs.rs/mdi-core/).
 - [Rendering model](/core/rendering/) — what each renderer's output actually contains, including the Chromium/PDF boundary.
+
+## Automatic warichu layout
+
+Rust is the only splitting implementation. Layout uses two lines at half the body font size with zero line gap. The first fragment can use remaining body-line capacity; later fragments use full capacity. Capacity and widths are half-em units at note size, using character-width estimates rather than exact proportional-font balancing.
+
+```rust
+let children = serde_json::json!([{"type":"text", "value":"一二三四五六"}]);
+let fragments = mdi_core::layout_warichu_with_options(children.as_array().unwrap(),
+    &mdi_core::WarichuOptions { first_capacity: 2, continuation_capacity: 4 });
+```
+
+Results include `lines`, `html`, `widths`, `overflow`, `hardBreakAfter` and `sources`. Source paths are child indices relative to the input array; `startUtf8` and `endUtf8` are half-open byte offsets in visible leaf text. Indivisible `group` IDs keep clusters across formatting boundaries together. Ruby, tcy and no-break stay whole. Hard breaks are retained; automatic splits do not change canonical MDI or plain text. Static HTML/EPUB readers may reflow differently. DOCX uses native combination groups; XML and importer checks are not a claim of Microsoft Word rendering tests.

--- a/docs/src/content/docs/bindings/swift.md
+++ b/docs/src/content/docs/bindings/swift.md
@@ -94,3 +94,15 @@ builds an XCFramework, runs XCTest with a 95% line-coverage gate for
 creates a manifest pull request and publishes the approved artifact after that
 PR is merged. It uses GitHub Actions' built-in token; no PAT or second
 repository is required.
+
+## Automatic warichu layout
+
+Rust is the only splitting implementation. Layout uses two lines at half the body font size with zero line gap. The first fragment can use remaining body-line capacity; later fragments use full capacity. Capacity and widths are half-em units at note size, using character-width estimates rather than exact proportional-font balancing.
+
+```swift
+let fragments = try MDI.layoutWarichu(
+    [.object(["type": .string("text"), "value": .string("一二三四五六")])],
+    capacity: 4, firstCapacity: 2)
+```
+
+Results include `lines`, `html`, `widths`, `overflow`, `hardBreakAfter` and `sources`. Source paths are child indices relative to the input array; `startUtf8` and `endUtf8` are half-open byte offsets in visible leaf text. Indivisible `group` IDs keep clusters across formatting boundaries together. Ruby, tcy and no-break stay whole. Hard breaks are retained; automatic splits do not change canonical MDI or plain text. Static HTML/EPUB readers may reflow differently. DOCX uses native combination groups; XML and importer checks are not a claim of Microsoft Word rendering tests.

--- a/docs/src/content/docs/ja/bindings/android.md
+++ b/docs/src/content/docs/ja/bindings/android.md
@@ -20,3 +20,14 @@ val html = Mdi.renderHtml("# 題\n\n{東京|とうきょう}")
 ```
 
 ローカルの Rust target の準備、native library の生成、acceptance command は [`android/README.md`](https://github.com/illusions-lab/MDI/blob/main/android/README.md) を参照してください。
+
+## 割注の自動組版
+
+分割規則は Rust が一元管理します。本文の50%の字級、固定2行、行間なしで表示します。先頭の断片には本文行の残り幅、後続には行全体の幅を指定できます。幅の単位は割注字級の半角emです。文字幅の推定であり、比例フォントの厳密な均衡は保証しません。
+
+```kotlin
+val fragments = Mdi.layoutWarichuJson(
+    """[{"type":"text","value":"一二三四五六"}]""", capacity = 4, firstCapacity = 2)
+```
+
+戻り値は `lines`、`html`、`widths`、`overflow`、`hardBreakAfter`、`sources` を含みます。`path` は入力配列からの子インデックス列、`startUtf8` / `endUtf8` は可視文字列内の半開UTF-8バイト範囲です。同一の `group` は書式境界をまたぐ書記素も分割しません。ルビ、縦中横、改行禁止は一体として扱います。明示改行を保ち、自動分割は正規MDIや平文に書き戻しません。静的HTML/EPUBは閲覧ソフトにより再配置が異なります。DOCXはネイティブの双行グループを使います。XMLやインポーターの検証をWordの描画実測とは記載しません。

--- a/docs/src/content/docs/ja/bindings/javascript.md
+++ b/docs/src/content/docs/ja/bindings/javascript.md
@@ -147,4 +147,4 @@ Node の default PDF host には別途 `npm install @illusions-lab/mdi-to-pdf` �
 
 ### Automatic warichu layout
 
-自動割注は本文の50%の文字サイズで2行に配置します。`layoutMdiWarichu(children, { firstCapacity, continuationCapacity })` がRustの分割処理を呼び出します。閲覧用HTMLには `attachMdiWarichuLayout(container)`、印刷前には `settleMdiPrintLayout(evaluate, { timeoutMs, signal })` を使用します。自動分割は表示のみで、保存するMDIは変わりません。スクリプトなしのHTML・EPUBも2行構造を保持しますが、リーダーによる再配置は異なる場合があります。
+自動割注は本文の50%の文字サイズで2行に配置します。`layoutMdiWarichu(children, { firstCapacity, continuationCapacity })` がRustの分割処理を呼び出します。閲覧用HTMLには `attachMdiWarichuLayout(container)`、印刷前には `settleMdiPrintLayout(evaluate, { timeoutMs, signal, page: prepared.page })` を使用します。自動分割は表示のみで、保存するMDIは変わりません。スクリプトなしのHTML・EPUBも2行構造を保持しますが、リーダーによる再配置は異なる場合があります。

--- a/docs/src/content/docs/ja/bindings/javascript.md
+++ b/docs/src/content/docs/ja/bindings/javascript.md
@@ -143,3 +143,8 @@ const pdf = await renderPdfWithChromium(source, profile);
 Node の default PDF host には別途 `npm install @illusions-lab/mdi-to-pdf` が必要です。Electron は `{ renderHtmlToPdf(html, profile, sourceWritingMode) }` を渡せます。PDF の paper、landscape、margin、縦横、font、font size/line spacing、文字数/行数、indent、page number は Rust が解決します。browser/WASM でも設定付き EPUB/DOCX は生成できます。Chromium を起動する PDF だけは `preparePdfExport()` を Node/Electron/Tauri/CLI host に送ります。
 
 非 string source と不正 option は `TypeError` です。diagnostic は document feedback として扱い、I/O/archive/host renderer の failure だけを `try`/`catch` してください。span は JavaScript index ではなく UTF-8 **byte** offset です。
+
+
+### Automatic warichu layout
+
+自動割注は本文の50%の文字サイズで2行に配置します。`layoutMdiWarichu(children, { firstCapacity, continuationCapacity })` がRustの分割処理を呼び出します。閲覧用HTMLには `attachMdiWarichuLayout(container)`、印刷前には `settleMdiPrintLayout(evaluate, { timeoutMs, signal })` を使用します。自動分割は表示のみで、保存するMDIは変わりません。スクリプトなしのHTML・EPUBも2行構造を保持しますが、リーダーによる再配置は異なる場合があります。

--- a/docs/src/content/docs/ja/bindings/python.md
+++ b/docs/src/content/docs/ja/bindings/python.md
@@ -79,3 +79,14 @@ Python binding は **実装済み・公開済み・テスト済み** です。te
 
 - [Rust Core API](/ja/core/rust-api/)
 - [出力形式](/ja/ecosystem/outputs/)
+
+## 割注の自動組版
+
+分割規則は Rust が一元管理します。本文の50%の字級、固定2行、行間なしで表示します。先頭の断片には本文行の残り幅、後続には行全体の幅を指定できます。幅の単位は割注字級の半角emです。文字幅の推定であり、比例フォントの厳密な均衡は保証しません。
+
+```python
+from mdi import layout_warichu
+fragments = layout_warichu([{"type": "text", "value": "一二三四五六"}], 4, first_capacity=2)
+```
+
+戻り値は `lines`、`html`、`widths`、`overflow`、`hardBreakAfter`、`sources` を含みます。`path` は入力配列からの子インデックス列、`startUtf8` / `endUtf8` は可視文字列内の半開UTF-8バイト範囲です。同一の `group` は書式境界をまたぐ書記素も分割しません。ルビ、縦中横、改行禁止は一体として扱います。明示改行を保ち、自動分割は正規MDIや平文に書き戻しません。静的HTML/EPUBは閲覧ソフトにより再配置が異なります。DOCXはネイティブの双行グループを使います。XMLやインポーターの検証をWordの描画実測とは記載しません。

--- a/docs/src/content/docs/ja/bindings/rust.md
+++ b/docs/src/content/docs/ja/bindings/rust.md
@@ -73,3 +73,15 @@ parse、`serialize_mdi`、HTML/TXT/EPUB/DOCX/PDF renderer はすべて実装済�
 
 - [docs.rs API reference](https://docs.rs/mdi-core/)
 - [レンダリングモデル](/ja/core/rendering/)
+
+## 割注の自動組版
+
+分割規則は Rust が一元管理します。本文の50%の字級、固定2行、行間なしで表示します。先頭の断片には本文行の残り幅、後続には行全体の幅を指定できます。幅の単位は割注字級の半角emです。文字幅の推定であり、比例フォントの厳密な均衡は保証しません。
+
+```rust
+let children = serde_json::json!([{"type":"text", "value":"一二三四五六"}]);
+let fragments = mdi_core::layout_warichu_with_options(children.as_array().unwrap(),
+    &mdi_core::WarichuOptions { first_capacity: 2, continuation_capacity: 4 });
+```
+
+戻り値は `lines`、`html`、`widths`、`overflow`、`hardBreakAfter`、`sources` を含みます。`path` は入力配列からの子インデックス列、`startUtf8` / `endUtf8` は可視文字列内の半開UTF-8バイト範囲です。同一の `group` は書式境界をまたぐ書記素も分割しません。ルビ、縦中横、改行禁止は一体として扱います。明示改行を保ち、自動分割は正規MDIや平文に書き戻しません。静的HTML/EPUBは閲覧ソフトにより再配置が異なります。DOCXはネイティブの双行グループを使います。XMLやインポーターの検証をWordの描画実測とは記載しません。

--- a/docs/src/content/docs/ja/bindings/swift.md
+++ b/docs/src/content/docs/ja/bindings/swift.md
@@ -71,3 +71,15 @@ do {
 ## 開発とリリース
 
 リポジトリの `swift/Package.swift` はローカル開発用パッケージです。CI は XCFramework をビルドし、XCTest を実行して `swift/Sources/MDI` に 95% の line-coverage gate を適用し、レポートを Codecov に送信します。release workflow は manifest 用の pull request を作成し、その PR がマージされた後に承認済み artifact を公開します。GitHub Actions 組み込みの token を使うため、PAT や別リポジトリは不要です。
+
+## 割注の自動組版
+
+分割規則は Rust が一元管理します。本文の50%の字級、固定2行、行間なしで表示します。先頭の断片には本文行の残り幅、後続には行全体の幅を指定できます。幅の単位は割注字級の半角emです。文字幅の推定であり、比例フォントの厳密な均衡は保証しません。
+
+```swift
+let fragments = try MDI.layoutWarichu(
+    [.object(["type": .string("text"), "value": .string("一二三四五六")])],
+    capacity: 4, firstCapacity: 2)
+```
+
+戻り値は `lines`、`html`、`widths`、`overflow`、`hardBreakAfter`、`sources` を含みます。`path` は入力配列からの子インデックス列、`startUtf8` / `endUtf8` は可視文字列内の半開UTF-8バイト範囲です。同一の `group` は書式境界をまたぐ書記素も分割しません。ルビ、縦中横、改行禁止は一体として扱います。明示改行を保ち、自動分割は正規MDIや平文に書き戻しません。静的HTML/EPUBは閲覧ソフトにより再配置が異なります。DOCXはネイティブの双行グループを使います。XMLやインポーターの検証をWordの描画実測とは記載しません。

--- a/docs/src/content/docs/zh-tw/bindings/android.md
+++ b/docs/src/content/docs/zh-tw/bindings/android.md
@@ -20,3 +20,14 @@ val html = Mdi.renderHtml("# 題\n\n{東京|とうきょう}")
 ```
 
 本機 Rust target 設定、native library 產生與驗收命令，請見 [`android/README.md`](https://github.com/illusions-lab/MDI/blob/main/android/README.md)。
+
+## 自動割注排版
+
+分割規則由 Rust 統一實作。固定兩行、正文50%字級、零小行間距。首個片段可使用正文行剩餘容量，後續片段使用完整行容量。容量與回傳寬度以割注字級的半個em為單位；這是字寬估算，不保證比例字型的精確均衡。
+
+```kotlin
+val fragments = Mdi.layoutWarichuJson(
+    """[{"type":"text","value":"一二三四五六"}]""", capacity = 4, firstCapacity = 2)
+```
+
+結果包含 `lines`、`html`、`widths`、`overflow`、`hardBreakAfter` 與 `sources`。`path` 是從輸入陣列起算的子節點索引路徑；`startUtf8` / `endUtf8` 是可見文字中的半開UTF-8位元組範圍。相同 `group` 保留跨格式邊界的書寫素。Ruby、縱中橫及no-break保持不可拆。作者硬換行保留，自動分割不寫回canonical MDI或純文字。靜態HTML/EPUB的閱讀器重排結果可能不同。DOCX使用原生雙行群組；XML與匯入器檢查不代表Word實測。

--- a/docs/src/content/docs/zh-tw/bindings/javascript.md
+++ b/docs/src/content/docs/zh-tw/bindings/javascript.md
@@ -142,4 +142,4 @@ Node 的 default PDF host 要另外 `npm install @illusions-lab/mdi-to-pdf`。El
 
 ### Automatic warichu layout
 
-自動割注使用正文50%字級與固定兩行。`layoutMdiWarichu(children, { firstCapacity, continuationCapacity })` 呼叫Rust分割規則；唯讀HTML使用 `attachMdiWarichuLayout(container)`，列印前使用 `settleMdiPrintLayout(evaluate, { timeoutMs, signal })`。自動分割只影響呈現，不改寫MDI。無腳本HTML與EPUB保留雙行結構，但閱讀器重排可能不同。
+自動割注使用正文50%字級與固定兩行。`layoutMdiWarichu(children, { firstCapacity, continuationCapacity })` 呼叫Rust分割規則；唯讀HTML使用 `attachMdiWarichuLayout(container)`，列印前使用 `settleMdiPrintLayout(evaluate, { timeoutMs, signal, page: prepared.page })`。自動分割只影響呈現，不改寫MDI。無腳本HTML與EPUB保留雙行結構，但閱讀器重排可能不同。

--- a/docs/src/content/docs/zh-tw/bindings/javascript.md
+++ b/docs/src/content/docs/zh-tw/bindings/javascript.md
@@ -138,3 +138,8 @@ const pdf = await renderPdfWithChromium(source, profile);
 Node 的 default PDF host 要另外 `npm install @illusions-lab/mdi-to-pdf`。Electron 可傳入 `{ renderHtmlToPdf(html, profile, sourceWritingMode) }`。PDF 的紙張、橫向、邊距、直/橫排、font、font size/line spacing、每行字數/每頁行數、indent、page number 都由 Rust 解決。browser/WASM 可在本機生成設定型 EPUB/DOCX；只有 PDF 因無法啟動 Chromium，需要把 `preparePdfExport()` 交給 Node/Electron/Tauri/CLI host。
 
 非字串 source 與無效 option 都是 `TypeError`。diagnostic 應作為 document feedback；只有 I/O/archive/host renderer failure 才適合 `try`/`catch`。span 是 UTF-8 **byte** offset，不是 JavaScript string index。
+
+
+### Automatic warichu layout
+
+自動割注使用正文50%字級與固定兩行。`layoutMdiWarichu(children, { firstCapacity, continuationCapacity })` 呼叫Rust分割規則；唯讀HTML使用 `attachMdiWarichuLayout(container)`，列印前使用 `settleMdiPrintLayout(evaluate, { timeoutMs, signal })`。自動分割只影響呈現，不改寫MDI。無腳本HTML與EPUB保留雙行結構，但閱讀器重排可能不同。

--- a/docs/src/content/docs/zh-tw/bindings/python.md
+++ b/docs/src/content/docs/zh-tw/bindings/python.md
@@ -97,3 +97,14 @@ def byte_span_to_str_index(source: str, byte_offset: int) -> int:
 - [Rust Core API](/zh-tw/core/rust-api/)
 - [Document IR](/zh-tw/core/document-ir/)
 - [CLI](/zh-tw/bindings/cli/)
+
+## 自動割注排版
+
+分割規則由 Rust 統一實作。固定兩行、正文50%字級、零小行間距。首個片段可使用正文行剩餘容量，後續片段使用完整行容量。容量與回傳寬度以割注字級的半個em為單位；這是字寬估算，不保證比例字型的精確均衡。
+
+```python
+from mdi import layout_warichu
+fragments = layout_warichu([{"type": "text", "value": "一二三四五六"}], 4, first_capacity=2)
+```
+
+結果包含 `lines`、`html`、`widths`、`overflow`、`hardBreakAfter` 與 `sources`。`path` 是從輸入陣列起算的子節點索引路徑；`startUtf8` / `endUtf8` 是可見文字中的半開UTF-8位元組範圍。相同 `group` 保留跨格式邊界的書寫素。Ruby、縱中橫及no-break保持不可拆。作者硬換行保留，自動分割不寫回canonical MDI或純文字。靜態HTML/EPUB的閱讀器重排結果可能不同。DOCX使用原生雙行群組；XML與匯入器檢查不代表Word實測。

--- a/docs/src/content/docs/zh-tw/bindings/rust.md
+++ b/docs/src/content/docs/zh-tw/bindings/rust.md
@@ -73,3 +73,15 @@ Parsing、`serialize_mdi` 及所有 renderer（`render_html`、`render_text_form
 - [Rust Core API](/zh-tw/core/rust-api/)
 - [docs.rs API reference](https://docs.rs/mdi-core/)
 - [轉譯模型](/zh-tw/core/rendering/)
+
+## 自動割注排版
+
+分割規則由 Rust 統一實作。固定兩行、正文50%字級、零小行間距。首個片段可使用正文行剩餘容量，後續片段使用完整行容量。容量與回傳寬度以割注字級的半個em為單位；這是字寬估算，不保證比例字型的精確均衡。
+
+```rust
+let children = serde_json::json!([{"type":"text", "value":"一二三四五六"}]);
+let fragments = mdi_core::layout_warichu_with_options(children.as_array().unwrap(),
+    &mdi_core::WarichuOptions { first_capacity: 2, continuation_capacity: 4 });
+```
+
+結果包含 `lines`、`html`、`widths`、`overflow`、`hardBreakAfter` 與 `sources`。`path` 是從輸入陣列起算的子節點索引路徑；`startUtf8` / `endUtf8` 是可見文字中的半開UTF-8位元組範圍。相同 `group` 保留跨格式邊界的書寫素。Ruby、縱中橫及no-break保持不可拆。作者硬換行保留，自動分割不寫回canonical MDI或純文字。靜態HTML/EPUB的閱讀器重排結果可能不同。DOCX使用原生雙行群組；XML與匯入器檢查不代表Word實測。

--- a/docs/src/content/docs/zh-tw/bindings/swift.md
+++ b/docs/src/content/docs/zh-tw/bindings/swift.md
@@ -71,3 +71,15 @@ do {
 ## 開發與發布
 
 repository 的 `swift/Package.swift` 是本機開發用 package。CI 會建置 XCFramework、跑 XCTest，並對 `swift/Sources/MDI` 強制 95% line coverage、上傳 Codecov。release workflow 會建立 manifest pull request；該 PR 合併後才發布核准的 artifact。它使用 GitHub Actions 內建 token，不需要 PAT 或第二個 repository。
+
+## 自動割注排版
+
+分割規則由 Rust 統一實作。固定兩行、正文50%字級、零小行間距。首個片段可使用正文行剩餘容量，後續片段使用完整行容量。容量與回傳寬度以割注字級的半個em為單位；這是字寬估算，不保證比例字型的精確均衡。
+
+```swift
+let fragments = try MDI.layoutWarichu(
+    [.object(["type": .string("text"), "value": .string("一二三四五六")])],
+    capacity: 4, firstCapacity: 2)
+```
+
+結果包含 `lines`、`html`、`widths`、`overflow`、`hardBreakAfter` 與 `sources`。`path` 是從輸入陣列起算的子節點索引路徑；`startUtf8` / `endUtf8` 是可見文字中的半開UTF-8位元組範圍。相同 `group` 保留跨格式邊界的書寫素。Ruby、縱中橫及no-break保持不可拆。作者硬換行保留，自動分割不寫回canonical MDI或純文字。靜態HTML/EPUB的閱讀器重排結果可能不同。DOCX使用原生雙行群組；XML與匯入器檢查不代表Word實測。

--- a/mdi-android-jni/Cargo.lock
+++ b/mdi-android-jni/Cargo.lock
@@ -197,7 +197,7 @@ dependencies = [
 
 [[package]]
 name = "mdi-android-jni"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "jni",
  "mdi-core",
@@ -205,7 +205,7 @@ dependencies = [
 
 [[package]]
 name = "mdi-core"
-version = "2.0.6"
+version = "2.0.7"
 dependencies = [
  "markdown",
  "serde",

--- a/mdi-android-jni/Cargo.lock
+++ b/mdi-android-jni/Cargo.lock
@@ -205,7 +205,7 @@ dependencies = [
 
 [[package]]
 name = "mdi-core"
-version = "2.0.5"
+version = "2.0.6"
 dependencies = [
  "markdown",
  "serde",

--- a/mdi-android-jni/Cargo.toml
+++ b/mdi-android-jni/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mdi-android-jni"
-version = "2.0.1"
+version = "2.0.2"
 description = "Android JNI boundary for mdi-core"
 edition = "2024"
 license = "MIT"

--- a/mdi-android-jni/src/lib.rs
+++ b/mdi-android-jni/src/lib.rs
@@ -145,6 +145,20 @@ pub extern "system" fn Java_app_illusions_mdi_internal_MdiNative_renderDocx(
     into_byte_array(&mut env, result)
 }
 
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_app_illusions_mdi_internal_MdiNative_layoutWarichuJson(
+    mut env: JNIEnv<'_>,
+    _class: JObject<'_>,
+    nodes: JString<'_>,
+    options: JString<'_>,
+) -> jstring {
+    let result = read_source(&mut env, nodes).and_then(|nodes| {
+        read_source(&mut env, options)
+            .and_then(|options| mdi_core::layout_warichu_options_json(&nodes, &options))
+    });
+    into_jstring(&mut env, result)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/mdi-core/CHANGELOG.md
+++ b/mdi-core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 2.0.7
 
 - Add Rust-owned automatic warichu layout with first-fragment and continuation capacities.
 - Preserve graphemes across formatting boundaries, indivisible inline groups, authored hard breaks and source UTF-8 paths.

--- a/mdi-core/CHANGELOG.md
+++ b/mdi-core/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## Unreleased
+
+- Add Rust-owned automatic warichu layout with first-fragment and continuation capacities.
+- Preserve graphemes across formatting boundaries, indivisible inline groups, authored hard breaks and source UTF-8 paths.
+- Return portable per-line HTML and retain oversized content with an overflow signal.
+- Keep two lines at half body size, including nested notes, without changing syntax, document IR or canonical text.
+- Expose thin language APIs; static reader reflow and exact proportional-font balance remain outside the tested guarantees.

--- a/mdi-core/Cargo.lock
+++ b/mdi-core/Cargo.lock
@@ -250,7 +250,7 @@ dependencies = [
 
 [[package]]
 name = "mdi-core"
-version = "2.0.6"
+version = "2.0.7"
 dependencies = [
  "js-sys",
  "markdown",

--- a/mdi-core/Cargo.toml
+++ b/mdi-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mdi-core"
-version = "2.0.6"
+version = "2.0.7"
 description = "Language-neutral parser for MDI 2.0 syntax"
 edition = "2024"
 rust-version = "1.85"

--- a/mdi-core/README.md
+++ b/mdi-core/README.md
@@ -58,3 +58,33 @@ dimension table.
 ## License
 
 MIT. See [LICENSE](https://github.com/illusions-lab/MDI/blob/main/LICENSE).
+
+## Automatic warichu presentation layout
+
+The Rust core supplies two lines at 50% body size with no line gap. Capacity is
+measured in half-em units at the note font size; it is a character-width estimate,
+not exact proportional-font measurement. The first fragment can use the space
+remaining on the current body line; following fragments use the full capacity.
+
+```rust
+let nodes = serde_json::json!([{"type":"text", "value":"一二三四五六"}]);
+let fragments = mdi_core::layout_warichu_with_options(nodes.as_array().unwrap(),
+    &mdi_core::WarichuOptions { first_capacity: 2, continuation_capacity: 4 });
+assert_eq!(fragments.len(), 2);
+```
+
+Results contain `lines`, `html`, `widths`, `overflow`, `hardBreakAfter`, and
+`sources`. Each source has a child-index `path` relative to the input inline array,
+half-open `startUtf8` / `endUtf8` offsets into that leaf's visible text, and an
+indivisible `group` ID. A cluster crossing formatting boundaries shares a group.
+Ruby, tcy, no-break and unknown containers remain whole; their coordinates use
+projected visible text (ruby base, excluding its reading). Oversized groups remain
+available and report overflow. Author hard breaks are retained; automatic splits
+never enter canonical MDI or plain text.
+
+The C ABI provides `mdi_layout_warichu_json`, taking inline-array JSON and options
+JSON (`firstCapacity`, `continuationCapacity`) and returning the same JSON through
+`mdi_ffi_result`. Release both returned buffers with `mdi_free_buffer`.
+Static HTML/EPUB includes readable precomputed lines; reader reflow can differ.
+DOCX uses native Word combination groups; XML verification is not a Word rendering
+test. Custom sizes, line counts and manual splitting remain tracked in MDI #85.

--- a/mdi-core/src/docx.rs
+++ b/mdi-core/src/docx.rs
@@ -39,6 +39,7 @@ pub(crate) fn write<W: Write + Seek>(
     let mut context = Context {
         footnote_ids,
         hyperlinks: Vec::new(),
+        next_warichu_id: 0,
     };
     let content = document
         .children
@@ -206,6 +207,7 @@ pub(crate) fn write<W: Write + Seek>(
 struct Context {
     footnote_ids: HashMap<String, usize>,
     hyperlinks: Vec<String>,
+    next_warichu_id: usize,
 }
 
 fn block_xml(node: &Value, profile: &ResolvedExportProfile, context: &mut Context) -> String {
@@ -326,6 +328,7 @@ struct RunProperties {
     size: Option<i64>,
     spacing: Option<i64>,
     break_before: bool,
+    warichu_id: Option<usize>,
 }
 
 fn inline_xml(
@@ -432,20 +435,28 @@ fn inline_xml(
                     },
                     base_size,
                 ),
-                "ruby" => ruby_xml(node, base_size),
+                "ruby" => ruby_xml(node, base_size, properties),
+                "tcy" if properties.warichu_id.is_some() => run_xml(
+                    node.get("value").and_then(Value::as_str).unwrap_or_default(),
+                    properties,
+                ),
                 "tcy" => format!(
                     "<w:r><w:rPr><w:eastAsianLayout w:combine=\"1\" w:combineBrackets=\"none\"/></w:rPr><w:t>{}</w:t></w:r>",
                     escape_xml(node.get("value").and_then(Value::as_str).unwrap_or_default())
                 ),
-                "warichu" => inline_xml(
-                    children(node),
-                    context,
-                    &RunProperties {
-                        size: Some((base_size as f64 * 0.6).round().max(10.0) as i64),
-                        ..properties.clone()
-                    },
-                    base_size,
-                ),
+                "warichu" => {
+                    context.next_warichu_id += 1;
+                    let id = context.next_warichu_id;
+                    inline_xml(
+                        children(node),
+                        context,
+                        &RunProperties {
+                            warichu_id: Some(id),
+                            ..properties.clone()
+                        },
+                        base_size,
+                    )
+                }
                 "kern" => {
                     let spacing = node
                         .get("amount")
@@ -499,6 +510,11 @@ fn run_xml(text: &str, properties: &RunProperties) -> String {
     if let Some(spacing) = properties.spacing.filter(|spacing| *spacing != 0) {
         run_properties.push_str(&format!("<w:spacing w:val=\"{spacing}\"/>"));
     }
+    if let Some(id) = properties.warichu_id {
+        run_properties.push_str(&format!(
+            "<w:eastAsianLayout w:id=\"{id}\" w:combine=\"1\" w:combineBrackets=\"none\"/>"
+        ));
+    }
     let properties_xml = if run_properties.is_empty() {
         String::new()
     } else {
@@ -515,7 +531,8 @@ fn run_xml(text: &str, properties: &RunProperties) -> String {
     )
 }
 
-fn ruby_xml(node: &Value, base_size: i64) -> String {
+fn ruby_xml(node: &Value, base_size: i64, properties: &RunProperties) -> String {
+    let group = properties.warichu_id.map(|id| format!("<w:rPr><w:eastAsianLayout w:id=\"{id}\" w:combine=\"1\" w:combineBrackets=\"none\"/></w:rPr>")).unwrap_or_default();
     let base = node.get("base").and_then(Value::as_str).unwrap_or_default();
     let ruby = node.get("ruby").and_then(|ruby| ruby.get("value"));
     let reading = match ruby {
@@ -534,7 +551,7 @@ fn ruby_xml(node: &Value, base_size: i64) -> String {
         (base_size as f64 * 0.8).round().max(18.0) as i64
     };
     format!(
-        "<w:r><w:ruby><w:rubyPr><w:rubyAlign w:val=\"center\"/><w:hps w:val=\"{ruby_size}\"/><w:hpsRaise w:val=\"{raise}\"/><w:hpsBaseText w:val=\"{base_size}\"/><w:lid w:val=\"ja-JP\"/></w:rubyPr><w:rt><w:r><w:t>{}</w:t></w:r></w:rt><w:rubyBase><w:r><w:t>{}</w:t></w:r></w:rubyBase></w:ruby></w:r>",
+        "<w:r>{group}<w:ruby><w:rubyPr><w:rubyAlign w:val=\"center\"/><w:hps w:val=\"{ruby_size}\"/><w:hpsRaise w:val=\"{raise}\"/><w:hpsBaseText w:val=\"{base_size}\"/><w:lid w:val=\"ja-JP\"/></w:rubyPr><w:rt><w:r><w:t>{}</w:t></w:r></w:rt><w:rubyBase><w:r><w:t>{}</w:t></w:r></w:rubyBase></w:ruby></w:r>",
         escape_xml(&reading),
         escape_xml(base)
     )

--- a/mdi-core/src/lib.rs
+++ b/mdi-core/src/lib.rs
@@ -16,6 +16,11 @@ use unicode_segmentation::UnicodeSegmentation;
 use zip::{CompressionMethod, ZipWriter, write::SimpleFileOptions};
 
 mod docx;
+mod warichu;
+pub use warichu::{
+    WarichuFragment, WarichuOptions, WarichuSource, layout_warichu, layout_warichu_options_json,
+    layout_warichu_with_options,
+};
 #[cfg(test)]
 mod provenance_tests;
 mod publication_profile;
@@ -751,6 +756,7 @@ fn markdown_macro_children(raw: &str, start_byte: usize) -> Option<Vec<serde_jso
     let tree = markdown::to_mdast(content, &options).ok()?;
     let mut value = serde_json::to_value(tree).ok()?;
     annotate_and_lower(&mut value, content, false);
+    lower_markdown_inside_mdi(&mut value, content);
     shift_spans(&mut value, start_byte + content_offset);
     let children = value
         .get_mut("children")?
@@ -1328,6 +1334,23 @@ pub mod ffi {
     ) -> MdiFfiResult {
         match source(data, len) {
             Ok(source) => success(operation(source).into_bytes()),
+            Err(error) => failure(error),
+        }
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn mdi_layout_warichu_json(
+        data: *const u8,
+        len: usize,
+        options_data: *const u8,
+        options_len: usize,
+    ) -> MdiFfiResult {
+        let result = source(data, len).and_then(|nodes| {
+            let options = utf8_argument(options_data, options_len, "warichu options")?;
+            super::layout_warichu_options_json(nodes, options)
+        });
+        match result {
+            Ok(value) => success(value.into_bytes()),
             Err(error) => failure(error),
         }
     }
@@ -2892,7 +2915,7 @@ fn css_value(value: &str) -> String {
 
 /// The base stylesheet is intentionally shipped by the core alongside the
 /// semantic HTML. Hosts may add presentation CSS, but not reinterpret nodes.
-pub const MDI_STYLESHEET: &str = ".mdi-tcy{text-combine-upright:all}.mdi-nobr{white-space:nowrap}.mdi-warichu{font-size:.6em}.mdi-em{text-emphasis:var(--mdi-em,filled sesame)}.mdi-kern{letter-spacing:var(--mdi-kern)}.mdi-blank{min-block-size:1lh}.mdi-indent{margin-inline-start:calc(var(--mdi-indent)*1em)}.mdi-bottom{text-align:end}.mdi-pagebreak{break-after:page}";
+pub const MDI_STYLESHEET: &str = ".mdi-tcy{text-combine-upright:all}.mdi-nobr{white-space:nowrap}.mdi-warichu{font-size:.5em;line-height:1}.mdi-warichu-fragment{display:inline-flex;flex-direction:column;vertical-align:middle;text-align:start}.mdi-warichu-line{display:block;white-space:nowrap;min-block-size:1em}.mdi-em{text-emphasis:var(--mdi-em,filled sesame)}.mdi-kern{letter-spacing:var(--mdi-kern)}.mdi-blank{min-block-size:1lh}.mdi-indent{margin-inline-start:calc(var(--mdi-indent)*1em)}.mdi-bottom{text-align:end}.mdi-pagebreak{break-after:page}";
 
 const VERTICAL_WHEEL_SCROLL_SCRIPT: &str = "<script>(function(){document.addEventListener('wheel',function(event){if(event.defaultPrevented||event.ctrlKey||event.shiftKey)return;var delta=event.deltaY;if(event.deltaMode===1)delta*=16;else if(event.deltaMode===2)delta*=window.innerWidth;if(!delta)return;var root=document.scrollingElement;var before=root.scrollLeft;window.scrollBy({left:-delta,behavior:'auto'});if(root.scrollLeft!==before)event.preventDefault()},{passive:false})})()</script>";
 
@@ -3584,7 +3607,37 @@ fn render_html_node(node: &serde_json::Value, out: &mut String) {
             ));
             out.push_str("\">");
         }
-        "table" => wrapped(out, "table", children),
+        "table" => {
+            out.push_str("<table>");
+            for (row_index, row) in crate::children(node).iter().enumerate() {
+                if row_index == 0 {
+                    out.push_str("<thead>");
+                }
+                if row_index == 1 {
+                    out.push_str("<tbody>");
+                }
+                out.push_str("<tr>");
+                for cell in crate::children(row) {
+                    out.push_str(if row_index == 0 {
+                        "<th scope=\"col\">"
+                    } else {
+                        "<td>"
+                    });
+                    for child in crate::children(cell) {
+                        render_html_node(child, out);
+                    }
+                    out.push_str(if row_index == 0 { "</th>" } else { "</td>" });
+                }
+                out.push_str("</tr>");
+                if row_index == 0 {
+                    out.push_str("</thead>");
+                }
+            }
+            if crate::children(node).len() > 1 {
+                out.push_str("</tbody>");
+            }
+            out.push_str("</table>");
+        }
         "tableRow" => wrapped(out, "tr", children),
         "tableCell" => wrapped(out, "td", children),
         "footnoteReference" => {
@@ -3636,11 +3689,7 @@ fn render_html_node(node: &serde_json::Value, out: &mut String) {
             children(out);
             out.push_str("</span>");
         }
-        "warichu" => {
-            out.push_str("<span class=\"mdi-warichu\">");
-            children(out);
-            out.push_str("</span>");
-        }
+        "warichu" => warichu::render(crate::children(node), out),
         "kern" => {
             out.push_str("<span class=\"mdi-kern\" style=\"--mdi-kern:");
             out.push_str(&escape_html(
@@ -4228,6 +4277,20 @@ mod wasm {
         resolve_mdi_source_spans_json, serialize_mdi, split_ruby, unescape_mdi, unescape_ruby,
     };
     use wasm_bindgen::prelude::*;
+
+    /// Presentation-only layout of already parsed inline IR. No syntax parsing.
+    #[wasm_bindgen(js_name = layoutWarichuOptionsJson)]
+    pub fn wasm_layout_warichu_options_json(nodes: &str, options: &str) -> Result<String, JsValue> {
+        super::layout_warichu_options_json(nodes, options).map_err(|e| JsValue::from_str(&e))
+    }
+
+    #[wasm_bindgen(js_name = layoutWarichuJson)]
+    pub fn wasm_layout_warichu_json(nodes_json: &str, capacity: u32) -> Result<String, JsValue> {
+        let nodes: Vec<serde_json::Value> = serde_json::from_str(nodes_json)
+            .map_err(|error| JsValue::from_str(&error.to_string()))?;
+        serde_json::to_string(&super::layout_warichu(&nodes, capacity as usize))
+            .map_err(|error| JsValue::from_str(&error.to_string()))
+    }
 
     /// Parse with Rust and return the versioned MDI IR as JSON.
     ///

--- a/mdi-core/src/warichu.rs
+++ b/mdi-core/src/warichu.rs
@@ -1,0 +1,360 @@
+//! Presentation-only warichu layout. Never write the generated splits into IR.
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use unicode_segmentation::UnicodeSegmentation;
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WarichuOptions {
+    pub first_capacity: usize,
+    #[serde(alias = "capacity")]
+    pub continuation_capacity: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WarichuSource {
+    pub path: Vec<usize>,
+    pub start_utf8: usize,
+    pub end_utf8: usize,
+    pub group: usize,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WarichuFragment {
+    pub lines: [Vec<Value>; 2],
+    pub sources: [Vec<WarichuSource>; 2],
+    pub html: [String; 2],
+    /// Widths in half-em units at the note's font size.
+    pub widths: [usize; 2],
+    pub overflow: bool,
+    pub hard_break_after: bool,
+}
+
+struct Unit {
+    nodes: Vec<Value>,
+    sources: Vec<WarichuSource>,
+    is_text: bool,
+    text: String,
+    width: usize,
+    hard_break: bool,
+}
+
+fn visible(node: &Value) -> String {
+    match node["type"].as_str().unwrap_or_default() {
+        "ruby" => node["base"].as_str().unwrap_or_default().to_owned(),
+        "image" => node["alt"].as_str().unwrap_or_default().to_owned(),
+        _ => node["value"]
+            .as_str()
+            .map(str::to_owned)
+            .unwrap_or_else(|| crate::children(node).iter().map(visible).collect()),
+    }
+}
+
+fn weight(text: &str) -> usize {
+    text.graphemes(true)
+        .map(|g| {
+            if g.chars()
+                .all(|c| c.is_ascii() || ('\u{ff61}'..='\u{ff9f}').contains(&c))
+            {
+                1
+            } else {
+                2
+            }
+        })
+        .sum()
+}
+
+fn units(nodes: &[Value], wrappers: &[Value], path: &[usize], out: &mut Vec<Unit>) {
+    for (index, node) in nodes.iter().enumerate() {
+        let mut path = path.to_vec();
+        path.push(index);
+        let kind = node["type"].as_str().unwrap_or_default();
+        if matches!(
+            kind,
+            "strong" | "emphasis" | "delete" | "em" | "kern" | "link"
+        ) {
+            let mut parents = wrappers.to_vec();
+            parents.push(node.clone());
+            units(crate::children(node), &parents, &path, out);
+            continue;
+        }
+        let parts = if kind == "text" {
+            node["value"]
+                .as_str()
+                .unwrap_or_default()
+                .chars()
+                .map(|g| json!({"type":"text", "value":g.to_string()}))
+                .collect::<Vec<_>>()
+        } else {
+            vec![node.clone()]
+        };
+        let mut offset = 0;
+        for mut part in parts {
+            let text = visible(&part);
+            let width = weight(&text);
+            for wrapper in wrappers.iter().rev() {
+                let mut parent = wrapper.clone();
+                parent["children"] = json!([part]);
+                part = parent;
+            }
+            out.push(Unit {
+                nodes: vec![part],
+                sources: vec![WarichuSource {
+                    path: path.clone(),
+                    start_utf8: offset,
+                    end_utf8: offset + text.len(),
+                    group: 0,
+                }],
+                is_text: kind == "text",
+                text: text.clone(),
+                width,
+                hard_break: kind == "break",
+            });
+            offset += text.len();
+        }
+    }
+}
+
+// Segment the complete adjacent text run, so formatting cannot split a cluster.
+fn join_graphemes(input: Vec<Unit>) -> Vec<Unit> {
+    let mut result: Vec<Unit> = Vec::new();
+    let mut input = input.into_iter().peekable();
+    while let Some(unit) = input.next() {
+        if !unit.is_text {
+            result.push(unit);
+            continue;
+        }
+        let mut run = vec![unit];
+        while input.peek().is_some_and(|unit| unit.is_text) {
+            run.push(input.next().unwrap());
+        }
+        let text: String = run.iter().map(|unit| unit.text.as_str()).collect();
+        let mut boundaries = text
+            .grapheme_indices(true)
+            .map(|(offset, _)| offset)
+            .peekable();
+        let mut offset = 0;
+        for unit in run {
+            if boundaries.peek() == Some(&offset) {
+                boundaries.next();
+                result.push(unit);
+            } else {
+                let previous = result.last_mut().unwrap();
+                previous.text.push_str(&unit.text);
+                previous.nodes.extend(unit.nodes);
+                previous.sources.extend(unit.sources);
+            }
+            offset += result
+                .last()
+                .unwrap()
+                .text
+                .chars()
+                .last()
+                .unwrap()
+                .len_utf8();
+        }
+    }
+    for (group, unit) in result.iter_mut().enumerate() {
+        unit.width = weight(&unit.text);
+        for source in &mut unit.sources {
+            source.group = group;
+        }
+    }
+    result
+}
+
+// Conservative Japanese line-head / line-end prohibition, including small kana.
+fn legal(left: &Unit, right: &Unit) -> bool {
+    let opening = "（〔［｛〈《「『【([{‘“";
+    let closing = "、。，．・：；？！ー々ゝゞヽヾ）〕］｝〉》」』】)]},.!?:;’”ぁぃぅぇぉっゃゅょゎァィゥェォッャュョヮヵヶ";
+    !left
+        .text
+        .chars()
+        .last()
+        .is_some_and(|c| opening.contains(c))
+        && !right
+            .text
+            .chars()
+            .next()
+            .is_some_and(|c| closing.contains(c))
+}
+
+fn emit_run(run: &[Unit], options: &WarichuOptions, out: &mut Vec<WarichuFragment>) {
+    let mut start = 0;
+    while start < run.len() {
+        let capacity = if out.is_empty() {
+            options.first_capacity
+        } else {
+            options.continuation_capacity
+        }
+        .max(1);
+        let mut end = start;
+        let mut total = 0;
+        while end < run.len()
+            && (total + run[end].width <= capacity.saturating_mul(2) || end == start)
+        {
+            total += run[end].width;
+            end += 1;
+        }
+        // Move an illegal fragment boundary backwards, or forwards if there is
+        // no legal boundary within capacity. Text always wins over clipping.
+        let target = end;
+        while end > start && end < run.len() && !legal(&run[end - 1], &run[end]) {
+            end -= 1;
+        }
+        if end == start {
+            end = target;
+            while end < run.len() && !legal(&run[end - 1], &run[end]) {
+                end += 1;
+            }
+        }
+        total = run[start..end].iter().map(|u| u.width).sum();
+        let mut first = 0;
+        let mut best = None;
+        for split in start + 1..end {
+            first += run[split - 1].width;
+            if !legal(&run[split - 1], &run[split]) {
+                continue;
+            }
+            let second = total - first;
+            let score = (
+                first.max(second) > capacity,
+                first.abs_diff(second),
+                first < second,
+            );
+            if best.as_ref().is_none_or(|(old, _, _)| score < *old) {
+                best = Some((score, split, first));
+            }
+        }
+        let (_, split, first) = best.unwrap_or(((true, total, false), end, total));
+        let second = total - first;
+        out.push(WarichuFragment {
+            lines: [
+                run[start..split]
+                    .iter()
+                    .flat_map(|u| u.nodes.clone())
+                    .collect(),
+                run[split..end]
+                    .iter()
+                    .flat_map(|u| u.nodes.clone())
+                    .collect(),
+            ],
+            sources: [
+                run[start..split]
+                    .iter()
+                    .flat_map(|u| u.sources.clone())
+                    .collect(),
+                run[split..end]
+                    .iter()
+                    .flat_map(|u| u.sources.clone())
+                    .collect(),
+            ],
+            html: [
+                render_units(&run[start..split]),
+                render_units(&run[split..end]),
+            ],
+            widths: [first, second],
+            overflow: first.max(second) > capacity,
+            hard_break_after: false,
+        });
+        start = end;
+    }
+}
+
+/// Split already parsed inline children; capacity is half-em units at 50% type.
+/// Ruby, tcy, no-break, and unknown inline containers remain indivisible.
+/// An unavailable browser measurement can use 40 (20 note em) as a fallback.
+pub fn layout_warichu(nodes: &[Value], capacity: usize) -> Vec<WarichuFragment> {
+    layout_warichu_with_options(
+        nodes,
+        &WarichuOptions {
+            first_capacity: capacity,
+            continuation_capacity: capacity,
+        },
+    )
+}
+
+pub fn layout_warichu_with_options(
+    nodes: &[Value],
+    options: &WarichuOptions,
+) -> Vec<WarichuFragment> {
+    let mut input = Vec::new();
+    units(nodes, &[], &[], &mut input);
+    let input = join_graphemes(input);
+    let mut out = Vec::new();
+    let mut start = 0;
+    for (index, unit) in input.iter().enumerate() {
+        if unit.hard_break {
+            let before = out.len();
+            emit_run(&input[start..index], options, &mut out);
+            if out.len() == before {
+                out.push(WarichuFragment {
+                    lines: [vec![], vec![]],
+                    sources: [vec![], vec![]],
+                    html: [String::new(), String::new()],
+                    widths: [0, 0],
+                    overflow: false,
+                    hard_break_after: true,
+                });
+            } else {
+                out.last_mut().unwrap().hard_break_after = true;
+            }
+            start = index + 1;
+        }
+    }
+    emit_run(&input[start..], options, &mut out);
+    out
+}
+
+fn render_units(units: &[Unit]) -> String {
+    let mut out = String::new();
+    for unit in units {
+        for node in &unit.nodes {
+            crate::render_html_node(node, &mut out);
+        }
+    }
+    // Nested notes already live at note size. Normalize only the renderer's
+    // generated outer span; escaped author text cannot match this markup.
+    out.replace(
+        "<span class=\"mdi-warichu\" style=\"font-size:.5em;line-height:1\"",
+        "<span class=\"mdi-warichu\" style=\"font-size:1em;line-height:1\"",
+    )
+}
+
+pub fn layout_warichu_options_json(nodes: &str, options: &str) -> Result<String, String> {
+    let nodes: Vec<Value> = serde_json::from_str(nodes).map_err(|e| e.to_string())?;
+    let options: WarichuOptions = serde_json::from_str(options).map_err(|e| e.to_string())?;
+    serde_json::to_string(&layout_warichu_with_options(&nodes, &options)).map_err(|e| e.to_string())
+}
+
+pub(crate) fn render(nodes: &[Value], out: &mut String) {
+    out.push_str("<span class=\"mdi-warichu\" style=\"font-size:.5em;line-height:1\" data-mdi-warichu-source=\"");
+    let source = serde_json::to_string(nodes).unwrap();
+    out.push_str(
+        &source
+            .replace('&', "&amp;")
+            .replace('"', "&quot;")
+            .replace('<', "&lt;")
+            .replace('>', "&gt;"),
+    );
+    out.push_str("\">");
+    for fragment in layout_warichu(nodes, 40) {
+        out.push_str("<span class=\"mdi-warichu-fragment\" style=\"display:inline-flex;flex-direction:column;vertical-align:middle;text-align:start\"");
+        if fragment.overflow {
+            out.push_str(" data-mdi-overflow=\"indivisible\"");
+        }
+        out.push('>');
+        for line in fragment.html {
+            out.push_str("<span class=\"mdi-warichu-line\" style=\"display:block;white-space:nowrap;min-block-size:1em\">");
+            out.push_str(&line);
+            out.push_str("</span>");
+        }
+        out.push_str("</span>");
+        if fragment.hard_break_after {
+            out.push_str("<br>");
+        }
+    }
+    out.push_str("</span>");
+}

--- a/mdi-core/tests/html_table_semantics.rs
+++ b/mdi-core/tests/html_table_semantics.rs
@@ -1,0 +1,8 @@
+#[test]
+fn gfm_header_cells_keep_accessible_html_semantics() {
+    let html = mdi_core::render_html("| 列A | 列B |\n| --- | --- |\n| 表一 | 表二 |");
+    assert_eq!(html.matches("<th scope=\"col\">").count(), 2, "{html}");
+    assert_eq!(html.matches("<td>").count(), 2, "{html}");
+    assert!(html.contains("<thead><tr><th scope=\"col\">列A</th>"));
+    assert!(html.contains("<tbody><tr><td>表一</td>"));
+}

--- a/mdi-core/tests/warichu_layout.rs
+++ b/mdi-core/tests/warichu_layout.rs
@@ -1,0 +1,277 @@
+use mdi_core::{parse_document, render_html, serialize_mdi};
+
+#[test]
+fn warichu_html_is_two_lines_without_changing_authored_source() {
+    let source = "本文[[warichu:一二三四五]]続き";
+    let before = serialize_mdi(source);
+    let document = parse_document(source);
+    let html = render_html(source);
+    assert!(html.contains("<span class=\"mdi-warichu-line\" style=\"display:block;white-space:nowrap;min-block-size:1em\">一二三</span><span class=\"mdi-warichu-line\" style=\"display:block;white-space:nowrap;min-block-size:1em\">四五</span>"), "{html}");
+    assert_eq!(parse_document(source), document);
+    assert_eq!(serialize_mdi(source), before);
+    assert!(!before.contains("[[br]]"));
+}
+
+fn note(source: &str, capacity: usize) -> Vec<mdi_core::WarichuFragment> {
+    let doc = parse_document(&format!("[[warichu:{source}]]"));
+    mdi_core::layout_warichu(
+        doc.children[0]["children"][0]["children"]
+            .as_array()
+            .unwrap(),
+        capacity,
+    )
+}
+fn text(nodes: &[serde_json::Value]) -> String {
+    nodes
+        .iter()
+        .map(|n| {
+            n["value"]
+                .as_str()
+                .or(n["base"].as_str())
+                .map(str::to_owned)
+                .unwrap_or_else(|| {
+                    n["children"]
+                        .as_array()
+                        .map(|c| text(c))
+                        .unwrap_or_default()
+                })
+        })
+        .collect()
+}
+
+#[test]
+fn balanced_unicode_and_mixed_widths() {
+    for (source, expected) in [
+        ("一二三四", [4, 4]),
+        ("一二三四五", [6, 4]),
+        ("AB一二", [4, 2]),
+        ("👨‍👩‍👧‍👦か\u{3099}一", [4, 2]),
+    ] {
+        let fragments = note(source, 40);
+        assert_eq!(fragments.len(), 1, "{source}");
+        assert_eq!(fragments[0].widths, expected, "{source}");
+        assert_eq!(
+            fragments
+                .iter()
+                .flat_map(|f| f.lines.iter())
+                .map(|l| text(l))
+                .collect::<String>(),
+            source
+        );
+    }
+}
+
+#[test]
+fn kinsoku_and_indivisible_inline_semantics() {
+    let f = note("一二、三四", 40);
+    assert_eq!(text(&f[0].lines[0]), "一二、");
+    let f = note("一二（三四）五", 40);
+    assert!(!text(&f[0].lines[0]).ends_with('（'));
+    assert!(!text(&f[0].lines[1]).starts_with('）'));
+    for source in ["{東京|とうきょう}", "[[no-break:一二三四五]]", "^1234^"] {
+        let f = note(source, 1);
+        assert_eq!(f.len(), 1, "{source}");
+        assert!(f[0].overflow, "{source}");
+        assert_eq!(f[0].lines[0].len(), 1);
+        assert!(f[0].lines[1].is_empty());
+    }
+}
+
+#[test]
+fn long_notes_keep_order_and_hard_boundaries() {
+    let source = "一二三四五六七八九十".repeat(20);
+    let f = note(&source, 8);
+    assert!(f.len() > 1);
+    assert!(f.iter().all(|p| !p.overflow && p.widths[0] >= p.widths[1]));
+    assert_eq!(
+        f.iter()
+            .flat_map(|p| p.lines.iter())
+            .map(|l| text(l))
+            .collect::<String>(),
+        source
+    );
+    let f = note("一二[[br]][[br]]三四", 40);
+    assert_eq!(f.len(), 3);
+    assert!(f[0].hard_break_after && f[1].hard_break_after);
+    assert!(!f[2].hard_break_after);
+    assert!(serialize_mdi("[[warichu:一二[[br]]三四]]").contains("[[br]]"));
+}
+
+#[test]
+fn docx_uses_native_combination_across_formatted_runs() {
+    use std::io::Read;
+    let bytes = mdi_core::render_docx("[[warichu:一**二**三]]外[[warichu:四五]]").unwrap();
+    let mut archive = zip::ZipArchive::new(std::io::Cursor::new(bytes)).unwrap();
+    let mut xml = String::new();
+    archive
+        .by_name("word/document.xml")
+        .unwrap()
+        .read_to_string(&mut xml)
+        .unwrap();
+    assert_eq!(xml.matches("w:combine=\"1\"").count(), 4, "{xml}");
+    assert_eq!(xml.matches("w:id=\"1\" w:combine").count(), 3);
+    assert_eq!(xml.matches("w:id=\"2\" w:combine").count(), 1);
+    assert!(!xml.contains("<w:sz w:val=\"14\""));
+}
+
+#[test]
+fn docx_native_note_keeps_ruby_and_tcy_in_its_group() {
+    use std::io::Read;
+    let bytes = mdi_core::render_docx("[[warichu:{東京|とうきょう}^12^]]").unwrap();
+    let mut archive = zip::ZipArchive::new(std::io::Cursor::new(bytes)).unwrap();
+    let mut xml = String::new();
+    archive
+        .by_name("word/document.xml")
+        .unwrap()
+        .read_to_string(&mut xml)
+        .unwrap();
+    assert_eq!(xml.matches("w:id=\"1\" w:combine").count(), 2, "{xml}");
+    assert!(xml.contains("<w:ruby>"));
+    assert!(xml.contains("とうきょう"));
+    assert!(xml.contains(">12</w:t>"));
+}
+
+#[test]
+fn formatting_boundary_does_not_split_a_grapheme() {
+    let nodes = serde_json::json!([
+        {"type":"text","value":"か"},
+        {"type":"strong","children":[{"type":"text","value":"\u{3099}"}]}
+    ]);
+    let fragments = mdi_core::layout_warichu(nodes.as_array().unwrap(), 1);
+    assert_eq!(fragments.len(), 1);
+    assert_eq!(text(&fragments[0].lines[0]), "か\u{3099}");
+    assert_eq!(fragments[0].widths, [2, 0]);
+}
+
+#[test]
+fn options_preserve_source_coordinates_and_use_continuation_capacity() {
+    let nodes = serde_json::json!([{"type":"text","value":"一二三四五六七八九十"}]);
+    let result = mdi_core::layout_warichu_with_options(
+        nodes.as_array().unwrap(),
+        &mdi_core::WarichuOptions {
+            first_capacity: 2,
+            continuation_capacity: 8,
+        },
+    );
+    assert_eq!(result.len(), 2);
+    assert_eq!(result[0].widths, [2, 2]);
+    assert_eq!(result[1].widths, [8, 8]);
+    let sources: Vec<_> = result
+        .iter()
+        .flat_map(|f| f.sources.iter().flatten())
+        .collect();
+    for (i, source) in sources.iter().enumerate() {
+        assert_eq!(source.path, [0]);
+        assert_eq!(source.start_utf8, i * 3);
+        assert_eq!(source.end_utf8, (i + 1) * 3);
+        assert_eq!(source.group, i);
+    }
+    assert_eq!(result[0].html, ["一", "二"]);
+}
+
+#[test]
+fn cross_format_sources_share_a_grapheme_group() {
+    let nodes = serde_json::json!([{"type":"text","value":"か"},{"type":"strong","children":[{"type":"text","value":"\u{3099}"}]}]);
+    let result = mdi_core::layout_warichu(nodes.as_array().unwrap(), 1);
+    let sources = &result[0].sources[0];
+    assert_eq!(sources.len(), 2);
+    assert_eq!(sources[0].group, sources[1].group);
+    assert_eq!(sources[1].path, [1, 0]);
+    assert_eq!(sources[1].end_utf8, 3);
+    assert!(result[0].overflow);
+}
+
+#[test]
+#[allow(unsafe_code)]
+fn json_and_c_layout_interfaces_report_invalid_options() {
+    assert!(mdi_core::layout_warichu_options_json("[]", "{}").is_err());
+    assert!(
+        mdi_core::layout_warichu_options_json(
+            "{}",
+            "{\"firstCapacity\":1,\"continuationCapacity\":2}"
+        )
+        .is_err()
+    );
+    let nodes = b"[]";
+    let options = b"{\"firstCapacity\":1,\"continuationCapacity\":2}";
+    let result = mdi_core::ffi::mdi_layout_warichu_json(
+        nodes.as_ptr(),
+        nodes.len(),
+        options.as_ptr(),
+        options.len(),
+    );
+    assert_eq!(result.error.len, 0);
+    assert_eq!(result.value.len, 2);
+    unsafe {
+        mdi_core::ffi::mdi_free_buffer(result.value);
+        mdi_core::ffi::mdi_free_buffer(result.error);
+    }
+}
+
+#[test]
+fn regional_indicators_across_formatting_follow_global_segmentation() {
+    let nodes = serde_json::json!([{"type":"text","value":"🇯"},{"type":"strong","children":[{"type":"text","value":"🇵🇺🇸"}]}]);
+    let result = mdi_core::layout_warichu(nodes.as_array().unwrap(), 2);
+    assert_eq!(result.len(), 1);
+    assert_eq!(text(&result[0].lines[0]), "🇯🇵");
+    assert_eq!(text(&result[0].lines[1]), "🇺🇸");
+}
+
+#[test]
+fn portable_html_keeps_two_lines_without_a_stylesheet() {
+    let html = render_html("[[warichu:一二]]");
+    assert!(html.contains("style=\"font-size:.5em;line-height:1\""));
+    assert!(html.contains(
+        "style=\"display:inline-flex;flex-direction:column;vertical-align:middle;text-align:start\""
+    ));
+}
+
+#[test]
+fn nested_notes_keep_half_body_size_instead_of_halving_repeatedly() {
+    let html = render_html("[[warichu:外[[warichu:内注]]外]]");
+    assert_eq!(
+        html.matches("style=\"font-size:.5em;line-height:1\"")
+            .count(),
+        1
+    );
+    assert_eq!(
+        html.matches("style=\"font-size:1em;line-height:1\"")
+            .count(),
+        1
+    );
+}
+
+#[test]
+fn docx_hard_breaks_stay_inside_the_native_note_group() {
+    use std::io::Read;
+    let bytes = mdi_core::render_docx("[[warichu:一[[br]][[br]]**二**]]").unwrap();
+    let mut archive = zip::ZipArchive::new(std::io::Cursor::new(bytes)).unwrap();
+    let mut xml = String::new();
+    archive
+        .by_name("word/document.xml")
+        .unwrap()
+        .read_to_string(&mut xml)
+        .unwrap();
+    assert_eq!(xml.matches("<w:br/>").count(), 2);
+    assert_eq!(xml.matches("w:id=\"1\" w:combine").count(), 4);
+    assert!(xml.contains("<w:b/>"));
+}
+
+#[test]
+fn formatted_no_break_inside_warichu_is_structured_and_indivisible() {
+    let source = "前[[warichu:一[[no-break:二**三**四]][[warichu:内注]]**e**́五六七八九十]]後";
+    let document = parse_document(source);
+    let children = document.children[0]["children"][1]["children"]
+        .as_array()
+        .unwrap();
+    assert_eq!(children[1]["type"], "noBreak");
+    assert_eq!(children[1]["children"][1]["type"], "strong");
+    assert_eq!(text(children[1]["children"].as_array().unwrap()), "二三四");
+    let fragments = mdi_core::layout_warichu(children, 2);
+    assert!(
+        fragments
+            .iter()
+            .any(|f| f.overflow && text(&f.lines[0]) == "二三四")
+    );
+    assert_eq!(serialize_mdi(&serialize_mdi(source)), serialize_mdi(source));
+}

--- a/nodejs/browser-test/src.ts
+++ b/nodejs/browser-test/src.ts
@@ -1,4 +1,4 @@
-import { getMdiTextBlocks, initializeMdi, parse, resolveMdiSourceSpan, resolveMdiSourceSpans, serializeMdi } from "@illusions-lab/mdi";
+import { attachMdiWarichuLayout, measureMdiWarichu, renderHtml, layoutMdiWarichu, getMdiTextBlocks, initializeMdi, parse, resolveMdiSourceSpan, resolveMdiSourceSpans, serializeMdi } from "@illusions-lab/mdi";
 import { parseForMdast, type MdiMdastDocument, type MdiMdastNode } from "@illusions-lab/mdi/internal/mdast";
 import remarkMdi from "@illusions-lab/mdi-remark";
 import remarkParse from "remark-parse";
@@ -62,6 +62,8 @@ async function run(): Promise<void> {
   const remarkOutput = processor.stringify(transformed);
 
   document.querySelector("#result")!.textContent = JSON.stringify({
+    warichuBrowser: await testWarichuBrowser(),
+    warichu: layoutMdiWarichu([{ type: "text", value: "一二三四五" }]),
     irVersion: parsed.irVersion,
     projectionVersion: projection.projectionVersion,
     provenanceJson: JSON.stringify(canonicalProvenance(parseForMdast(source).document)),
@@ -97,4 +99,46 @@ function canonicalNodeProvenance(node: MdiMdastNode): unknown {
     provenance: node.mdiProvenance ?? null,
     children: (node.children ?? []).map(canonicalNodeProvenance),
   };
+}
+
+async function testWarichuBrowser() {
+ const iframe=document.createElement('iframe');
+ iframe.style.cssText='width:400px;height:500px';
+ const noteText='一二三四五六七八九十'.repeat(12);
+ const loaded=new Promise<void>(resolve=>iframe.onload=()=>resolve());
+ iframe.srcdoc=renderHtml(`前文前文（[[warichu:${noteText}]]）後文\n\n[[warichu:甲[[br]][[br]]乙]]\n\n[[warichu:甲[[warichu:乙丙]]丁]]`);
+ document.body.append(iframe);await loaded;
+ const body=iframe.contentDocument!.body;
+ body.style.cssText='font-size:24px;width:180px';
+ const adapter=attachMdiWarichuLayout(body);
+ await adapter.settled();
+ const note=body.querySelector<HTMLElement>('.mdi-warichu')!;
+ const original=note.dataset.mdiWarichuSource;
+ const beforeZoom=measureMdiWarichu(body)[0].options;
+ body.style.transform='scale(0.8)';body.style.zoom='1.5';adapter.configure();await adapter.settled();
+ const afterZoom=measureMdiWarichu(body)[0].options;
+ const zoomStable=JSON.stringify(beforeZoom)===JSON.stringify(afterZoom);
+ body.style.transform='';body.style.zoom='';adapter.configure();await adapter.settled();
+ const lines=Array.from(note.querySelectorAll<HTMLElement>('.mdi-warichu-line'));
+ const geometry=lines.slice(0,2).map(line=>{const r=line.getBoundingClientRect();return {x:r.x,y:r.y,w:r.width,h:r.height};});
+ const previous=note.previousSibling!;
+ const openingRange=iframe.contentDocument!.createRange();openingRange.setStart(previous,previous.textContent!.length-1);openingRange.setEnd(previous,previous.textContent!.length);
+ const opening=openingRange.getBoundingClientRect();
+ const firstFragment=note.querySelector('.mdi-warichu-fragment')!.getBoundingClientRect();
+ const adjacentOpening=opening.top<firstFragment.bottom && opening.bottom>firstFragment.top;
+ const next=note.nextSibling!;const closingRange=iframe.contentDocument!.createRange();closingRange.setStart(next,0);closingRange.setEnd(next,1);
+ const closing=closingRange.getBoundingClientRect();const lastFragment=Array.from(note.querySelectorAll('.mdi-warichu-fragment')).at(-1)!.getBoundingClientRect();
+ const adjacentClosing=closing.top<lastFragment.bottom && closing.bottom>lastFragment.top;
+ const preserved=note.textContent===noteText;
+ const wraps=new Set(Array.from(note.querySelectorAll('.mdi-warichu-fragment')).map(n=>n.getBoundingClientRect().y)).size>1;
+ const hardBreaks=body.querySelectorAll('.mdi-warichu')[1].querySelectorAll('br').length;
+ body.style.width='280px'; adapter.configure();await adapter.settled();
+ const resized=note.dataset.mdiWarichuSource===original && note.textContent===noteText;
+ body.style.cssText='font-size:24px;height:220px;writing-mode:vertical-rl';adapter.configure();await adapter.settled();
+ const vertical=Array.from(note.querySelectorAll('.mdi-warichu-line')).slice(0,2).map(n=>{const r=n.getBoundingClientRect();return {x:r.x,y:r.y};});
+ const outer=body.querySelectorAll<HTMLElement>('.mdi-warichu')[2];
+ const inner=outer.querySelector<HTMLElement>('.mdi-warichu')!;
+ const nested={text:outer.textContent,lines:inner.querySelectorAll(':scope > .mdi-warichu-fragment > .mdi-warichu-line').length,sameSize:iframe.contentWindow!.getComputedStyle(inner).fontSize===iframe.contentWindow!.getComputedStyle(outer).fontSize,measured:measureMdiWarichu(body).length};
+ adapter.dispose();iframe.remove();
+ return {geometry,preserved,wraps,hardBreaks,resized,vertical,adjacentOpening,adjacentClosing,zoomStable,nested};
 }

--- a/nodejs/packages/mdi-core/CHANGELOG.md
+++ b/nodejs/packages/mdi-core/CHANGELOG.md
@@ -1,5 +1,8 @@
 # @illusions-lab/mdi-core
 
+## Unreleased
+
+- Add Rust-owned automatic warichu fragments and a presentation-only layout API; render native DOCX two-line text. Add first/continuation capacities, UTF-8 source mappings and portable fragment HTML; adaptive editor integration is a separate consumer gate.
 ## 2.0.21
 
 ### Patch Changes

--- a/nodejs/packages/mdi-core/src/browser.d.ts
+++ b/nodejs/packages/mdi-core/src/browser.d.ts
@@ -1,5 +1,5 @@
 export {
-  applyPdfProfileJson, blockMacroAmount, blockMacroKind, blockMacroVariant,
+  layoutWarichuJson, layoutWarichuOptionsJson, applyPdfProfileJson, blockMacroAmount, blockMacroKind, blockMacroVariant,
   getMdiTextBlocksJson, pageSizeCatalogJson, parseMdiSyntaxJson, parseMdiMdastJson, prepareChromiumPrintProfileJson,
   resolveMdiSourceSpanJson,
   resolveMdiSourceSpansJson,

--- a/nodejs/packages/mdi-core/src/browser.js
+++ b/nodejs/packages/mdi-core/src/browser.js
@@ -38,3 +38,7 @@ export const resolveRuby = (...args) => (requireInitialized(), bindings.resolveR
 export const serializeMdi = (...args) => (requireInitialized(), bindings.serializeMdi(...args));
 export const unescapeMdi = (...args) => (requireInitialized(), bindings.unescapeMdi(...args));
 export const unescapeRubyText = (...args) => (requireInitialized(), bindings.unescapeRubyText(...args));
+
+export const layoutWarichuJson = (...args) => (requireInitialized(), bindings.layoutWarichuJson(...args));
+
+export const layoutWarichuOptionsJson = (...args) => (requireInitialized(), bindings.layoutWarichuOptionsJson(...args));

--- a/nodejs/packages/mdi-core/src/node.cjs
+++ b/nodejs/packages/mdi-core/src/node.cjs
@@ -31,3 +31,7 @@ exports.resolveRuby = bindings.resolveRuby;
 exports.serializeMdi = bindings.serializeMdi;
 exports.unescapeMdi = bindings.unescapeMdi;
 exports.unescapeRubyText = bindings.unescapeRubyText;
+
+exports.layoutWarichuJson = bindings.layoutWarichuJson;
+
+exports.layoutWarichuOptionsJson = (...args) => bindings.layoutWarichuOptionsJson(...args);

--- a/nodejs/packages/mdi/CHANGELOG.md
+++ b/nodejs/packages/mdi/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix long notes clipping or shrinking during PDF output by measuring the physical printable page and actual glyph advances, including inherited tracking and indentation.
+
 - Add Rust-owned automatic warichu fragments and a presentation-only layout API; render native DOCX two-line text. Add first/continuation capacities, UTF-8 source mappings and portable fragment HTML; adaptive editor integration is a separate consumer gate.
 ## 2.0.21
 

--- a/nodejs/packages/mdi/CHANGELOG.md
+++ b/nodejs/packages/mdi/CHANGELOG.md
@@ -1,5 +1,8 @@
 # @illusions-lab/mdi
 
+## Unreleased
+
+- Add Rust-owned automatic warichu fragments and a presentation-only layout API; render native DOCX two-line text. Add first/continuation capacities, UTF-8 source mappings and portable fragment HTML; adaptive editor integration is a separate consumer gate.
 ## 2.0.21
 
 ### Patch Changes

--- a/nodejs/packages/mdi/README.md
+++ b/nodejs/packages/mdi/README.md
@@ -217,3 +217,30 @@ executable syntax authority is `mdi-core`.
 - [Document IR and diagnostics](https://mdi.illusions.app/core/document-ir/)
 - [Rendering model](https://mdi.illusions.app/core/rendering/)
 - [JavaScript documentation](https://mdi.illusions.app/bindings/javascript/)
+
+### Automatic two-line notes
+
+`layoutMdiWarichu(children, capacity)` remains available. To account for the
+space before a note, pass `{ firstCapacity, continuationCapacity }` instead.
+Both capacities use half-em units at the note's 50% font size. Rust returns
+`lines`, `widths`, `overflow`, `hardBreakAfter`, `html`, and `sources`. Source
+paths address the original inline children; byte offsets are UTF-8 leaf
+boundaries, and `group` identifies indivisible units. Repeated text must be
+mapped by these positions, never by searching its value.
+
+For read-only rendered HTML, initialize MDI and call
+`attachMdiWarichuLayout(container)`. The controller exposes `configure()`,
+`settled({ timeoutMs, signal })`, and `dispose()`. Resize, font, and ancestor
+style changes trigger presentation updates. Editors should use the layout
+result with their own selection-preserving presentation layer.
+
+`settleMdiPrintLayout(evaluate, { timeoutMs, signal })` works with a host's
+existing hidden print document. Supply `code => page.evaluate(code)` for
+Playwright or `code => webContents.executeJavaScript(code)` for Electron.
+The helper waits for fonts and a stable Rust layout; timeout, cancellation,
+and nonconvergence reject the promise and must prevent printing.
+
+The adapter does not change canonical MDI or insert generated `[[br]]`.
+No-script HTML/EPUB retain precomputed two-line spans. Their reading system
+may reflow differently; proportional-font balance is an estimate, and this
+API does not imply testing in Word or every EPUB reader.

--- a/nodejs/packages/mdi/README.md
+++ b/nodejs/packages/mdi/README.md
@@ -234,8 +234,8 @@ For read-only rendered HTML, initialize MDI and call
 style changes trigger presentation updates. Editors should use the layout
 result with their own selection-preserving presentation layer.
 
-`settleMdiPrintLayout(evaluate, { timeoutMs, signal })` works with a host's
-existing hidden print document. Supply `code => page.evaluate(code)` for
+`settleMdiPrintLayout(evaluate, { timeoutMs, signal, page: prepared.page })` works with a host's
+existing hidden print document. Pass the resolved `page` from `prepareChromiumPrintProfile` so layout uses the paper's printable dimensions instead of the host window's viewport. Supply `code => page.evaluate(code)` for
 Playwright or `code => webContents.executeJavaScript(code)` for Electron.
 The helper waits for fonts and a stable Rust layout; timeout, cancellation,
 and nonconvergence reject the promise and must prevent printing.
@@ -244,3 +244,5 @@ The adapter does not change canonical MDI or insert generated `[[br]]`.
 No-script HTML/EPUB retain precomputed two-line spans. Their reading system
 may reflow differently; proportional-font balance is an estimate, and this
 API does not imply testing in Word or every EPUB reader.
+
+Browser measurement accounts for actual rendered advances and inherited text insets; Rust still owns every split. This retains configured tracking while avoiding clipped notes and Chromium shrink-to-fit.

--- a/nodejs/packages/mdi/src/index.ts
+++ b/nodejs/packages/mdi/src/index.ts
@@ -928,3 +928,33 @@ export function renderTextFormatWithDiagnostics(
 
 /** @deprecated Use {@link parse}; it now parses the complete document. */
 export const parseMdiSyntax = parse;
+
+/** UTF-8 boundaries in an original inline leaf; paths are relative to children. */
+export interface MdiWarichuSource { path: number[]; startUtf8: number; endUtf8: number; group: number }
+export interface MdiWarichuOptions { firstCapacity: number; continuationCapacity: number }
+/** Presentation-only two-line fragment; generated boundaries never belong in MDI. */
+export interface MdiWarichuFragment {
+  lines: [Record<string, unknown>[], Record<string, unknown>[]];
+  widths: [number, number];
+  overflow: boolean;
+  hardBreakAfter: boolean;
+  sources: [MdiWarichuSource[], MdiWarichuSource[]];
+  html: [string, string];
+}
+/** Rust owns splitting. Capacities are half-em units at the note's 50% font size. */
+export function layoutMdiWarichu(
+  children: readonly Record<string, unknown>[],
+  capacity: number | MdiWarichuOptions = 40,
+): MdiWarichuFragment[] {
+  const options = typeof capacity === "number" ? {firstCapacity:capacity,continuationCapacity:capacity} : capacity;
+  for (const value of [options.firstCapacity, options.continuationCapacity]) {
+    if (!Number.isSafeInteger(value) || value < 1 || value > 0xffffffff) {
+      throw new RangeError("Warichu capacity must be a positive u32 integer");
+    }
+  }
+  return JSON.parse(mdiCore.layoutWarichuOptionsJson(JSON.stringify(children), JSON.stringify(options)));
+}
+export { attachMdiWarichuLayout, measureMdiWarichu, applyMdiWarichu } from "./warichu-browser.js";
+export type { MdiWarichuLayoutController, MdiWarichuSettleOptions } from "./warichu-browser.js";
+
+export { settleMdiPrintLayout, type MdiPrintEvaluate } from "./warichu-print.js";

--- a/nodejs/packages/mdi/src/index.ts
+++ b/nodejs/packages/mdi/src/index.ts
@@ -957,4 +957,4 @@ export function layoutMdiWarichu(
 export { attachMdiWarichuLayout, measureMdiWarichu, applyMdiWarichu } from "./warichu-browser.js";
 export type { MdiWarichuLayoutController, MdiWarichuSettleOptions } from "./warichu-browser.js";
 
-export { settleMdiPrintLayout, type MdiPrintEvaluate } from "./warichu-print.js";
+export { settleMdiPrintLayout, type MdiPrintEvaluate, type MdiPrintPage, type MdiPrintLayoutOptions } from "./warichu-print.js";

--- a/nodejs/packages/mdi/src/warichu-browser.test.ts
+++ b/nodejs/packages/mdi/src/warichu-browser.test.ts
@@ -5,7 +5,7 @@ function fixture() {
  const listeners=new Map<string,()=>void>();const observed=new Set<unknown>();
  let mutation:(records:any[])=>void=()=>{},resize:(entries:any[])=>void=()=>{};
  const style={writingMode:'horizontal-tb',direction:'ltr',fontSize:'20px',paddingInlineStart:'0',paddingInlineEnd:'0'};
- const note:any={dataset:{mdiWarichuSource:JSON.stringify([{type:'text',value:'一二三四五六'}])},innerHTML:'',closest:()=>paragraph};
+ const note:any={dataset:{mdiWarichuSource:JSON.stringify([{type:'text',value:'一二三四五六'}])},innerHTML:'',querySelectorAll:()=>[],closest:()=>paragraph};
  const paragraph:any={clientWidth:200,clientHeight:300,getBoundingClientRect:()=>({left:0,right:200,bottom:300}),contains:(n:unknown)=>n===note,closest:(selector:string)=>selector.startsWith('[data')?null:paragraph,nodeType:1};
  let rects:any[]=[{left:0,right:120,bottom:40}];
  const win:any={getComputedStyle:()=>style,requestAnimationFrame:(cb:()=>void)=>setTimeout(cb,0),addEventListener:vi.fn(),removeEventListener:vi.fn(),visualViewport:{addEventListener:vi.fn(),removeEventListener:vi.fn()},MutationObserver:class{constructor(cb:any){mutation=cb}observe(){}disconnect(){}},ResizeObserver:class{constructor(cb:any){resize=cb}observe(element:unknown){observed.add(element)}unobserve(element:unknown){observed.delete(element)}disconnect(){observed.clear()}}};
@@ -79,4 +79,12 @@ it('cancels the pending animation frame and global readiness on disposal',async(
  const adapter=attachMdiWarichuLayout(f.container);await Promise.resolve();await Promise.resolve();
  adapter.dispose();await expect(f.win.__mdiWarichuLayoutReady).rejects.toThrow('disposed');
  expect(f.win.cancelAnimationFrame).toHaveBeenCalledWith(42);
+});
+it('measures real row advances and inherited insets without changing typography',()=>{
+ const f=fixture();
+ const line={dataset:{mdiWidth:'4'},getBoundingClientRect:()=>({left:0,right:90,top:0,bottom:20})};
+ f.note.querySelectorAll=()=>[line,{dataset:{mdiWidth:'0'}}];
+ f.container.ownerDocument.createRange=()=>({selectNodeContents(){},setEndBefore(){},getClientRects:()=>[{left:0,right:120,bottom:40}],getBoundingClientRect:()=>({left:10,right:90,top:0,bottom:20,width:80,height:20})});
+ expect(measureMdiWarichu(f.container)[0]).toMatchObject({unit:20,options:{firstCapacity:3,continuationCapacity:9}});
+ expect(measureMdiWarichu(f.container,undefined,{0:25})[0]).toMatchObject({unit:25,options:{firstCapacity:2,continuationCapacity:7}});
 });

--- a/nodejs/packages/mdi/src/warichu-browser.test.ts
+++ b/nodejs/packages/mdi/src/warichu-browser.test.ts
@@ -1,0 +1,82 @@
+import {expect,it,vi} from 'vitest';
+import {measureMdiWarichu,applyMdiWarichu,attachMdiWarichuLayout} from './warichu-browser.js';
+import {layoutMdiWarichu} from './index.js';
+function fixture() {
+ const listeners=new Map<string,()=>void>();const observed=new Set<unknown>();
+ let mutation:(records:any[])=>void=()=>{},resize:(entries:any[])=>void=()=>{};
+ const style={writingMode:'horizontal-tb',direction:'ltr',fontSize:'20px',paddingInlineStart:'0',paddingInlineEnd:'0'};
+ const note:any={dataset:{mdiWarichuSource:JSON.stringify([{type:'text',value:'一二三四五六'}])},innerHTML:'',closest:()=>paragraph};
+ const paragraph:any={clientWidth:200,clientHeight:300,getBoundingClientRect:()=>({left:0,right:200,bottom:300}),contains:(n:unknown)=>n===note,closest:(selector:string)=>selector.startsWith('[data')?null:paragraph,nodeType:1};
+ let rects:any[]=[{left:0,right:120,bottom:40}];
+ const win:any={getComputedStyle:()=>style,requestAnimationFrame:(cb:()=>void)=>setTimeout(cb,0),addEventListener:vi.fn(),removeEventListener:vi.fn(),visualViewport:{addEventListener:vi.fn(),removeEventListener:vi.fn()},MutationObserver:class{constructor(cb:any){mutation=cb}observe(){}disconnect(){}},ResizeObserver:class{constructor(cb:any){resize=cb}observe(element:unknown){observed.add(element)}unobserve(element:unknown){observed.delete(element)}disconnect(){observed.clear()}}};
+ const fonts={ready:Promise.resolve(),addEventListener:(name:string,cb:()=>void)=>listeners.set(name,cb),removeEventListener:vi.fn()};
+ const doc:any={defaultView:win,fonts,documentElement:{},createRange:()=>({selectNodeContents(){},setEndBefore(){},getClientRects:()=>rects})};
+ const paragraphs=[paragraph];
+ const container:any={ownerDocument:doc,querySelectorAll:(selector:string)=>selector.startsWith('[data')?[note]:paragraphs,contains:(n:unknown)=>n===note||n===paragraph};
+ note.ownerDocument=doc;note.parentElement=paragraph;
+ return {container,note,paragraph,paragraphs,observed,style,win,fonts,rects:(value:any[])=>rects=value,mutation:(records:any[])=>mutation(records),resize:(entries:any[])=>resize(entries),listeners};
+}
+it('measures remaining capacity in the containing realm and writing direction',()=>{
+ const f=fixture();
+ expect(measureMdiWarichu(f.container)[0].options).toEqual({firstCapacity:8,continuationCapacity:20});
+ f.style.writingMode='vertical-rl';expect(measureMdiWarichu(f.container)[0].options.firstCapacity).toBe(26);
+ f.style.writingMode='horizontal-tb';f.style.direction='rtl';expect(measureMdiWarichu(f.container)[0].options.firstCapacity).toBe(20);
+ f.rects([]);expect(measureMdiWarichu(f.container)[0].options.firstCapacity).toBe(20);
+ expect(measureMdiWarichu(f.container,[])).toEqual([]);
+ expect(measureMdiWarichu(f.container,[f.paragraph])).toHaveLength(1);
+});
+it('preserves author breaks, indivisible overflow and source while avoiding redundant writes',()=>{
+ const f=fixture();const source=f.note.dataset.mdiWarichuSource;
+ const fragments=layoutMdiWarichu([{type:'noBreak',children:[{type:'text',value:'甲乙'}]},{type:'break'},{type:'break'}],1);
+ const updates=[{index:0,fragments},{index:99,fragments}];
+ expect(applyMdiWarichu(updates,f.container)).toBe(true);
+ expect(f.note.innerHTML).toContain('data-mdi-overflow');expect(f.note.innerHTML.match(/<br>/g)).toHaveLength(2);
+ expect(applyMdiWarichu(updates,f.container)).toBe(false);expect(f.note.dataset.mdiWarichuSource).toBe(source);
+});
+it('settles queued mutations, resize, fonts and disposal without touching source',async()=>{
+ const f=fixture();const adapter=attachMdiWarichuLayout(f.container);
+ adapter.configure();await adapter.settled();
+ f.mutation([{target:f.paragraph}]);await adapter.settled();
+ f.resize([{target:f.paragraph}]);await adapter.settled();
+ f.resize([{target:f.container}]);await adapter.settled();
+ f.mutation([{target:{contains:()=>false}}]);
+ f.listeners.get('loadingdone')!();await adapter.settled();
+ adapter.dispose();adapter.configure();expect(f.fonts.removeEventListener).toHaveBeenCalled();
+});
+it('settled rejects pending font timeout and cancellation',async()=>{
+ const f=fixture();f.fonts.ready=new Promise(()=>{});const adapter=attachMdiWarichuLayout(f.container);
+ await expect(adapter.settled({timeoutMs:2})).rejects.toThrow('timed out');
+ const abort=new AbortController();const pending=adapter.settled({signal:abort.signal});abort.abort();await expect(pending).rejects.toBeDefined();
+ await expect(adapter.settled({signal:abort.signal})).rejects.toBeDefined();adapter.dispose();
+});
+it('keeps capacities invariant when browser rectangles are scaled',()=>{
+ const f=fixture();
+ f.paragraph.offsetWidth=200;f.paragraph.offsetHeight=300;
+ f.paragraph.getBoundingClientRect=()=>({left:0,right:400,bottom:600,width:400,height:600});
+ f.rects([{left:0,right:240,bottom:80}]);
+ expect(measureMdiWarichu(f.container)[0].options).toEqual({firstCapacity:8,continuationCapacity:20});
+ f.style.writingMode='vertical-rl';expect(measureMdiWarichu(f.container)[0].options.firstCapacity).toBe(26);
+});
+it('cancels stability waiting immediately on disposal even if fonts never resolve',async()=>{
+ const f=fixture();f.fonts.ready=new Promise(()=>{});const adapter=attachMdiWarichuLayout(f.container);
+ const pending=adapter.settled({timeoutMs:20});adapter.dispose();
+ await expect(pending).rejects.toThrow('disposed');
+});
+
+it('observes later paragraphs and releases removed paragraphs',async()=>{
+ const f=fixture();const adapter=attachMdiWarichuLayout(f.container);await adapter.settled();
+ const added={...f.paragraph};f.paragraphs.push(added);f.mutation([{target:f.paragraph}]);await adapter.settled();
+ expect(f.observed.has(added)).toBe(true);
+ f.paragraphs.pop();f.mutation([{target:f.paragraph}]);await adapter.settled();expect(f.observed.has(added)).toBe(false);
+ adapter.dispose();
+});
+it('moves a note to the next line when the remaining slot cannot fit its first indivisible unit',async()=>{
+ const f=fixture();f.rects([{left:0,right:195,bottom:40}]);const adapter=attachMdiWarichuLayout(f.container);
+ await adapter.settled();expect(f.note.innerHTML).not.toContain('data-mdi-overflow');adapter.dispose();
+});
+it('cancels the pending animation frame and global readiness on disposal',async()=>{
+ const f=fixture();f.win.requestAnimationFrame=()=>42;f.win.cancelAnimationFrame=vi.fn();
+ const adapter=attachMdiWarichuLayout(f.container);await Promise.resolve();await Promise.resolve();
+ adapter.dispose();await expect(f.win.__mdiWarichuLayoutReady).rejects.toThrow('disposed');
+ expect(f.win.cancelAnimationFrame).toHaveBeenCalledWith(42);
+});

--- a/nodejs/packages/mdi/src/warichu-browser.ts
+++ b/nodejs/packages/mdi/src/warichu-browser.ts
@@ -4,9 +4,11 @@ export interface MdiWarichuMeasurement {
  index: number;
  children: Record<string, unknown>[];
  options: MdiWarichuOptions;
+ /** Measured CSS pixels per Rust half-em unit for this layout pass. */
+ unit?:number;
 }
 /** Self-contained for execution in a browser hosted by Electron or Playwright. */
-export function measureMdiWarichu(container: HTMLElement = document.body, affected?: readonly HTMLElement[]): MdiWarichuMeasurement[] {
+export function measureMdiWarichu(container: HTMLElement = document.body, affected?: readonly HTMLElement[], minimumUnits?:Readonly<Record<number,number>>): MdiWarichuMeasurement[] {
  return Array.from(container.querySelectorAll<HTMLElement>('[data-mdi-warichu-source]')).flatMap((note,index) => {
   if (note.parentElement?.closest('[data-mdi-warichu-source]')) return [];
   if (affected && !affected.some(element=>element.contains(note))) return [];
@@ -23,8 +25,18 @@ export function measureMdiWarichu(container: HTMLElement = document.body, affect
   const paddingEnd = parseFloat(style.paddingInlineEnd)||0;
   const full = (vertical ? paragraph.clientHeight : paragraph.clientWidth)-paddingStart-paddingEnd;
   const scale = (vertical ? box.height/paragraph.offsetHeight : box.width/paragraph.offsetWidth) || 1;
+  let unit=Math.max(size/2,minimumUnits?.[index] ?? 0);
+  let inset=0;
+  for(const line of note.querySelectorAll<HTMLElement>(':scope > .mdi-warichu-fragment > .mdi-warichu-line[data-mdi-width]')) {
+   const width=Number(line.dataset.mdiWidth);if(!(width>0)) continue;
+   const contents=container.ownerDocument.createRange();contents.selectNodeContents(line);
+   const bounds=contents.getBoundingClientRect();
+   const lineBox=line.getBoundingClientRect();
+   inset=Math.max(inset,(vertical?bounds.top-lineBox.top:style.direction==='rtl'?lineBox.right-bounds.right:bounds.left-lineBox.left)/scale);
+   unit=Math.max(unit,(vertical?bounds.height:bounds.width)/scale/width);
+  }
   const remaining = !previous ? full : vertical ? (box.bottom-previous.bottom)/scale-paddingEnd : style.direction === 'rtl' ? (previous.left-box.left)/scale-paddingStart : (box.right-previous.right)/scale-paddingEnd;
-  return [{index,children:JSON.parse(note.dataset.mdiWarichuSource!),options:{firstCapacity:Math.max(1,Math.floor((remaining<=0?full:Math.min(full,remaining))*2/size)),continuationCapacity:Math.max(1,Math.floor(full*2/size))}}];
+  return [{index,unit,children:JSON.parse(note.dataset.mdiWarichuSource!),options:{firstCapacity:Math.max(1,Math.floor(((remaining<=0?full:Math.min(full,remaining))-inset)/unit)),continuationCapacity:Math.max(1,Math.floor((full-inset)/unit))}}];
  });
 }
 /** If Rust reports that only the first remaining slot is too small, use the next body line. */
@@ -42,7 +54,7 @@ export function applyMdiWarichu(updates: {index:number;fragments:MdiWarichuFragm
  let changed = false;
  for (const {index,fragments} of updates) {
   const note = notes[index]; if (!note) continue;
-  const html = fragments.map(fragment => `<span class="mdi-warichu-fragment" style="display:inline-flex;flex-direction:column;vertical-align:middle;text-align:start"${fragment.overflow?' data-mdi-overflow="true"':''}>${fragment.html.map(line=>`<span class="mdi-warichu-line" style="display:block;white-space:nowrap;min-block-size:1em">${line}</span>`).join('')}</span>${fragment.hardBreakAfter?'<br>':''}`).join('');
+  const html = fragments.map(fragment => `<span class="mdi-warichu-fragment" style="display:inline-flex;flex-direction:column;vertical-align:middle;text-align:start"${fragment.overflow?' data-mdi-overflow="true"':''}>${fragment.html.map((line,row)=>`<span class="mdi-warichu-line" data-mdi-width="${fragment.widths[row]}" style="display:block;white-space:nowrap;min-block-size:1em">${line}</span>`).join('')}</span>${fragment.hardBreakAfter?'<br>':''}`).join('');
   // Browser serialization normalizes markup. Compare the intended markup cache.
   if (note.dataset.mdiWarichuLayout === html) continue;
   note.innerHTML = html;
@@ -97,9 +109,13 @@ export function attachMdiWarichuLayout(container:HTMLElement):MdiWarichuLayoutCo
      await Promise.race([container.ownerDocument.fonts.ready,disposal]);
      await frame();
      let stable=false;
+     const minimumUnits:Record<number,number>={};
      for(let pass=0;pass<12;pass++) {
       if(disposed) return;
-      const updates=measureMdiWarichu(container,batch).map(m=>({index:m.index,fragments:layoutMeasuredMdiWarichu(m)}));
+      const updates=measureMdiWarichu(container,batch,minimumUnits).map(m=>{
+       if(m.unit) minimumUnits[m.index]=m.unit;
+       return {index:m.index,fragments:layoutMeasuredMdiWarichu(m)};
+      });
       mutation.disconnect();
       let changed:boolean;
       try {changed=applyMdiWarichu(updates,container);} finally {observe();}

--- a/nodejs/packages/mdi/src/warichu-browser.ts
+++ b/nodejs/packages/mdi/src/warichu-browser.ts
@@ -1,0 +1,136 @@
+import { layoutMdiWarichu, type MdiWarichuFragment, type MdiWarichuOptions } from './index.js';
+
+export interface MdiWarichuMeasurement {
+ index: number;
+ children: Record<string, unknown>[];
+ options: MdiWarichuOptions;
+}
+/** Self-contained for execution in a browser hosted by Electron or Playwright. */
+export function measureMdiWarichu(container: HTMLElement = document.body, affected?: readonly HTMLElement[]): MdiWarichuMeasurement[] {
+ return Array.from(container.querySelectorAll<HTMLElement>('[data-mdi-warichu-source]')).flatMap((note,index) => {
+  if (note.parentElement?.closest('[data-mdi-warichu-source]')) return [];
+  if (affected && !affected.some(element=>element.contains(note))) return [];
+  const paragraph = note.closest<HTMLElement>('p,li,td,th,h1,h2,h3,h4,h5,h6') ?? note.parentElement ?? container;
+  const view = container.ownerDocument.defaultView!;
+  const style = view.getComputedStyle(paragraph);
+  const vertical = style.writingMode.startsWith('vertical');
+  const box = paragraph.getBoundingClientRect();
+  const range = container.ownerDocument.createRange(); range.selectNodeContents(paragraph); range.setEndBefore(note);
+  const rects = Array.from(range.getClientRects());
+  const previous = rects.at(-1);
+  const size = parseFloat(view.getComputedStyle(note).fontSize) || parseFloat(style.fontSize)/2;
+  const paddingStart = parseFloat(style.paddingInlineStart)||0;
+  const paddingEnd = parseFloat(style.paddingInlineEnd)||0;
+  const full = (vertical ? paragraph.clientHeight : paragraph.clientWidth)-paddingStart-paddingEnd;
+  const scale = (vertical ? box.height/paragraph.offsetHeight : box.width/paragraph.offsetWidth) || 1;
+  const remaining = !previous ? full : vertical ? (box.bottom-previous.bottom)/scale-paddingEnd : style.direction === 'rtl' ? (previous.left-box.left)/scale-paddingStart : (box.right-previous.right)/scale-paddingEnd;
+  return [{index,children:JSON.parse(note.dataset.mdiWarichuSource!),options:{firstCapacity:Math.max(1,Math.floor((remaining<=0?full:Math.min(full,remaining))*2/size)),continuationCapacity:Math.max(1,Math.floor(full*2/size))}}];
+ });
+}
+/** If Rust reports that only the first remaining slot is too small, use the next body line. */
+export function layoutMeasuredMdiWarichu(measurement:MdiWarichuMeasurement):MdiWarichuFragment[] {
+ const {children,options}=measurement;
+ const fragments=layoutMdiWarichu(children,options);
+ const first=fragments[0];
+ return first?.overflow && options.firstCapacity<options.continuationCapacity && Math.max(...first.widths)<=options.continuationCapacity
+  ? layoutMdiWarichu(children,{...options,firstCapacity:options.continuationCapacity})
+  : fragments;
+}
+/** Applies Rust-rendered presentation only; never modifies canonical source. */
+export function applyMdiWarichu(updates: {index:number;fragments:MdiWarichuFragment[]}[], container:HTMLElement = document.body): boolean {
+ const notes = container.querySelectorAll<HTMLElement>('[data-mdi-warichu-source]');
+ let changed = false;
+ for (const {index,fragments} of updates) {
+  const note = notes[index]; if (!note) continue;
+  const html = fragments.map(fragment => `<span class="mdi-warichu-fragment" style="display:inline-flex;flex-direction:column;vertical-align:middle;text-align:start"${fragment.overflow?' data-mdi-overflow="true"':''}>${fragment.html.map(line=>`<span class="mdi-warichu-line" style="display:block;white-space:nowrap;min-block-size:1em">${line}</span>`).join('')}</span>${fragment.hardBreakAfter?'<br>':''}`).join('');
+  // Browser serialization normalizes markup. Compare the intended markup cache.
+  if (note.dataset.mdiWarichuLayout === html) continue;
+  note.innerHTML = html;
+  note.dataset.mdiWarichuLayout = html;
+  changed = true;
+ }
+ return changed;
+}
+export interface MdiWarichuSettleOptions { timeoutMs?:number; signal?:AbortSignal }
+export interface MdiWarichuLayoutController {
+ configure():void;
+ settled(options?:MdiWarichuSettleOptions):Promise<void>;
+ dispose():void;
+}
+/** Attach to read-only Rust-rendered HTML. Editable editors consume layoutMdiWarichu directly. */
+export function attachMdiWarichuLayout(container:HTMLElement):MdiWarichuLayoutController {
+ const win = container.ownerDocument.defaultView!;
+ const realm = win as unknown as typeof globalThis;
+ let disposed = false, scheduled = false, pending = false;
+ let affected:Set<HTMLElement>|null=null;
+ let rejectDisposal!:(reason:Error)=>void;
+ const disposal=new Promise<never>((_,reject)=>{rejectDisposal=reject;});void disposal.catch(()=>{});
+ let ready:Promise<void> = Promise.resolve();
+ const publish = () => { (win as unknown as {__mdiWarichuLayoutReady:Promise<void>}).__mdiWarichuLayoutReady = ready; void ready.catch(()=>{}); };
+ const frame = async () => {
+  let id=0;
+  try {await Promise.race([new Promise<void>(resolve=>{id=win.requestAnimationFrame(()=>resolve());}),disposal]);}
+  finally {win.cancelAnimationFrame?.(id);}
+ };
+ const observe = () => mutation.observe(container.ownerDocument.documentElement,{subtree:true,childList:true,characterData:true,attributes:true,attributeFilter:['style','class','dir','data-mdi-warichu-source']});
+ const mutation = new realm.MutationObserver(records=>{
+  for(const record of records) {
+   if(!container.contains(record.target) && !record.target.contains(container)) continue;
+   const element=record.target.nodeType===1?record.target as HTMLElement:record.target.parentElement;
+   const paragraph=element?.closest<HTMLElement>('p,li,td,th,h1,h2,h3,h4,h5,h6');
+   invalidate(paragraph && container.contains(paragraph)?paragraph:undefined);
+  }
+ });
+ const configure=()=>invalidate();
+ const invalidate = (paragraph?:HTMLElement) => {
+  if(paragraph) affected?.add(paragraph);else affected=null;
+  if(disposed) return;
+  pending = true;
+  if(scheduled) return;
+  scheduled = true;
+  ready = (async()=>{
+   try {
+    do {
+     syncObservedParagraphs();
+     pending=false;
+     const batch=affected===null?undefined:Array.from(affected);affected=new Set();
+     await Promise.race([container.ownerDocument.fonts.ready,disposal]);
+     await frame();
+     let stable=false;
+     for(let pass=0;pass<12;pass++) {
+      if(disposed) return;
+      const updates=measureMdiWarichu(container,batch).map(m=>({index:m.index,fragments:layoutMeasuredMdiWarichu(m)}));
+      mutation.disconnect();
+      let changed:boolean;
+      try {changed=applyMdiWarichu(updates,container);} finally {observe();}
+      await frame();
+      if(!changed) {stable=true;break;}
+     }
+     if(!stable) throw new Error('Warichu layout did not stabilize');
+    } while(pending && !disposed);
+   } finally { scheduled=false; }
+  })(); publish();
+ };
+ const resize = new realm.ResizeObserver(entries=>{for(const entry of entries) invalidate(entry.target===container?undefined:entry.target as HTMLElement);}); resize.observe(container);
+ const observed=new Set<HTMLElement>();
+ const syncObservedParagraphs=()=>{
+  const paragraphs=new Set(container.querySelectorAll<HTMLElement>('p,li,td,th,h1,h2,h3,h4,h5,h6'));
+  for(const paragraph of observed) if(!paragraphs.has(paragraph)){resize.unobserve(paragraph);observed.delete(paragraph);}
+  for(const paragraph of paragraphs) if(!observed.has(paragraph)){resize.observe(paragraph);observed.add(paragraph);}
+ };
+ syncObservedParagraphs();
+ observe();
+ container.ownerDocument.fonts.addEventListener('loadingdone',configure);
+ win.addEventListener('resize',configure);
+ win.visualViewport?.addEventListener('resize',configure);
+ configure();
+ return {configure, settled:({timeoutMs=10000,signal}={})=>new Promise<void>((resolve,reject)=>{
+  if(signal?.aborted) { reject(signal.reason ?? new Error('Warichu layout cancelled')); return; }
+  const finish=(error?:unknown)=>{clearTimeout(timer);signal?.removeEventListener('abort',abort);error?reject(error):resolve();};
+  const abort=()=>finish(signal?.reason ?? new Error('Warichu layout cancelled'));
+  const timer=setTimeout(()=>finish(new Error('Warichu layout timed out')),timeoutMs);
+  signal?.addEventListener('abort',abort,{once:true});
+  const latest=async()=>{let current;do {current=ready;await Promise.race([current,disposal]);} while(current!==ready);};
+  latest().then(()=>finish(),finish);
+ }),dispose:()=>{disposed=true;rejectDisposal(new Error('Warichu layout disposed'));resize.disconnect();mutation.disconnect();container.ownerDocument.fonts.removeEventListener('loadingdone',configure);win.removeEventListener('resize',configure);win.visualViewport?.removeEventListener('resize',configure);}};
+}

--- a/nodejs/packages/mdi/src/warichu-options.test.ts
+++ b/nodejs/packages/mdi/src/warichu-options.test.ts
@@ -1,0 +1,9 @@
+import { expect, it } from 'vitest';
+import { layoutMdiWarichu } from './index.js';
+it('uses distinct first and continuation capacities without writing breaks', () => {
+ const children = [{type:'text',value:'一二三四五六七八九十'}];
+ const result = layoutMdiWarichu(children, {firstCapacity:2,continuationCapacity:6});
+ expect(result[0]?.widths).toEqual([2,2]);
+ expect(result.slice(1).some(f => Math.max(...f.widths)>2)).toBe(true);
+ expect(children[0].value).toBe('一二三四五六七八九十');
+});

--- a/nodejs/packages/mdi/src/warichu-print.test.ts
+++ b/nodejs/packages/mdi/src/warichu-print.test.ts
@@ -27,3 +27,24 @@ it('stops host writes when cancelled during pending font evaluation',async()=>{
  release();await Promise.resolve();await Promise.resolve();
  expect(evaluate).toHaveBeenCalledTimes(1);
 });
+it('constrains the transient print body using resolved physical page margins',async()=>{
+ const evaluate=vi.fn(async(code:string)=>code.includes('measureMdiWarichu')?[]:false);
+ await settleMdiPrintLayout(evaluate,{page:{widthMm:148,heightMm:210,marginsMm:{top:15,right:15,bottom:15,left:15}}});
+ expect(evaluate.mock.calls[0][0]).toContain('document.body.style.setProperty("inline-size"');
+ expect(evaluate.mock.calls[0][0]).toContain('? 180 : 118');
+ expect(evaluate.mock.calls[1][0]).toContain('document.fonts.ready');
+});
+it('rejects impossible physical print geometry without evaluating the document',async()=>{
+ const evaluate=vi.fn();
+ for(const widthMm of [0,NaN,Infinity]) {
+  await expect(settleMdiPrintLayout(evaluate,{page:{widthMm,heightMm:210,marginsMm:{top:15,right:15,bottom:15,left:15}}})).rejects.toThrow('printable dimensions');
+ }
+ expect(evaluate).not.toHaveBeenCalled();
+});
+it('stops before font evaluation when cancelled during physical viewport preparation',async()=>{
+ const abort=new AbortController();let release!:()=>void;
+ const evaluate=vi.fn(()=>new Promise<void>(resolve=>{release=resolve}));
+ const pending=settleMdiPrintLayout(evaluate,{signal:abort.signal,page:{widthMm:148,heightMm:210,marginsMm:{top:15,right:15,bottom:15,left:15}}});
+ abort.abort(new Error('cancelled viewport'));await expect(pending).rejects.toThrow('cancelled viewport');
+ release();await Promise.resolve();await Promise.resolve();expect(evaluate).toHaveBeenCalledTimes(1);
+});

--- a/nodejs/packages/mdi/src/warichu-print.test.ts
+++ b/nodejs/packages/mdi/src/warichu-print.test.ts
@@ -1,0 +1,29 @@
+import {expect,it,vi} from 'vitest';
+import {settleMdiPrintLayout} from './warichu-print.js';
+it('waits for fonts and stable presentation without modifying source',async()=>{
+ const evaluate=vi.fn(async(code:string)=>code.includes('measureMdiWarichu')?[]:false);
+ await settleMdiPrintLayout(evaluate);
+ expect(evaluate).toHaveBeenCalledTimes(4);
+ expect(evaluate.mock.calls[0][0]).toContain('document.fonts.ready');
+});
+it('rejects a font/evaluation timeout instead of printing an unfinished layout',async()=>{
+ await expect(settleMdiPrintLayout(()=>new Promise(()=>{}),{timeoutMs:5})).rejects.toThrow('timed out');
+});
+it('rejects cancellation without starting evaluation',async()=>{
+ const controller=new AbortController();controller.abort(new Error('cancelled'));
+ const evaluate=vi.fn();
+ await expect(settleMdiPrintLayout(evaluate,{signal:controller.signal})).rejects.toThrow('cancelled');
+ expect(evaluate).not.toHaveBeenCalled();
+});
+it('rejects layouts that do not converge',async()=>{
+ await expect(settleMdiPrintLayout(async code=>code.includes('measureMdiWarichu')?[]:true)).rejects.toThrow('did not stabilize');
+});
+it('stops host writes when cancelled during pending font evaluation',async()=>{
+ const controller=new AbortController();let release!:()=>void;
+ const evaluate=vi.fn(()=>new Promise<void>(resolve=>{release=resolve}));
+ const pending=settleMdiPrintLayout(evaluate,{signal:controller.signal});
+ controller.abort(new Error('cancelled during fonts'));
+ await expect(pending).rejects.toThrow('cancelled during fonts');
+ release();await Promise.resolve();await Promise.resolve();
+ expect(evaluate).toHaveBeenCalledTimes(1);
+});

--- a/nodejs/packages/mdi/src/warichu-print.ts
+++ b/nodejs/packages/mdi/src/warichu-print.ts
@@ -1,0 +1,31 @@
+import { measureMdiWarichu, applyMdiWarichu, layoutMeasuredMdiWarichu, type MdiWarichuMeasurement, type MdiWarichuSettleOptions } from './warichu-browser.js';
+/** Execute JavaScript in the print document. Electron and Playwright can supply their existing page. */
+export type MdiPrintEvaluate = (javascript:string)=>Promise<unknown>;
+/** Wait for fonts, then measure and apply the shared Rust layout before permitting printing. */
+export async function settleMdiPrintLayout(evaluate:MdiPrintEvaluate, {timeoutMs=10000,signal}:MdiWarichuSettleOptions={}):Promise<void> {
+ let timer:ReturnType<typeof setTimeout>|undefined;
+ let abort:()=>void=()=>{};
+ let stopped=false;
+ const failure = new Promise<never>((_,reject)=>{
+  abort=()=>{stopped=true;reject(signal?.reason ?? new Error('MDI print layout cancelled'));};
+  if(signal?.aborted) {abort();return;}
+  signal?.addEventListener('abort',abort,{once:true});
+  timer=setTimeout(()=>{stopped=true;reject(new Error('MDI print layout timed out'));},timeoutMs);
+ });
+ const run=async()=>{
+  if(stopped) return;
+  await evaluate('document.fonts.ready.then(() => undefined)');
+  for(let pass=0;pass<12;pass++) {
+   if(stopped) return;
+   const measurements=await evaluate(`(${measureMdiWarichu.toString()})()`) as MdiWarichuMeasurement[];
+   if(stopped) return;
+   const updates=measurements.map(m=>({index:m.index,fragments:layoutMeasuredMdiWarichu(m)}));
+   const changed=await evaluate(`(${applyMdiWarichu.toString()})(${JSON.stringify(updates)})`);
+   if(stopped) return;
+   await evaluate('new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(() => resolve())))');
+   if(!changed) return;
+  }
+  throw new Error('MDI print layout did not stabilize');
+ };
+ try {await Promise.race([failure,run()]);} finally {stopped=true;clearTimeout(timer);signal?.removeEventListener('abort',abort);}
+}

--- a/nodejs/packages/mdi/src/warichu-print.ts
+++ b/nodejs/packages/mdi/src/warichu-print.ts
@@ -1,8 +1,26 @@
 import { measureMdiWarichu, applyMdiWarichu, layoutMeasuredMdiWarichu, type MdiWarichuMeasurement, type MdiWarichuSettleOptions } from './warichu-browser.js';
 /** Execute JavaScript in the print document. Electron and Playwright can supply their existing page. */
 export type MdiPrintEvaluate = (javascript:string)=>Promise<unknown>;
+/** Physical page dimensions resolved by the upstream Chromium print profile. */
+export interface MdiPrintPage {
+ widthMm:number;
+ heightMm:number;
+ marginsMm:{top:number;right:number;bottom:number;left:number};
+}
+export interface MdiPrintLayoutOptions extends MdiWarichuSettleOptions {
+ /** Pass prepared.page so measurement uses paper space rather than the host window viewport. */
+ page?:MdiPrintPage;
+}
 /** Wait for fonts, then measure and apply the shared Rust layout before permitting printing. */
-export async function settleMdiPrintLayout(evaluate:MdiPrintEvaluate, {timeoutMs=10000,signal}:MdiWarichuSettleOptions={}):Promise<void> {
+export async function settleMdiPrintLayout(evaluate:MdiPrintEvaluate, {timeoutMs=10000,signal,page}:MdiPrintLayoutOptions={}):Promise<void> {
+ let contentWidthMm:number|undefined,contentHeightMm:number|undefined;
+ if(page) {
+  contentWidthMm=page.widthMm-page.marginsMm.left-page.marginsMm.right;
+  contentHeightMm=page.heightMm-page.marginsMm.top-page.marginsMm.bottom;
+  if(!Number.isFinite(contentWidthMm)||!Number.isFinite(contentHeightMm)||contentWidthMm<=0||contentHeightMm<=0) {
+   throw new RangeError('MDI print page must have positive finite printable dimensions');
+  }
+ }
  let timer:ReturnType<typeof setTimeout>|undefined;
  let abort:()=>void=()=>{};
  let stopped=false;
@@ -14,12 +32,20 @@ export async function settleMdiPrintLayout(evaluate:MdiPrintEvaluate, {timeoutMs
  });
  const run=async()=>{
   if(stopped) return;
+  if(page) {
+   await evaluate(`document.body.style.setProperty("inline-size", (getComputedStyle(document.body).writingMode.startsWith("vertical") ? ${contentHeightMm} : ${contentWidthMm}) + "mm")`);
+   if(stopped) return;
+  }
   await evaluate('document.fonts.ready.then(() => undefined)');
+  const minimumUnits:Record<number,number>={};
   for(let pass=0;pass<12;pass++) {
    if(stopped) return;
-   const measurements=await evaluate(`(${measureMdiWarichu.toString()})()`) as MdiWarichuMeasurement[];
+   const measurements=await evaluate(`(${measureMdiWarichu.toString()})(document.body,undefined,${JSON.stringify(minimumUnits)})`) as MdiWarichuMeasurement[];
    if(stopped) return;
-   const updates=measurements.map(m=>({index:m.index,fragments:layoutMeasuredMdiWarichu(m)}));
+   const updates=measurements.map(m=>{
+    if(m.unit) minimumUnits[m.index]=m.unit;
+    return {index:m.index,fragments:layoutMeasuredMdiWarichu(m)};
+   });
    const changed=await evaluate(`(${applyMdiWarichu.toString()})(${JSON.stringify(updates)})`);
    if(stopped) return;
    await evaluate('new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(() => resolve())))');

--- a/nodejs/packages/mdi/src/warichu.test.ts
+++ b/nodejs/packages/mdi/src/warichu.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { layoutMdiWarichu, parse, renderHtml, renderText, serializeMdi } from "./index.js";
+
+describe("Rust warichu layout binding", () => {
+  it("uses parsed children without changing canonical MDI", () => {
+    const source = "[[warichu:一二三四五]]";
+    const document = parse(source).document;
+    const before = JSON.stringify(document);
+    const children = document.children[0]!.children![0]!.children!;
+    const fragments = layoutMdiWarichu(children);
+    expect(fragments[0]?.widths).toEqual([6, 4]);
+    expect(fragments[0]?.lines.map(line => line.map(n => n.value).join(""))).toEqual(["一二三", "四五"]);
+    expect(JSON.stringify(document)).toBe(before);
+    expect(serializeMdi(source)).not.toContain("[[br]]");
+    expect(renderText(source).trim()).toBe("一二三四五");
+    expect(renderHtml(source)).toContain('class="mdi-warichu-line"');
+  });
+  it("diagnoses oversized indivisible content and rejects invalid capacity", () => {
+    const atomic = [{ type: "noBreak", children: [{ type: "text", value: "一二三四" }] }];
+    expect(layoutMdiWarichu(atomic, 1)[0]?.overflow).toBe(true);
+    for (const capacity of [0, -1, 1.5, Infinity, NaN, 0x100000000]) {
+      expect(() => layoutMdiWarichu(atomic, capacity)).toThrow(RangeError);
+    }
+    expect(layoutMdiWarichu([])).toEqual([]);
+  });
+});

--- a/nodejs/packages/mdi/tsconfig.json
+++ b/nodejs/packages/mdi/tsconfig.json
@@ -1,4 +1,13 @@
 {
   "extends": "../../tsconfig.base.json",
-  "include": ["src"]
+  "include": [
+    "src"
+  ],
+  "compilerOptions": {
+    "lib": [
+      "ES2022",
+      "DOM",
+      "DOM.Iterable"
+    ]
+  }
 }

--- a/nodejs/packages/to-docx/src/index.test.ts
+++ b/nodejs/packages/to-docx/src/index.test.ts
@@ -292,8 +292,8 @@ describe("mdiToDocx edge cases", () => {
     expect(document).toContain('<w:em w:val="dot"/>');
     // -0.1em at the canonical 10pt body size is -20 signed twips.
     expect(document).toContain('<w:spacing w:val="-20"/>');
-    // Warichu is deliberately a visible small-text fallback, not fake two-line XML.
-    expect(document).toContain('<w:sz w:val="12"/>');
+    // Warichu uses native two-lines-in-one; Word chooses the split.
+    expect(document).toContain('<w:eastAsianLayout w:id="1" w:combine="1" w:combineBrackets="none"/>');
     expect(document).toContain("note");
     // There is no arbitrary-run OOXML no-break feature; its source is still present.
     expect(document).toContain("keep together");

--- a/nodejs/packages/to-hast/CHANGELOG.md
+++ b/nodejs/packages/to-hast/CHANGELOG.md
@@ -31,3 +31,7 @@
 - Updated dependencies
   - mdast-util-mdi@2.0.2
   - @illusions-lab/mdi-remark@2.0.3
+
+## Unreleased
+
+- Render legacy mdast warichu through the Rust layout engine with portable two-line spans, transient source maps, and preserved authored hard breaks.

--- a/nodejs/packages/to-hast/package.json
+++ b/nodejs/packages/to-hast/package.json
@@ -30,7 +30,8 @@
   },
   "dependencies": {
     "mdast-util-mdi": "workspace:*",
-    "mdast-util-to-hast": "^13.0.0"
+    "mdast-util-to-hast": "^13.0.0",
+    "@illusions-lab/mdi-core": "workspace:*"
   },
   "devDependencies": {
     "@types/hast": "^3.0.0",

--- a/nodejs/packages/to-hast/src/index.test.ts
+++ b/nodejs/packages/to-hast/src/index.test.ts
@@ -50,9 +50,7 @@ describe("mdiToHast", () => {
 		expect(html("[[no-break:東京都新宿区]]")).toBe(
 			'<p><span class="mdi-nobr">東京都新宿区</span></p>',
 		);
-		expect(html("[[warichu:六曜の一つで吉日とされる]]")).toBe(
-			'<p><span class="mdi-warichu">六曜の一つで吉日とされる</span></p>',
-		);
+		expect(html("[[warichu:六曜の一つで吉日とされる]]").match(/class="mdi-warichu-line"/g)).toHaveLength(2);
 		expect(html("[[kern:-0.1em:確実]]")).toBe(
 			'<p><span class="mdi-kern" style="--mdi-kern:-0.1em;">確実</span></p>',
 		);
@@ -111,9 +109,9 @@ describe("mdiToHast", () => {
 
 	it("nests macros and retains GFM inline children in aligned paragraphs", () => {
 		const nested = html("[[em:[[no-break:[[warichu:{東京|とうきょう}]]]]]]");
-		expect(nested).toContain(
-			'<span class="mdi-em" style="--mdi-em:&#x22;﹅&#x22;;"><span class="mdi-nobr"><span class="mdi-warichu"><ruby class="mdi-ruby">東京',
-		);
+		expect(nested).toContain('<span class="mdi-nobr"><span class="mdi-warichu"');
+		expect(nested).toContain('<ruby class="mdi-ruby">東京');
+		expect(nested.match(/class="mdi-warichu-line"/g)).toHaveLength(2);
 		expect(html("[[indent:2]]\n[link](https://example.com) and ~~old~~ {東京|とうきょう}")).toBe(
 			'<p class="mdi-indent" style="--mdi-indent:2;"><a href="https://example.com">link</a> and <del>old</del> <ruby class="mdi-ruby">東京<rp>（</rp><rt>とうきょう</rt><rp>）</rp></ruby></p>',
 		);
@@ -129,4 +127,21 @@ describe("mdiToHast", () => {
 		);
 		expect(html("通常の段落")).toBe("<p>通常の段落</p>");
 	});
+});
+
+it('renders automatic warichu with two lines instead of a single small span', () => {
+ const tree = {type:'root',children:[{type:'paragraph',children:[{type:'mdiWarichu',children:[{type:'text',value:'一二三四五六'}]}]}]} as Root;
+ const html = toHtml(mdiToHast(tree).hast);
+ expect(html.match(/class="mdi-warichu-line"/g)).toHaveLength(2);
+ expect(html).toContain('data-mdi-warichu-source');
+});
+
+it('preserves atomic overflow, repeated authored breaks and formatted ruby within notes', () => {
+ const source = `[[warichu:[[no-break:${'甲'.repeat(50)}]][[br]][[br]]{東京|とう|きょう} **本文** ^12^]]`;
+ const output=html(source);
+ expect(output).toContain('data-mdi-overflow="true"');
+ expect(output.match(/<br>/g)).toHaveLength(2);
+ expect(output).toContain('<strong>');
+ expect(output).toContain('<ruby');
+ expect(output).toContain('mdi-tcy');
 });

--- a/nodejs/packages/to-hast/src/index.ts
+++ b/nodejs/packages/to-hast/src/index.ts
@@ -1,3 +1,4 @@
+import { layoutWarichuJson } from "@illusions-lab/mdi-core";
 import { toHast } from "mdast-util-to-hast";
 import type { Handler, State } from "mdast-util-to-hast";
 import type {} from "mdast-util-mdi";
@@ -83,6 +84,31 @@ function ruby(reading: string): Element["children"] {
 	];
 }
 
+// Shape conversion only: all splitting decisions remain in Rust.
+function warichuIr(node: Record<string, any>): Record<string, any> {
+ const types:Record<string,string>={mdiRuby:'ruby',mdiTcy:'tcy',mdiBreak:'break',mdiEm:'em',mdiNoBreak:'noBreak',mdiWarichu:'warichu',mdiKern:'kern'};
+ const out:Record<string,any>={...node,type:types[node.type] ?? node.type};
+ if(node.children) out.children=node.children.map(warichuIr);
+ if(node.type==='mdiRuby') out.ruby={kind:Array.isArray(node.ruby)?'perCharacter':'group',value:node.ruby};
+ return out;
+}
+function warichuMdast(node: Record<string, any>): Record<string, any> {
+ const types:Record<string,string>={ruby:'mdiRuby',tcy:'mdiTcy',break:'mdiBreak',em:'mdiEm',noBreak:'mdiNoBreak',warichu:'mdiWarichu',kern:'mdiKern'};
+ const out:Record<string,any>={...node,type:types[node.type] ?? node.type};
+ if(node.children) out.children=node.children.map(warichuMdast);
+ if(node.type==='ruby') out.ruby=node.ruby.value;
+ return out;
+}
+const mdiWarichu:Handler=(state,node)=>{
+ const children=node.children.map(warichuIr);
+ const fragments=JSON.parse(layoutWarichuJson(JSON.stringify(children),40)) as {lines:Record<string,any>[][];overflow:boolean;hardBreakAfter:boolean}[];
+ return element(state,node,'span',{className:['mdi-warichu'],style:'font-size:.5em;line-height:1',dataMdiWarichuSource:JSON.stringify(children)},fragments.flatMap(fragment=>[{
+  type:'element',tagName:'span',properties:{className:['mdi-warichu-fragment'],style:'display:inline-flex;flex-direction:column;vertical-align:middle;text-align:start',...(fragment.overflow?{dataMdiOverflow:'true'}:{})},children:fragment.lines.map(line=>({
+   type:'element',tagName:'span',properties:{className:['mdi-warichu-line'],style:'display:block;white-space:nowrap;min-block-size:1em'},children:state.all({...node,children:line.map(warichuMdast)})
+  }))
+ },...(fragment.hardBreakAfter?[{type:'element' as const,tagName:'br',properties:{},children:[]}]:[])]));
+};
+
 const mdiTcy: Handler = (state, node) =>
 	element(state, node, "span", { className: ["mdi-tcy"] }, [
 		{ type: "text", value: node.value },
@@ -154,7 +180,7 @@ export const mdiHandlers: Record<string, Handler> = {
 	mdiBlank,
 	mdiEm,
 	mdiNoBreak: phrasing("mdi-nobr"),
-	mdiWarichu: phrasing("mdi-warichu"),
+	mdiWarichu,
 	mdiKern,
 	mdiPagebreak,
 	paragraph,

--- a/nodejs/packages/to-hast/src/mdi.css
+++ b/nodejs/packages/to-hast/src/mdi.css
@@ -16,14 +16,9 @@
 .mdi-blank {
   min-block-size: 1lh; /* an empty <p> otherwise collapses to zero height */
 }
-.mdi-warichu {
-  display: inline-block;
-  font-size: 0.5em;
-  line-height: 1.1;
-  max-inline-size: 10em;
-  vertical-align: middle;
-  text-align: start;
-}
+.mdi-warichu { font-size: .5em; line-height: 1; }
+.mdi-warichu-fragment { display: inline-flex; flex-direction: column; vertical-align: middle; text-align: start; }
+.mdi-warichu-line { display: block; white-space: nowrap; min-block-size: 1em; }
 .mdi-kern {
   letter-spacing: var(--mdi-kern, 0em);
 }

--- a/nodejs/packages/to-hast/src/stylesheet.ts
+++ b/nodejs/packages/to-hast/src/stylesheet.ts
@@ -16,14 +16,9 @@ export const MDI_STYLESHEET = `.mdi-em {
 .mdi-blank {
   min-block-size: 1lh; /* an empty <p> otherwise collapses to zero height */
 }
-.mdi-warichu {
-  display: inline-block;
-  font-size: 0.5em;
-  line-height: 1.1;
-  max-inline-size: 10em;
-  vertical-align: middle;
-  text-align: start;
-}
+.mdi-warichu { font-size: .5em; line-height: 1; }
+.mdi-warichu-fragment { display: inline-flex; flex-direction: column; vertical-align: middle; text-align: start; }
+.mdi-warichu-line { display: block; white-space: nowrap; min-block-size: 1em; }
 .mdi-kern {
   letter-spacing: var(--mdi-kern, 0em);
 }

--- a/nodejs/packages/to-pdf/CHANGELOG.md
+++ b/nodejs/packages/to-pdf/CHANGELOG.md
@@ -37,3 +37,7 @@
 - Complete converter implementations targeting MDI 2.0: the shared mdast → hast mapping with the default MDI stylesheet, HTML document output, PDF via headless Chromium (correct `vertical-rl` / `text-combine-upright` / `text-emphasis`), EPUB 3 packaging with spine split on page breaks, native-OOXML DOCX (`<w:ruby>`, `<w:eastAsianLayout>`, vertical sections), and the `mdi build` CLI.
 - Updated dependencies
   - @illusions-lab/mdi-to-html@2.0.3
+
+## Unreleased
+
+- Wait for fonts and converged Rust warichu layout before PDF printing. Expose cancellable, bounded `settleMdiPrintLayout` for browser hosts.

--- a/nodejs/packages/to-pdf/CHANGELOG.md
+++ b/nodejs/packages/to-pdf/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix long notes clipping or shrinking during PDF output by measuring the physical printable page and actual glyph advances, including inherited tracking and indentation.
+
 ### Patch Changes
 
 - Add the browser-safe `@illusions-lab/mdi-to-pdf/profile` entry for applying

--- a/nodejs/packages/to-pdf/README.md
+++ b/nodejs/packages/to-pdf/README.md
@@ -59,3 +59,5 @@ cannot make syntax, profile-validation, or semantic-rendering decisions.
 - [Export-profile guide](https://mdi.illusions.app/ecosystem/export-profiles/)
 - [API reference](https://mdi.illusions.app/api/to-pdf/)
 - [JavaScript documentation](https://mdi.illusions.app/bindings/javascript/)
+
+Print hosts must pass `prepared.page` to `settleMdiPrintLayout(evaluate, { page: prepared.page })`. The Node PDF adapter does this automatically, constraining measurement to the physical printable page before font/layout stabilization.

--- a/nodejs/packages/to-pdf/package.json
+++ b/nodejs/packages/to-pdf/package.json
@@ -36,10 +36,10 @@
     "@illusions-lab/mdi-export-profile": "workspace:*",
     "@illusions-lab/mdi-to-html": "workspace:*",
     "playwright": "^1.48.0",
-    "@types/mdast": "^4.0.0"
+    "@types/mdast": "^4.0.0",
+    "@illusions-lab/mdi": "workspace:*"
   },
   "devDependencies": {
-    "@illusions-lab/mdi": "workspace:*",
     "@illusions-lab/mdi-remark": "workspace:*",
     "remark-parse": "^11.0.0",
     "unified": "^11.0.0",

--- a/nodejs/packages/to-pdf/src/index.test.ts
+++ b/nodejs/packages/to-pdf/src/index.test.ts
@@ -287,3 +287,10 @@ describe("PDF export profile", () => {
     expect(html).toContain("line-height:1.5");
   });
 });
+
+it('prints a long formatted warichu only after host-driven layout converges', async()=>{
+ const html=renderHtml(`前文（[[warichu:${'一二三四五六七八九十'.repeat(15)}[[br]][[br]]{東京|とうきょう}]]）後文`);
+ const pdf=await renderHtmlToPdf(html);
+ expect(pdf.subarray(0,5).toString()).toBe('%PDF-');
+ expect(pdf.length).toBeGreaterThan(500);
+},30000);

--- a/nodejs/packages/to-pdf/src/index.ts
+++ b/nodejs/packages/to-pdf/src/index.ts
@@ -29,7 +29,7 @@ export async function renderHtmlToPdf(
     const page = await browser.newPage();
     await page.setContent(prepared.html);
     await page.emulateMedia({media:"print"});
-    await settleMdiPrintLayout(code => page.evaluate(code), options);
+    await settleMdiPrintLayout(code => page.evaluate(code), { ...options, page: prepared.page });
     return Buffer.from(
       await page.pdf({
         preferCSSPageSize: true,

--- a/nodejs/packages/to-pdf/src/index.ts
+++ b/nodejs/packages/to-pdf/src/index.ts
@@ -1,3 +1,5 @@
+import { settleMdiPrintLayout, type MdiWarichuSettleOptions } from "@illusions-lab/mdi";
+export { settleMdiPrintLayout } from "@illusions-lab/mdi";
 import { chromium } from "playwright";
 import type { Root } from "mdast";
 import { mdiToHtml } from "@illusions-lab/mdi-to-html";
@@ -18,13 +20,16 @@ export const MDI_SPEC_VERSION = "2.0";
 export async function renderHtmlToPdf(
   html: string,
   profile?: ExportProfile,
-  sourceWritingMode?: unknown
+  sourceWritingMode?: unknown,
+  options?: MdiWarichuSettleOptions
 ): Promise<Buffer> {
   const prepared = prepareChromiumPrintProfile(html, profile, sourceWritingMode);
   const browser = await chromium.launch({ headless: true });
   try {
     const page = await browser.newPage();
     await page.setContent(prepared.html);
+    await page.emulateMedia({media:"print"});
+    await settleMdiPrintLayout(code => page.evaluate(code), options);
     return Buffer.from(
       await page.pdf({
         preferCSSPageSize: true,

--- a/nodejs/packages/to-pdf/src/warichu-geometry.test.ts
+++ b/nodejs/packages/to-pdf/src/warichu-geometry.test.ts
@@ -24,3 +24,27 @@ it('extracts automatic note text in source order and places its rows at half bod
   expect(new Set(rows.map(item=>Math.round(item.transform[5]))).size).toBeGreaterThan(2);
  } finally {await loadingTask.destroy();}
 },30000);
+
+it.each(['horizontal','vertical'] as const)('lays out a long A5 %s note in physical page space without clipping or shrinking body type', async(writingMode)=>{
+ const note='ABCDEFGHIJKLMNOPQRSTUVWX'.repeat(30);
+ const pdf=await renderHtmlToPdf(renderHtml(`PREFIX[[warichu:${note}]]SUFFIX`),{
+  layout:{system:'japanese-publisher'},
+  typesetting:{writingMode,fontFamily:'monospace'},
+  pagination:{pageSize:'A5',margins:{top:15,right:15,bottom:15,left:15},pageNumbers:{enabled:false}},
+ });
+ const loadingTask=getDocument({data:new Uint8Array(pdf)});
+ try {
+  const document=await loadingTask.promise;
+  const items=[];
+  for(let i=1;i<=document.numPages;i++) {
+   const content=await (await document.getPage(i)).getTextContent();
+   items.push(...content.items.filter((item):item is Extract<typeof item,{str:string}>=>'str' in item));
+  }
+  expect(items.map(item=>item.str).join('').replace(/\s/g,'')).toBe(`PREFIX${note}SUFFIX`);
+  const body=items.find(item=>item.str.trim())!;
+  expect(Math.hypot(body.transform[0],body.transform[1])).toBeCloseTo(10.5,2);
+  const rows=items.filter(item=>item.str.trim()&&Math.abs(Math.hypot(item.transform[0],item.transform[1])-5.25)<.02);
+  expect(rows.length).toBeGreaterThan(2);
+  expect(rows.every(item=>Math.abs(Math.hypot(item.transform[0],item.transform[1])-5.25)<.02)).toBe(true);
+ } finally {await loadingTask.destroy();}
+},30000);

--- a/nodejs/packages/to-pdf/src/warichu-geometry.test.ts
+++ b/nodejs/packages/to-pdf/src/warichu-geometry.test.ts
@@ -1,0 +1,26 @@
+import {expect,it} from 'vitest';
+import {getDocument} from 'pdfjs-dist/legacy/build/pdf.mjs';
+import {renderHtml} from '@illusions-lab/mdi';
+import {renderHtmlToPdf} from './index.js';
+
+it('extracts automatic note text in source order and places its rows at half body size',async()=>{
+ const note='ABCDEFGHIJKLMNOPQRSTUVWXYZ'.repeat(14);
+ const html=renderHtml(`PREFIX[[warichu:${note}]]SUFFIX`).replace('</head>','<style>body{font-family:monospace;font-size:24px}p{width:220px}</style></head>');
+ const pdf=await renderHtmlToPdf(html);
+ const loadingTask=getDocument({data:new Uint8Array(pdf)});
+ const document=await loadingTask.promise;
+ try {
+  const page=await document.getPage(1);const content=await page.getTextContent();
+  const items=content.items.filter((item):item is Extract<typeof item,{str:string}>=>'str' in item);
+  const sourceItems=items.filter(item=>/^[A-Z]+$/.test(item.str));
+  const text=sourceItems.map(item=>item.str).join('');
+  expect(text).toBe(`PREFIX${note}SUFFIX`);
+  const body=items.find(item=>item.str.includes('PREFIX'))!;
+  const rows=sourceItems.filter(item=>item.str && !item.str.includes('PREFIX') && !item.str.includes('SUFFIX'));
+  expect(rows.length).toBeGreaterThan(4);
+  expect(rows.every(item=>Math.abs(item.transform[3]/body.transform[3]-.5)<.01)).toBe(true);
+  const first=rows[0];
+  expect(rows.some(item=>Math.abs(item.transform[4]-first.transform[4])<.1 && Math.abs(item.transform[5]-first.transform[5])>1)).toBe(true);
+  expect(new Set(rows.map(item=>Math.round(item.transform[5]))).size).toBeGreaterThan(2);
+ } finally {await loadingTask.destroy();}
+},30000);

--- a/nodejs/scripts/test-browser-wasm.mjs
+++ b/nodejs/scripts/test-browser-wasm.mjs
@@ -148,6 +148,19 @@ async function testPage(browserName, page, url, getNodeProjection, parseNodeMdas
   assert.equal(result.error, undefined, `${browserName}: ${result.error}`);
   assert.equal(result.irVersion, "1.0", browserName);
   assert.equal(result.projectionVersion, "1.0", browserName);
+  assert.deepEqual(result.warichu[0].widths, [6, 4], browserName);
+  const geometry=result.warichuBrowser;
+  assert(geometry.preserved && geometry.wraps && geometry.resized, `${browserName}: adaptive warichu preserves source through wrapping and resizing`);
+  assert.deepEqual(geometry.nested,{text:'甲乙丙丁',lines:2,sameSize:true,measured:3});
+  assert(geometry.zoomStable, `${browserName}: zoom preserves capacity units`);
+  assert(geometry.adjacentOpening && geometry.adjacentClosing, `${browserName}: external parentheses stay adjacent`);
+  assert.equal(geometry.hardBreaks,2, `${browserName}: authored repeated hard breaks`);
+  assert.equal(geometry.geometry[0].x,geometry.geometry[1].x);
+  assert(geometry.geometry[0].y<geometry.geometry[1].y);
+  assert.equal(geometry.vertical[0].y,geometry.vertical[1].y);
+  assert(geometry.vertical[0].x>geometry.vertical[1].x);
+
+  assert.equal(result.warichu[0].lines.flat().map(node => node.value).join(""), "一二三四五", browserName);
   assert.equal(
     result.provenanceJson,
     JSON.stringify(canonicalProvenance(parseNodeMdast(result.projectionSource).document)),

--- a/nodejs/scripts/test-publication-contracts.mjs
+++ b/nodejs/scripts/test-publication-contracts.mjs
@@ -27,6 +27,7 @@ const rustPageDimensions = Object.fromEntries(JSON.parse(pageSizeCatalogJson()).
 ]));
 assert.deepEqual(PAGE_DIMENSIONS, rustPageDimensions, "export-profile snapshot must match Rust's publication catalogue");
 import {
+  settleMdiPrintLayout,
   renderDocxWithProfile,
   renderEpubWithProfile,
   renderHtml,
@@ -58,6 +59,8 @@ date: 2026-07-23
 # 第一章
 
 本文には{東京|とうきょう}、縦中横^12^、[[em:圏点]]、[[kern:0.1em:字間]]がある。
+
+本文[[warichu:一**二**三四五六]]続き。[[warichu:{東京|とうきょう}^12^]]
 
 ## 第二節
 
@@ -425,6 +428,8 @@ async function validatePdfs(cases) {
       const page = await browser.newPage();
       try {
         await page.setContent(prepared.html);
+        await page.emulateMedia({ media: "print" });
+        await settleMdiPrintLayout(code => page.evaluate(code));
         const pdf = Buffer.from(
           await page.pdf({
             preferCSSPageSize: true,

--- a/nodejs/scripts/test-publication-contracts.mjs
+++ b/nodejs/scripts/test-publication-contracts.mjs
@@ -429,7 +429,7 @@ async function validatePdfs(cases) {
       try {
         await page.setContent(prepared.html);
         await page.emulateMedia({ media: "print" });
-        await settleMdiPrintLayout(code => page.evaluate(code));
+        await settleMdiPrintLayout(code => page.evaluate(code), { page: prepared.page });
         const pdf = Buffer.from(
           await page.pdf({
             preferCSSPageSize: true,

--- a/nodejs/scripts/test-warichu-layout.mjs
+++ b/nodejs/scripts/test-warichu-layout.mjs
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict';
+import { chromium } from 'playwright';
+import { renderHtml } from '../packages/mdi/dist/index.js';
+
+const browser = await chromium.launch({ headless: true });
+try {
+  const page = await browser.newPage();
+  const source = '本文[[warichu:一二三四五六]]続き';
+  await page.setContent(renderHtml(source));
+  await page.evaluate(() => document.fonts.ready);
+  for (const writingMode of ['horizontal-tb', 'vertical-rl']) {
+    const boxes = await page.evaluate(mode => {
+      document.body.style.cssText = `font-size:32px;writing-mode:${mode}`;
+      return [...document.querySelectorAll('.mdi-warichu-line')].map(line => {
+        const r = line.getBoundingClientRect();
+        return { x: r.x, y: r.y, width: r.width, height: r.height, text: line.textContent };
+      });
+    }, writingMode);
+    assert.equal(boxes.length, 2);
+    assert.equal(boxes.map(b => b.text).join(''), '一二三四五六');
+    if (writingMode === 'horizontal-tb') {
+      assert.equal(boxes[0].x, boxes[1].x);
+      assert(boxes[1].y > boxes[0].y);
+    } else {
+      assert.equal(boxes[0].y, boxes[1].y);
+      assert(boxes[0].x > boxes[1].x);
+    }
+    assert(boxes.every(b => b.width > 0 && b.height > 0));
+  }
+  await page.setContent(renderHtml(`[[warichu:${'一二三四五六七八九十'.repeat(20)}]]`));
+  await page.evaluate(() => { document.body.style.cssText = 'width:180px;font-size:16px'; });
+  const long = await page.locator('.mdi-warichu-fragment').evaluateAll(nodes => nodes.map(n => n.getBoundingClientRect().y));
+  assert(long.length > 1);
+  assert(new Set(long).size > 1, 'long note must wrap between fragments');
+  console.log('Warichu Chromium horizontal, vertical, reading order and fragment wrapping passed.');
+} finally {
+  await browser.close();
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -311,6 +311,9 @@ importers:
 
   nodejs/packages/to-hast:
     dependencies:
+      '@illusions-lab/mdi-core':
+        specifier: workspace:*
+        version: link:../mdi-core
       mdast-util-mdi:
         specifier: workspace:*
         version: link:../mdast-util-mdi
@@ -376,6 +379,9 @@ importers:
 
   nodejs/packages/to-pdf:
     dependencies:
+      '@illusions-lab/mdi':
+        specifier: workspace:*
+        version: link:../mdi
       '@illusions-lab/mdi-core':
         specifier: workspace:*
         version: link:../mdi-core
@@ -392,9 +398,6 @@ importers:
         specifier: ^1.48.0
         version: 1.61.1
     devDependencies:
-      '@illusions-lab/mdi':
-        specifier: workspace:*
-        version: link:../mdi
       '@illusions-lab/mdi-remark':
         specifier: workspace:*
         version: link:../remark

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 2.0.5
 
 - Add Rust-owned automatic warichu layout with first-fragment and continuation capacities.
 - Preserve graphemes across formatting boundaries, indivisible inline groups, authored hard breaks and source UTF-8 paths.

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## Unreleased
+
+- Add Rust-owned automatic warichu layout with first-fragment and continuation capacities.
+- Preserve graphemes across formatting boundaries, indivisible inline groups, authored hard breaks and source UTF-8 paths.
+- Return portable per-line HTML and retain oversized content with an overflow signal.
+- Keep two lines at half body size, including nested notes, without changing syntax, document IR or canonical text.
+- Expose thin language APIs; static reader reflow and exact proportional-font balance remain outside the tested guarantees.

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -166,7 +166,7 @@ dependencies = [
 
 [[package]]
 name = "mdi-core"
-version = "2.0.5"
+version = "2.0.6"
 dependencies = [
  "markdown",
  "serde",

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -111,7 +111,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "illusion-markdown-python"
-version = "2.0.4"
+version = "2.0.5"
 dependencies = [
  "mdi-core",
  "pyo3",
@@ -166,7 +166,7 @@ dependencies = [
 
 [[package]]
 name = "mdi-core"
-version = "2.0.6"
+version = "2.0.7"
 dependencies = [
  "markdown",
  "serde",

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "illusion-markdown-python"
-version = "2.0.4"
+version = "2.0.5"
 description = "PyO3 bindings for illusion Markdown (MDI)"
 edition = "2024"
 license = "MIT"

--- a/python/README.md
+++ b/python/README.md
@@ -91,3 +91,31 @@ boundaries, and the stable API surface.
 ## License
 
 [MIT](https://github.com/illusions-lab/MDI/blob/main/LICENSE)
+
+## Automatic warichu presentation layout
+
+The Rust core supplies two lines at 50% body size with no line gap. Capacity is
+measured in half-em units at the note font size; it is a character-width estimate,
+not exact proportional-font measurement. The first fragment can use the space
+remaining on the current body line; following fragments use the full capacity.
+
+```python
+from mdi import layout_warichu
+fragments = layout_warichu([{"type": "text", "value": "一二三四五六"}], 4, first_capacity=2)
+```
+
+Results contain `lines`, `html`, `widths`, `overflow`, `hardBreakAfter`, and
+`sources`. Each source has a child-index `path` relative to the input inline array,
+half-open `startUtf8` / `endUtf8` offsets into that leaf's visible text, and an
+indivisible `group` ID. A cluster crossing formatting boundaries shares a group.
+Ruby, tcy, no-break and unknown containers remain whole; their coordinates use
+projected visible text (ruby base, excluding its reading). Oversized groups remain
+available and report overflow. Author hard breaks are retained; automatic splits
+never enter canonical MDI or plain text.
+
+The C ABI provides `mdi_layout_warichu_json`, taking inline-array JSON and options
+JSON (`firstCapacity`, `continuationCapacity`) and returning the same JSON through
+`mdi_ffi_result`. Release both returned buffers with `mdi_free_buffer`.
+Static HTML/EPUB includes readable precomputed lines; reader reflow can differ.
+DOCX uses native Word combination groups; XML verification is not a Word rendering
+test. Custom sizes, line counts and manual splitting remain tracked in MDI #85.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "illusion-markdown"
-version = "2.0.4"
+version = "2.0.5"
 description = "Python bindings for illusion Markdown (MDI), backed by the Rust core."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -6,6 +6,11 @@ use pyo3::types::PyBytes;
 create_exception!(mdi._native, MdiRenderError, pyo3::exceptions::PyException);
 
 #[pyfunction]
+fn layout_warichu_json(nodes: &str, options: &str) -> PyResult<String> {
+    mdi_core::layout_warichu_options_json(nodes, options).map_err(PyValueError::new_err)
+}
+
+#[pyfunction]
 fn parse_json(source: &str) -> String {
     mdi_core::parse_json(source)
 }
@@ -48,6 +53,7 @@ fn _native(module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add("MDI_SPEC_VERSION", mdi_core::MDI_SPEC_VERSION)?;
     module.add("MDI_IR_VERSION", mdi_core::MDI_IR_VERSION)?;
     module.add("MdiRenderError", module.py().get_type::<MdiRenderError>())?;
+    module.add_function(wrap_pyfunction!(layout_warichu_json, module)?)?;
     module.add_function(wrap_pyfunction!(parse_json, module)?)?;
     module.add_function(wrap_pyfunction!(render_html, module)?)?;
     module.add_function(wrap_pyfunction!(serialize_mdi, module)?)?;

--- a/python/src/mdi/__init__.py
+++ b/python/src/mdi/__init__.py
@@ -65,7 +65,19 @@ def render_docx(source: str) -> bytes:
 parse_mdi_syntax = parse
 
 __all__ = [
-    "MDI_IR_VERSION", "MDI_SPEC_VERSION", "MdiRenderError", "TextFormat", "parse",
+    "layout_warichu", "MDI_IR_VERSION", "MDI_SPEC_VERSION", "MdiRenderError", "TextFormat", "parse",
     "parse_mdi_syntax", "render_docx", "render_epub", "render_html", "render_text",
     "render_text_format", "serialize_mdi",
 ]
+
+
+def layout_warichu(children: list[dict[str, Any]], capacity: int = 40, *, first_capacity: int | None = None) -> list[dict[str, Any]]:
+    """Lay out two presentation lines using Rust; widths are note half-em units.
+
+    Paths are relative to children; UTF-8 offsets address the visible leaf text.
+    Automatic splits never modify the supplied document.
+    """
+    return json.loads(_native.layout_warichu_json(json.dumps(children), json.dumps({
+        "firstCapacity": capacity if first_capacity is None else first_capacity,
+        "continuationCapacity": capacity,
+    })))

--- a/python/tests/test_mdi.py
+++ b/python/tests/test_mdi.py
@@ -170,6 +170,7 @@ def test_packaged_archives_are_created_in_rust_with_required_parts() -> None:
 
 def test_public_api_exports_and_legacy_alias() -> None:
     assert set(mdi.__all__) == {
+        "layout_warichu",
         "MDI_IR_VERSION",
         "MDI_SPEC_VERSION",
         "MdiRenderError",
@@ -211,3 +212,11 @@ def test_text_format_validation_and_unsupported_ir_guard(monkeypatch: pytest.Mon
     monkeypatch.setattr(mdi._native, "parse_json", lambda _source: json.dumps({"irVersion": "999.0"}))
     with pytest.raises(RuntimeError, match="Unsupported MDI IR version: 999.0"):
         mdi.parse("text")
+
+
+def test_warichu_layout_options_and_source_paths():
+    import mdi
+    result = mdi.layout_warichu([{"type": "text", "value": "一二三四五六"}], 4, first_capacity=2)
+    assert [f["widths"] for f in result] == [[2, 2], [4, 4]]
+    assert result[1]["sources"][0][0]["startUtf8"] == 6
+    assert result[1]["html"] == ["三四", "五六"]

--- a/swift/CHANGELOG.md
+++ b/swift/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## Unreleased
+
+- Add Rust-owned automatic warichu layout with first-fragment and continuation capacities.
+- Preserve graphemes across formatting boundaries, indivisible inline groups, authored hard breaks and source UTF-8 paths.
+- Return portable per-line HTML and retain oversized content with an overflow signal.
+- Keep two lines at half body size, including nested notes, without changing syntax, document IR or canonical text.
+- Expose thin language APIs; static reader reflow and exact proportional-font balance remain outside the tested guarantees.

--- a/swift/README.md
+++ b/swift/README.md
@@ -64,3 +64,32 @@ let note = try MDI.renderTextFormat(
 field emitted by the Rust IR is available without Swift-side grammar logic.
 `MDITextFormat` exposes all six Rust-backed text conventions: plain text,
 ruby-preserving text, Narou, Kakuyomu, Aozora Bunko, and note.
+
+## Automatic warichu presentation layout
+
+The Rust core supplies two lines at 50% body size with no line gap. Capacity is
+measured in half-em units at the note font size; it is a character-width estimate,
+not exact proportional-font measurement. The first fragment can use the space
+remaining on the current body line; following fragments use the full capacity.
+
+```swift
+let fragments = try MDI.layoutWarichu(
+    [.object(["type": .string("text"), "value": .string("一二三四五六")])],
+    capacity: 4, firstCapacity: 2)
+```
+
+Results contain `lines`, `html`, `widths`, `overflow`, `hardBreakAfter`, and
+`sources`. Each source has a child-index `path` relative to the input inline array,
+half-open `startUtf8` / `endUtf8` offsets into that leaf's visible text, and an
+indivisible `group` ID. A cluster crossing formatting boundaries shares a group.
+Ruby, tcy, no-break and unknown containers remain whole; their coordinates use
+projected visible text (ruby base, excluding its reading). Oversized groups remain
+available and report overflow. Author hard breaks are retained; automatic splits
+never enter canonical MDI or plain text.
+
+The C ABI provides `mdi_layout_warichu_json`, taking inline-array JSON and options
+JSON (`firstCapacity`, `continuationCapacity`) and returning the same JSON through
+`mdi_ffi_result`. Release both returned buffers with `mdi_free_buffer`.
+Static HTML/EPUB includes readable precomputed lines; reader reflow can differ.
+DOCX uses native Word combination groups; XML verification is not a Word rendering
+test. Custom sizes, line counts and manual splitting remain tracked in MDI #85.

--- a/swift/Sources/MDI/MDI.swift
+++ b/swift/Sources/MDI/MDI.swift
@@ -93,6 +93,18 @@ public enum MDITextFormat: String, CaseIterable, Codable, Sendable {
 
 /// Swift interface to the Rust-owned MDI parser and renderers.
 public enum MDI {
+    /// Rust presentation layout; capacity is in half-em units at the note font size.
+    public static func layoutWarichu(_ children: [MDIJSONValue], capacity: UInt = 40, firstCapacity: UInt? = nil) throws -> MDIJSONValue {
+        let nodes = Array(try JSONEncoder().encode(children))
+        let options = Array(try JSONEncoder().encode(["firstCapacity": firstCapacity ?? capacity, "continuationCapacity": capacity]))
+        let result = nodes.withUnsafeBufferPointer { nodes in
+            options.withUnsafeBufferPointer { options in
+                mdi_layout_warichu_json(nodes.baseAddress, nodes.count, options.baseAddress, options.count)
+            }
+        }
+        return try JSONDecoder().decode(MDIJSONValue.self, from: data(from: result))
+    }
+
     public static func parse(_ source: String) throws -> MDIParseResult {
         try parseResult(from: call(source, operation: mdi_parse_json))
     }

--- a/swift/Sources/MDICore/include/mdi_core.h
+++ b/swift/Sources/MDICore/include/mdi_core.h
@@ -7,6 +7,7 @@
 typedef struct { uint8_t *data; size_t len; } mdi_ffi_buffer;
 typedef struct { mdi_ffi_buffer value; mdi_ffi_buffer error; } mdi_ffi_result;
 
+mdi_ffi_result mdi_layout_warichu_json(const uint8_t *data, size_t len, const uint8_t *options_data, size_t options_len);
 mdi_ffi_result mdi_parse_json(const uint8_t *data, size_t len);
 mdi_ffi_result mdi_render_html(const uint8_t *data, size_t len);
 mdi_ffi_result mdi_serialize_mdi(const uint8_t *data, size_t len);

--- a/swift/Tests/MDITests/MDITests.swift
+++ b/swift/Tests/MDITests/MDITests.swift
@@ -4,6 +4,15 @@ import MDICore
 @testable import MDI
 
 final class MDITests: XCTestCase {
+    func testWarichuLayoutPreservesSource() throws {
+        let children: [MDIJSONValue] = [.object(["type": .string("text"), "value": .string("一二三四五六")])]
+        let result = try MDI.layoutWarichu(children, capacity: 4, firstCapacity: 2)
+        guard case let .array(fragments) = result else { return XCTFail("Expected fragments") }
+        XCTAssertEqual(fragments.count, 2)
+        guard case let .object(first) = fragments[0] else { return XCTFail("Expected fragment") }
+        XCTAssertEqual(first["widths"], .array([.number(2), .number(2)]))
+    }
+
     private let formatContractSource = """
     ---
     title: Swift package contract


### PR DESCRIPTION
Long `[[warichu:...]]` annotations now form continuous two-row fragments using the first body line's remaining capacity and later lines' full capacity. The syntax and AST remain compatible; author `[[br]]` breaks are preserved, and automatic rows never write back to source.

Rust owns grapheme-safe splitting, kinsoku, atomic ruby/tcy/no-break/nested content, overflow reporting and UTF-8 source paths. Numeric layout calls remain supported alongside first/continuation capacity options, with thin C, Python, Swift and Kotlin/JNI interfaces. HTML, legacy HAST, EPUB and PDF use the shared rules; DOCX retains native Word combine groups. The browser controller supports invalidation, reconfiguration, settlement and disposal. Printing settles against resolved physical page dimensions, including measured font/letter-spacing advances.

The change also preserves semantic HTML table headers and formatted nested no-break parsing, both caught by consumer regressions. Public types, examples, multilingual binding documentation and changelogs are updated. Custom size, row count and manual split controls remain tracked in #85.

Local verification for `fbfaf640f40e2d628fe67e8568d5dc91d9638248`:

- Rust fmt, clippy, full tests/coverage and packaged crate; Python wheel/sdist installs and 27 tests at 100% coverage.
- Swift five-target XCFramework, exact binary consumer (17 tests, 99.34%) and format validators; Android two ABIs, JNI host tests, four hidden native tests and coverage gate.
- Node build/typecheck, all package coverage gates, packed Chromium/Firefox/WebKit consumers, publication contracts (65 DOCX + 9 specified rejections, 7 LibreOffice imports, 74 PDF, 7 EPUB, 3 HTML).
- Complete local downstream chain: plugin release:check/three-browser consumers passed; Illusions 629 test files, 5,587 tests and unchanged full/changed coverage gates passed, with renderer/Electron builds and two hidden warichu E2E scenarios.
- Actual A5 horizontal/vertical PDFs preserve all 720 annotation characters and 10.5pt body/5.25pt note glyphs. No Word GUI, native OS IME or EPUB reader compatibility claim is made.

This is the source candidate for the authorized npm/Rust/Python/Android publications and subsequent Swift prepare → manifest PR → publish workflow. Publication uses the established protected-branch CI and release workflows. Illusions app publication is outside this change.
