### PR TITLE
Release Swift package 2.1.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
         .library(name: "MDI", targets: ["MDI"]),
     ],
     targets: [
-        .binaryTarget(name: "MDICore", url: "https://github.com/illusions-lab/MDI/releases/download/2.0.3/MDICore.xcframework.zip", checksum: "ab6d91840673a7f54f4d76fb814f9102359780d274751e1e11ea5c411f73621e"),
+        .binaryTarget(name: "MDICore", url: "https://github.com/illusions-lab/MDI/releases/download/2.1.0/MDICore.xcframework.zip", checksum: "58b08b71ba8aaaf3c33a060e800ee9d7018707cec71c53c245579df9b34c13e0"),
         .target(name: "MDI", dependencies: ["MDICore"], path: "swift/Sources/MDI"),
         .testTarget(name: "MDITests", dependencies: ["MDI", "MDICore"], path: "swift/Tests/MDITests"),
     ]


### PR DESCRIPTION
## Summary

Point Swift Package Manager at the MDI 2.1.0 XCFramework prepared and tested by GitHub Actions run 34733026042. The binary includes opt-in comment IR and preserves comments in canonical source while excluding them from publication output.

## Related issue

#89

## Validation

The successful prepare workflow built the Apple framework, passed Swift coverage and official format checks, and saved the immutable archive and checksum. Publish that same archive after this manifest passes required CI and merges.

## Checklist

- [x] Only the prepared package manifest changes.
- [x] Tests and format validation passed in prepare CI.
- [x] API and migration documentation shipped with #90.
- [x] No secrets added; no npm Changeset required.
